### PR TITLE
Switch to cloud-admin user for the deployment

### DIFF
--- a/ansible/files/osp/tripleo_deploy/network-environment.yaml
+++ b/ansible/files/osp/tripleo_deploy/network-environment.yaml
@@ -1,6 +1,6 @@
 resource_registry:
-  OS::TripleO::Controller::Net::SoftwareConfig: /root/net-config/net-config-static-bridge.yaml
-  OS::TripleO::Compute::Net::SoftwareConfig: /root/net-config/net-config-static-bridge-compute.yaml
+  OS::TripleO::Controller::Net::SoftwareConfig: /home/cloud-admin/net-config/net-config-static-bridge.yaml
+  OS::TripleO::Compute::Net::SoftwareConfig: /home/cloud-admin/net-config/net-config-static-bridge-compute.yaml
 
 parameter_defaults:
   EC2MetadataIp: 192.168.25.1

--- a/ansible/templates/osp/ctlplane/osp-director_controlplane.yaml.j2
+++ b/ansible/templates/osp/ctlplane/osp-director_controlplane.yaml.j2
@@ -4,7 +4,7 @@ metadata:
   name: overcloud
   namespace: {{ namespace }}
 spec:
-  openStackClientImageURL: quay.io/openstack-k8s-operators/tripleo-deploy
+  openStackClientImageURL: quay.io/openstack-k8s-operators/tripleo-deploy:cloud-admin
   passwordSecret: userpassword
   controller:
     networks:

--- a/tripleo-deploy-container/Containerfile
+++ b/tripleo-deploy-container/Containerfile
@@ -12,6 +12,12 @@ RUN curl -s -S -o /tmp/openshift-client-linux.tar.gz https://mirror.openshift.co
 RUN tar xfz /tmp/openshift-client-linux.tar.gz -C /usr/local/bin/
 RUN rm -f /tmp/openshift-client-linux.tar.gz
 RUN dnf -y clean all
+# fixed IDs which are used in openstackclient fsGroup
+RUN groupadd -g 1001 cloud-admin
+RUN useradd -m -g 1001 -u 1001 cloud-admin&& echo "cloud-admin        ALL=(ALL)       NOPASSWD: ALL" >/etc/sudoers.d/cloud-admin
+RUN mkdir /home/cloud-admin/.ssh && chown cloud-admin:cloud-admin /home/cloud-admin/.ssh
 
 ADD hostnamectl /usr/local/bin/
-WORKDIR /root
+WORKDIR /home/cloud-admin
+USER cloud-admin
+CMD /bin/bash


### PR DESCRIPTION
Switch the tripleo container to use cloud-admin as the deployment
user to be in sync with the overcloud deployment user.