### PR TITLE
Temporary webhook deployment support

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -88,10 +88,12 @@ osp_tests_run: hosts local-defaults.yaml
 	-i hosts -e @local-defaults.yaml \
 	osp_tempest_ocp.yaml
 
+# FIXME: Remove install_webhooks.yaml once OLM properly deploys webhooks
 olm: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
 	-v -i hosts -e @local-defaults.yaml \
 	install_namespace.yaml \
+	install_webhooks.yaml \
 	olm.yaml
 
 olm_cleanup: hosts local-defaults.yaml

--- a/ansible/install_webhooks.yaml
+++ b/ansible/install_webhooks.yaml
@@ -25,7 +25,7 @@
     - "validation.yaml"
 
   - name: Deploy webhooks
-    shell: oc apply -f "{{ webhooks_yaml_dir }}"
+    command: oc apply -f "{{ webhooks_yaml_dir }}"
     environment:
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"

--- a/ansible/install_webhooks.yaml
+++ b/ansible/install_webhooks.yaml
@@ -1,0 +1,31 @@
+---
+- hosts: localhost
+  vars_files: vars/default.yaml
+  roles:
+  - oc_local
+
+  tasks:
+  - name: Set directory for webhook yaml files
+    set_fact:
+      webhooks_yaml_dir: "{{ working_yamls_dir }}/webhooks"
+
+  - name: Create webhooks yaml dir
+    file:
+      path: "{{ webhooks_yaml_dir }}"
+      state: directory
+      mode: '0755'
+
+  - name: Render common webhook templates to working dir
+    template:
+      src: "osp-director-operator/webhooks/{{ item }}.j2"
+      dest: "{{ webhooks_yaml_dir }}/{{ item }}"
+      mode: '0644'
+    with_items:
+    - "service.yaml"
+    - "validation.yaml"
+
+  - name: Deploy webhooks
+    shell: oc apply -f "{{ webhooks_yaml_dir }}"
+    environment:
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"

--- a/ansible/templates/osp-director-operator/webhooks/service.yaml.j2
+++ b/ansible/templates/osp-director-operator/webhooks/service.yaml.j2
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: osp-director-operator-webhook-service
+  namespace: {{ namespace }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+    

--- a/ansible/templates/osp-director-operator/webhooks/validation.yaml.j2
+++ b/ansible/templates/osp-director-operator/webhooks/validation.yaml.j2
@@ -1,0 +1,46 @@
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: osp-director-operator-validation-webhooks
+  namespace: {{ namespace }}
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: osp-director-operator-webhook-service
+      namespace: {{ namespace }}
+      path: /validate-osp-director-openstack-org-v1beta1-baremetalset
+  failurePolicy: Fail
+  name: vbaremetalset.kb.io
+  rules:
+  - apiGroups:
+    - osp-director.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - baremetalsets
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: osp-director-operator-webhook-service
+      namespace: {{ namespace }}
+      path: /validate-osp-director-openstack-org-v1beta1-vmset
+  failurePolicy: Fail
+  name: vvmset.kb.io
+  rules:
+  - apiGroups:
+    - osp-director.openstack.org
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - vmsets


### PR DESCRIPTION
OLM seems to be incapable of completely deploying all required resources for admission controller validation webhooks to function properly.  For the meantime, we can use dev-tools to deploy the two resources (the actual webhook YAML and accompanying service) that OLM fails to bundle.

NOTE: If we decide to merge this, it must *not* be merged before https://github.com/openstack-k8s-operators/osp-director-operator/pull/110 is merged and a new `osp-director-operator:0.0.1` is built from master and pushed to `quay.io/openstack-k8s-operators`.