### PR TITLE
fix hco crd version

### DIFF
--- a/ansible/files/cnv/2/deploy_operator.yaml
+++ b/ansible/files/cnv/2/deploy_operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: hco.kubevirt.io/v1alpha1
+apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged


### PR DESCRIPTION
hco v2.5 uses v1beta1 instead of v1alpha1