### PR TITLE
Ansible playbook and makefile task to download_tools

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -16,6 +16,11 @@ local-defaults.yaml:
 local-deps:
 	ansible-galaxy install -r requirements.yml
 
+download_tools: hosts local-defaults.yaml
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-v -i hosts -e @local-defaults.yaml \
+	download_tools.yaml
+
 ocp_install:
 	$(MAKE) host_prep
 	$(MAKE) dev_scripts

--- a/ansible/download_tools.yaml
+++ b/ansible/download_tools.yaml
@@ -1,0 +1,34 @@
+#!/usr/bin/env ansible-playbook
+---
+- hosts: localhost
+  vars_files: "vars/default.yaml"
+  roles:
+  - oc_local
+
+  tasks:
+
+  - name: Set opm download url suffix
+    set_fact: opm_url_suffix="latest/download"
+    when: opm_version is undefined or opm_version == "latest"
+
+  - name: Set opm download url suffix
+    set_fact: opm_url_suffix="download/{{ opm_version }}"
+    when: opm_version is defined and opm_version != "latest"
+
+  - name: Download opm
+    get_url:
+      url: https://github.com/operator-framework/operator-registry/releases/{{ opm_url_suffix }}/linux-amd64-opm
+      dest: "{{ lookup('env', 'HOME') }}/bin/opm"
+      mode: '0755'
+
+  - name: Download operator-sdk
+    get_url:
+      url: https://github.com/operator-framework/operator-sdk/releases/download/{{ sdk_version }}/ansible-operator-{{ sdk_version }}-x86_64-linux-gnu
+      dest: "{{ lookup('env', 'HOME') }}/bin/operator-sdk"
+      mode: '0755'
+
+  - name: Download and extract kustomize
+    unarchive:
+      src: https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F{{ kustomize_version }}/kustomize_{{ kustomize_version }}_linux_amd64.tar.gz
+      dest: "{{ lookup('env', 'HOME') }}/bin/"
+      remote_src: yes

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -34,11 +34,14 @@ ocp_worker_disk: 120
 # OCP cluster name
 ocp_cluster_name: ostest
 
-# Released version of the opm package from the operator-framework
+# Released version of the opm package (can be set to 'latest')
 opm_version: v1.12.5
 
-# operator-sdk version to use
+# operator-sdk version to use (must be specific version)
 sdk_version: v1.1.0
+
+# kustomize version to use (must be specific version)
+kustomize_version: v3.8.6
 
 # namespace to deploy the operator to
 # Note: right now only openstack is supported as it is hardcoded in the Dockerfile


### PR DESCRIPTION
Adds a playbook to download opm/operator-sdk/and kustomize. Useful both locally and on devel boxes directly where some of us are developing directly now.