### PR TITLE
ControlPlane CR changed due to [1] "Connect OSP controller VMs to OSP network"

### DIFF
--- a/ansible/templates/osp/ctlplane/osp-director_controlplane.yaml.j2
+++ b/ansible/templates/osp/ctlplane/osp-director_controlplane.yaml.j2
@@ -12,5 +12,18 @@ spec:
     diskSize: {{ osp_controller_disk_size }}
     baseImageURL: {{ osp_controller_base_image_url }}
     storageClass: {{ osp_controller_storage_class }}
-    networks:
-    - name: ctlplane
+    ospNetwork:
+      bridgeName: br-osp
+      desiredState:
+        interfaces:
+        - bridge:
+            options:
+              stp:
+                enabled: false
+            port:
+            - name: {{ osp_interface }}
+          description: Linux bridge with {{ osp_interface }} as a port
+          name: br-osp
+          state: up
+          type: linux-bridge
+      name: osp

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -85,4 +85,5 @@ osp_controller_memory: 12
 osp_controller_disk_size: 50
 osp_controller_base_image_url: http://download.eng.brq.redhat.com/brewroot/packages/rhel-guest-image/8.3/417/images/rhel-guest-image-8.3-417.x86_64.qcow2
 osp_controller_storage_class: host-nfs-storageclass
-
+# Interface connected to osp network, will be configured as linux-bridge using nmstate
+osp_interface: enp6s0


### PR DESCRIPTION
"Connect OSP controller VMs to OSP network"

[1] https://github.com/openstack-k8s-operators/osp-director-operator/pull/31