### PR TITLE
The HCO API is now v1beta1

### DIFF
--- a/ansible/files/cnv/2/deploy_operator.yaml
+++ b/ansible/files/cnv/2/deploy_operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: hco.kubevirt.io/v1alpha1
+apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged


### PR DESCRIPTION
On reinstall a fresh reinstalled the CNV HCO API version is now v1beta1