### PR TITLE
Bump worker and controller vm CPU resources + add oc client

### DIFF
--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -33,7 +33,7 @@ ocp_master_memory: 16384
 ocp_master_vcpu: 8
 ocp_master_disk: 120
 ocp_worker_memory: 30000
-ocp_worker_vcpu: 4
+ocp_worker_vcpu: 8
 ocp_worker_disk: 120
 
 # OCP cluster name
@@ -89,7 +89,7 @@ openstackclient_pod_worker: worker-0
 
 # OSP controller VM sizing
 osp_controller_count: 1
-osp_controller_cores: 2
+osp_controller_cores: 6
 osp_controller_memory: 12
 osp_controller_disk_size: 50
 # use http://download.devel.redhat.com to get the local mirror depending on where the server is

--- a/tripleo-deploy-container/Containerfile
+++ b/tripleo-deploy-container/Containerfile
@@ -1,6 +1,6 @@
 FROM registry.redhat.io/ubi8/ubi
 
-RUN dnf -y install http://download.lab.bos.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm
+RUN dnf -y install http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm
 RUN rhos-release 16.2 -p passed_phase2 --without-ceph
 RUN dnf -y install python3-tripleoclient
 RUN dnf -y install sudo
@@ -8,6 +8,9 @@ RUN dnf -y install bash-completion
 RUN dnf -y install patch
 RUN dnf -y install python3-osc-placement
 RUN openstack complete | tee /etc/bash_completion.d/osc.bash_completion > /dev/null
+RUN curl -s -S -o /tmp/openshift-client-linux.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz > /dev/null
+RUN tar xfz /tmp/openshift-client-linux.tar.gz -C /usr/local/bin/
+RUN rm -f /tmp/openshift-client-linux.tar.gz
 RUN dnf -y clean all
 
 ADD hostnamectl /usr/local/bin/


### PR DESCRIPTION
Bumping worker/controller VM CPUs as it has shown pacemaker checks
timed out due to cpu limitations.
Also adding oc client to openstackclient image.