### PR TITLE
Add datavolume playbook

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -49,6 +49,7 @@ cnv_install: hosts local-defaults.yaml
 	ocp_cnv.yaml
 
 openstack:
+	$(MAKE) datavolume
 	$(MAKE) networks
 	$(MAKE) ctlplane
 	$(MAKE) computes
@@ -77,6 +78,11 @@ computes: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
 	-i hosts -e @local-defaults.yaml \
 	install_computes.yaml
+
+datavolume: hosts local-defaults.yaml
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-i hosts -e @local-defaults.yaml \
+	datavolume.yaml
 
 osp_content: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \

--- a/ansible/datavolume.yaml
+++ b/ansible/datavolume.yaml
@@ -1,0 +1,45 @@
+#!/usr/bin/env ansible-playbook
+---
+- hosts: localhost
+  vars_files: "vars/default.yaml"
+  roles:
+  - oc_local
+
+  tasks:
+
+  # NOTE: we copy this to the Ironic images directory to reuse it for
+  # the provision server (baremetalsets). This avoids downloading
+  # the same image twice.
+  - name: Check if {{ osp_controller_base_image_url | basename }} already exist
+    stat:
+      path: "{{ base_path }}/ironic/html/images/{{ osp_controller_base_image_url | basename }}"
+    register: stat_result
+
+  - name: Get RHEL guest base image
+    when: not stat_result.stat.exists
+    get_url:
+      url: "{{ osp_controller_base_image_url }}"
+      dest: "{{ base_path }}/ironic/html/images/{{ osp_controller_base_image_url | basename }}"
+      mode: '0644'
+
+  - name: does the datavolume already exist
+    ignore_errors: true
+    shell: >
+      oc get datavolume openstack-base-img -n {{ namespace }}
+    environment: &oc_env
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
+    register: datavolume_switch
+
+  - name: Deploy the datavolume
+    shell: |
+      virtctl image-upload dv openstack-base-img -n {{ namespace }} --size={{ osp_controller_disk_size }}G --image-path=/home/ocp/ironic/html/images/{{ osp_controller_base_image_url | basename }}
+    environment:
+      <<: *oc_env
+    when: datavolume_switch.rc == 1
+
+  - name: Wait for the datavolume to be ready
+    shell: |
+      oc wait datavolume openstack-base-img --for condition=Ready -n "{{ namespace }}" --timeout={{ default_timeout }}s
+    environment:
+      <<: *oc_env

--- a/ansible/install_computes.yaml
+++ b/ansible/install_computes.yaml
@@ -26,18 +26,6 @@
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"
 
-  - name: Check if {{ osp_controller_base_image_url | basename }} already exist
-    stat:
-      path: "/home/ocp/ironic/html/images/{{ osp_controller_base_image_url | basename }}"
-    register: stat_result
-
-  - name: Get RHEL guest base image
-    when: not stat_result.stat.exists
-    get_url:
-      url: "{{ osp_controller_base_image_url }}"
-      dest: "/home/ocp/ironic/html/images/{{ osp_controller_base_image_url | basename }}"
-      mode: '0644'
-
   - name: Render templates to yaml dir
     template:
       src: "osp/compute/{{ item }}.j2"
@@ -46,7 +34,7 @@
     with_items:
     - "baremetalset.yaml"
 
-  - name: Start baremtalset
+  - name: Start baremetalset
     shell: |
       set -e
       oc apply -n openstack -f "{{ compute_yaml_dir }}"

--- a/ansible/templates/osp/ctlplane/osp-director_controlplane.yaml.j2
+++ b/ansible/templates/osp/ctlplane/osp-director_controlplane.yaml.j2
@@ -14,7 +14,9 @@ spec:
     cores: {{ osp_controller_cores }}
     memory: {{ osp_controller_memory }}
     diskSize: {{ osp_controller_disk_size }}
+    # FIXME: remove this once we make baseImageURL optional
     baseImageURL: {{ osp_controller_base_image_url }}
+    baseImageVolumeName: openstack-base-img
     storageClass: {{ osp_controller_storage_class }}
     ospNetwork:
       bridgeName: br-osp


### PR DESCRIPTION
This playbook pre-creates an openstack-base-img DataVolume
using virtctl on the CLI. This has the effect of uploading
the image into the cluster from disk thus avoiding
repeatedly downloading the same image. This also works
around a case where cdi-datavolume streamed http downloads
can be really slow from some mirrors (more to be said about
that but perhaps not here).