### PR TITLE
Support install/cleanup of Local Storage Operator

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -105,6 +105,16 @@ olm_cleanup: hosts local-defaults.yaml
 	-v -i hosts -e @local-defaults.yaml \
 	olm_cleanup.yaml
 
+local_storage: hosts local-defaults.yaml
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-v -i hosts -e @local-defaults.yaml \
+	local_storage.yaml
+
+local_storage_cleanup: hosts local-defaults.yaml
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-v -i hosts -e @local-defaults.yaml \
+	local_storage_cleanup.yaml
+
 nfs_cleanup: hosts
 	ANSIBLE_FORCE_COLOR=true ansible -i hosts convergence_base \
 	--become -m shell -a \

--- a/ansible/local_storage.yaml
+++ b/ansible/local_storage.yaml
@@ -107,7 +107,7 @@
     - "storage_class.yaml"
     - "local_disks.yaml"
 
-  - name: Create namespace, operatorgroup and subscription
+  - name: Creating storage class and local disks
     shell: |
       set -e
       oc apply -f "{{ local_storage_volume_yaml_dir }}"

--- a/ansible/local_storage.yaml
+++ b/ansible/local_storage.yaml
@@ -1,0 +1,115 @@
+---
+- hosts: localhost
+  vars_files: vars/default.yaml
+  become: true
+  become_user: root
+  roles:
+  - oc_local
+
+  tasks:
+  - name: Create VM attached Local Storage for local-storage-operator
+    with_items: "{{ local_storage_domains }}"
+    include_role:
+      name: local_storage
+    vars:
+      domain: "{{ item }}"
+
+  - name: Lookup defaultChannel for local-storage-operator
+    shell: >
+      oc get -o json packagemanifest local-storage-operator | jq -re .status.defaultChannel
+    register: local_storage_default_channel_cmd
+    environment: &oc_env
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
+
+  - name: Set defaultChannel fact for local-storage-operator
+    set_fact:
+      local_storage_default_channel: "{{ local_storage_default_channel_cmd.stdout }}"
+
+  - name: Lookup currentCSV for local-storage-operator
+    shell: >
+      oc get -o json packagemanifest local-storage-operator | jq -re .status.channels[0].currentCSV
+    register: local_storage_current_csv_cmd
+    environment:
+      <<: *oc_env
+
+  - name: Set currentCsv fact for local-storage-operator
+    set_fact:
+      local_storage_current_csv: "{{ local_storage_current_csv_cmd.stdout }}"
+
+  - name: Set directory for local_storage yaml files
+    set_fact:
+      local_storage_yaml_dir: "{{ working_yamls_dir }}/local_storage_operator"
+
+  - debug:
+      msg: "Operator yamls will be written to {{ local_storage_yaml_dir }} locally"
+
+  - name: Create local yamldir for local_storage operator
+    file:
+      path: "{{ local_storage_yaml_dir }}"
+      state: directory
+      mode: '0755'
+      owner: root
+      group: root
+
+  - name: Render templates to local_storage operator yaml dir
+    template:
+      src: "local_storage/operator/{{ item }}.j2"
+      dest: "{{ local_storage_yaml_dir }}/{{ item }}"
+      mode: '0644'
+      owner: root
+      group: root
+    with_items:
+    - "namespace.yaml"
+    - "operatorgroup.yaml"
+    - "subscription.yaml"
+
+  - name: Create namespace, operatorgroup and subscription for Local Storage Operator
+    shell: |
+      set -e
+      oc apply -f "{{ local_storage_yaml_dir }}"
+    environment:
+      <<: *oc_env
+
+  - name: wait for OpenShift Local Storage Operator to be installed
+    shell: |
+      oc wait deployment.apps/local-storage-operator -n openshift-local-storage --for condition=Available --timeout={{ default_timeout }}s
+    environment:
+      <<: *oc_env
+    retries: 50
+    delay: 5
+    register: result
+    until: result.rc == 0
+
+  - name: Set directory for local_volume yaml files
+    set_fact:
+      local_storage_volume_yaml_dir: "{{ working_yamls_dir }}/local_storage_volume"
+
+  - debug:
+      msg: "Volume yamls will be written to {{ local_storage_volume_yaml_dir }} locally"
+
+  - name: Create local yamldir
+    file:
+      path: "{{ local_storage_volume_yaml_dir }}"
+      state: directory
+      mode: '0755'
+      owner: root
+      group: root
+
+  - name: Render templates to yaml dir
+    template:
+      src: "local_storage/volume/{{ item }}.j2"
+      dest: "{{ local_storage_volume_yaml_dir }}/{{ item }}"
+      mode: '0644'
+      owner: root
+      group: root
+    with_items:
+    - "storage_class.yaml"
+    - "local_disks.yaml"
+
+  - name: Create namespace, operatorgroup and subscription
+    shell: |
+      set -e
+      oc apply -f "{{ local_storage_volume_yaml_dir }}"
+    environment:
+      <<: *oc_env

--- a/ansible/local_storage_cleanup.yaml
+++ b/ansible/local_storage_cleanup.yaml
@@ -1,0 +1,45 @@
+---
+- hosts: localhost
+  vars_files: vars/default.yaml
+  become: true
+  become_user: root
+  roles:
+  - oc_local
+
+  tasks:
+  - name: cleanup local storage volumes
+    command: "{{ item }}"
+    environment: &oc_env
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
+    ignore_errors: true
+    with_items:
+      - "oc delete -n openshift-local-storage localvolume local-disks"
+
+  - name: Get local PVs
+    shell: "oc get pv | grep local | cut -f 1 -d \" \""
+    environment:
+      <<: *oc_env
+    register: local_pvs
+
+  - name: cleanup local pvs
+    command: "oc delete pv {{ item }}"
+    environment:
+      <<: *oc_env
+    ignore_errors: true
+    with_items: "{{ local_pvs.stdout_lines | list }}"
+
+  - name: Cleanup VM attached Local Storage
+    include_role:
+      name: local_storage
+      tasks_from: cleanup
+    vars:
+      domain: "{{ item }}"
+    with_items: "{{ local_storage_domains }}"
+
+  # NOTE: this can take awhile to terminate as the nodes will reboot above
+  - name: Uninstall Local Storage Operator and Namespace  (worker rebooted...)
+    environment:
+      <<: *oc_env
+    command: "oc delete project openshift-local-storage"
+    ignore_errors: true

--- a/ansible/roles/local_storage/tasks/cleanup.yaml
+++ b/ansible/roles/local_storage/tasks/cleanup.yaml
@@ -1,0 +1,37 @@
+---
+- name: Get current {{ domain }} VM attached disk count
+  become: true
+  become_user: root
+  shell: "virsh dumpxml {{ domain }} | grep \"source file='{{ local_storage_data_dir }}/{{ domain }}/local_storage_disk\" | wc -l"
+  register: cur_storage_disks
+
+- name: Change {{ domain }} VM specs
+  become: true
+  become_user: root
+  when: (cur_storage_disks.stdout | int) > 0
+  block:
+
+  - name: Clear host VM memory cache
+    shell: echo 3 | tee /proc/sys/vm/drop_caches
+
+  - name: Detach data disks from {{ domain }} VM
+    command: "virsh detach-disk {{ domain }} --target {{ disk }} --persistent"
+    ignore_errors: yes
+    loop: "{{ local_storage_disks }}"
+    loop_control:
+      index_var: index
+      loop_var: disk
+
+  - name: Destroy local storage data disks for {{ domain }} VM
+    file:
+      state: absent
+      path: "{{ local_storage_data_dir }}/{{ domain }}/local_storage_disk_{{ index + 1 }}"
+    loop: "{{ local_storage_disks }}"
+    loop_control:
+      index_var: index
+      loop_var: disk
+
+- name: Stop {{ domain }} VM
+  virt:
+    name: "{{ domain }}"
+    state: destroyed

--- a/ansible/roles/local_storage/tasks/main.yaml
+++ b/ansible/roles/local_storage/tasks/main.yaml
@@ -1,0 +1,45 @@
+---
+- name: Get current {{ domain }} VM attached disk count
+  shell: "virsh dumpxml {{ domain }} | grep \"source file='{{ local_storage_data_dir }}/{{ domain }}/local_storage_disk\" | wc -l"
+  register: cur_storage_disks
+
+- name: Change {{ domain }} VM specs
+  become: true
+  become_user: root
+  when: (cur_storage_disks.stdout | int) != (local_storage_disks | length)
+  block:
+
+  - name: Clear host VM memory cache
+    shell: echo 3 | tee /proc/sys/vm/drop_caches
+
+  - name: Create local storage data disks for {{ domain }} VM
+    shell: |
+      set -e -o pipefail
+
+      for i in {1..{{ local_storage_disks | length }}}; do
+          fs="{{ local_storage_data_dir }}/{{ domain }}/local_storage_disk_${i}"
+
+          if [ ! -f "$fs" ]; then
+              # Create a sparse file of the correct size and populate it with an
+              # ext4  filesystem.
+              mkdir -p {{ local_storage_data_dir }}/{{ domain }}
+              truncate -s {{ local_storage_disk_size }}G $fs
+              mkfs.ext4 -m 0 "$fs"
+
+              # Make world readable
+              chown nobody.nobody "$fs"
+              chmod 0777 "$fs"
+          fi
+      done
+
+  - name: Stop {{ domain }} VM
+    virt:
+      name: "{{ domain }}"
+      state: destroyed
+
+  - name: Attach data disks to {{ domain }} VM
+    command: "virsh attach-disk {{ domain }} --source {{ local_storage_data_dir }}/{{ domain }}/local_storage_disk_{{ index + 1 }} --target {{ disk }} --persistent"
+    loop: "{{ local_storage_disks }}"
+    loop_control:
+      index_var: index
+      loop_var: disk

--- a/ansible/templates/local_storage/operator/namespace.yaml.j2
+++ b/ansible/templates/local_storage/operator/namespace.yaml.j2
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-local-storage

--- a/ansible/templates/local_storage/operator/operatorgroup.yaml.j2
+++ b/ansible/templates/local_storage/operator/operatorgroup.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-local-storage-group
+  namespace: openshift-local-storage
+spec:
+  targetNamespaces:
+    - openshift-local-storage

--- a/ansible/templates/local_storage/operator/subscription.yaml.j2
+++ b/ansible/templates/local_storage/operator/subscription.yaml.j2
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: local-storage-operator
+  namespace: openshift-local-storage
+spec:
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  name: local-storage-operator
+  startingCSV: {{ local_storage_current_csv }}
+  channel: "{{ local_storage_default_channel }}"
+  installPlanApproval: "Automatic"

--- a/ansible/templates/local_storage/volume/local_disks.yaml.j2
+++ b/ansible/templates/local_storage/volume/local_disks.yaml.j2
@@ -1,0 +1,20 @@
+apiVersion: "local.storage.openshift.io/v1"
+kind: "LocalVolume"
+metadata:
+  name: "local-disks"
+  namespace: "openshift-local-storage"
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values: {{ local_storage_workers }}
+  storageClassDevices:
+    - storageClassName: "local"
+      volumeMode: Filesystem
+      fsType: ext4
+      devicePaths:
+{% for dev in local_storage_disks %}
+        - '/dev/{{ dev }}'
+{% endfor %}

--- a/ansible/templates/local_storage/volume/storage_class.yaml.j2
+++ b/ansible/templates/local_storage/volume/storage_class.yaml.j2
@@ -1,0 +1,5 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: local
+provisioner: kubernetes.io/no-provisioner

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -104,3 +104,16 @@ osp_container_tag: 16.2_20210215.1
 
 # number of OCP worker nodes should be OSP compute hosts
 osp_compute_count: 1
+
+# Local Storage Operator specific (only required if using local-storage operator)
+local_storage_domains:
+  - ostest_worker_0
+  - ostest_worker_1
+local_storage_workers:
+  - worker-0
+  - worker-1
+local_storage_data_dir: /home/local_storage/data
+local_storage_disks:
+  - vda
+  - vdb
+local_storage_disk_size: 50


### PR DESCRIPTION
This adds configurable support for the Local Storage Operator
within our dev-scripts. It automatically attaches disks to
the configured worker VMs and configures the local-storage-operator
to provide those as PVs for the 'local' storage class.

Two Makefile targets are included:

 -make local_storage
 -make local_storage_cleanup

These targets are both currently optional (opt in) for those who
wish to experiment with an alternate PV type.