### PR TITLE
Add Makefile target to create network(s)

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -49,6 +49,7 @@ cnv_install: hosts local-defaults.yaml
 	ocp_cnv.yaml
 
 openstack:
+	$(MAKE) networks
 	$(MAKE) ctlplane
 	$(MAKE) computes
 	# $(MAKE) overcloud
@@ -57,6 +58,12 @@ openstack_cleanup: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
 	-i hosts -e @local-defaults.yaml \
 	openstack_cleanup.yaml
+
+networks: hosts local-defaults.yaml
+	# NOTE: requires 'make olm'
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-i hosts -e @local-defaults.yaml \
+	install_networks.yaml
 
 ctlplane: hosts local-defaults.yaml
 	# NOTE: requires 'make olm'

--- a/ansible/install_networks.yaml
+++ b/ansible/install_networks.yaml
@@ -1,0 +1,46 @@
+---
+- hosts: localhost
+  vars_files: vars/default.yaml
+  roles:
+  - oc_local
+
+  tasks:
+  - set_fact:
+      network_yaml_dir: "{{ working_yamls_dir }}/networks"
+
+  - debug:
+      msg: "yamls will be written to {{ network_yaml_dir }} locally"
+
+  - name: Create yaml dir
+    file:
+      path: "{{ network_yaml_dir }}"
+      state: directory
+
+  - name: register dev-tools prepared extra_hosts
+    shell: |
+      set -e
+      oc apply -f /home/ocp/dev-scripts/ocp/ostest/extra_host_manifests.yaml
+    environment: &oc_env
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
+
+  - name: Render templates to yaml dir
+    template:
+      src: "osp/networks/{{ item }}.j2"
+      dest: "{{ network_yaml_dir }}/{{ item }}"
+    with_items:
+    - "01-ctlplane.yaml"
+
+  - name: do the networks already exist
+    ignore_errors: true
+    shell: >
+      oc get overcloudnet ctlplane
+    register: overcloud_net_switch
+
+  - name: Start networks
+    shell: |
+      set -e
+      oc apply -n openstack -f "{{ network_yaml_dir }}"
+    environment:
+      <<: *oc_env
+    when: overcloud_net_switch.rc == 1

--- a/ansible/templates/osp/compute/baremetalset.yaml.j2
+++ b/ansible/templates/osp/compute/baremetalset.yaml.j2
@@ -10,7 +10,9 @@ spec:
   rhelImageUrl: http://172.22.0.1/images/{{ osp_controller_base_image_url | basename }}.gz
   # The secret containing the SSH pub key to place on the provisioned nodes
   deploymentSSHSecret: osp-controlplane-ssh-keys
-  # A CIDR for a management network on which to access the nodes
-  mgmtCidr: 192.168.25.0/24
   # The interface on the nodes that will be assigned an IP from the mgmtCidr
   mgmtInterface: eth2
+  # Networks to associate with this host
+  networks:
+    - ctlplane
+  role: worker

--- a/ansible/templates/osp/networks/01-ctlplane.yaml.j2
+++ b/ansible/templates/osp/networks/01-ctlplane.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OvercloudNet
+metadata:
+  name: ctlplane
+spec:
+  cidr: 192.168.25.1/24
+  allocationStart: 192.168.25.100
+  allocationEnd: 192.168.25.250


### PR DESCRIPTION
Currently creates just the overcloud ctlplane. Additionally
this patch is currently only integrated with baremetalset.

Working on integration with the ctlplane VM next...