### PR TITLE
Fix downstream pull request pipeline

### DIFF
--- a/.pull_request_pipeline
+++ b/.pull_request_pipeline
@@ -6,13 +6,11 @@ pipeline {
                 branch 'PR-*'
             }
 
-            stage('osp-director-dev-tools-pr') {
-                steps {
-                    build job: 'osp-director-dev-tools-pr',
-                              parameters: [
-                                  string(name: 'GITHUB_PULL_REQUEST_ID', value: String.valueOf(CHANGE_ID))
-                              ]
-                }
+            steps {
+                build job: 'osp-director-dev-tools-pr',
+                          parameters: [
+                              string(name: 'GITHUB_PULL_REQUEST_ID', value: String.valueOf(CHANGE_ID))
+                          ]
             }
         }
 


### PR DESCRIPTION
Currently osp-director-dev-tools triggers only
one downstream job for every pull request and
it can not be inside stage{} which is meant
for more then one jobs.