### PR TITLE
Remove overcloudipset from openstack cleanup routine

### DIFF
--- a/ansible/openstack_cleanup.yaml
+++ b/ansible/openstack_cleanup.yaml
@@ -14,5 +14,4 @@
     with_items:
       - "oc delete -n openstack baremetalset compute"
       - "oc delete -n openstack controlplane overcloud"
-      - "oc delete -n openstack overcloudipset compute"
       - "oc delete -n openstack overcloudnet ctlplane"


### PR DESCRIPTION
The ipsets are now deleted by the above objects so no need
to manually clean them up (it just causes an error)