### PR TITLE
Reduce VM disk size for masters and workers

### DIFF
--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -31,10 +31,10 @@ ocp_num_extra_workers: 2
 ocp_extra_workers_online_status: false
 ocp_master_memory: 16384
 ocp_master_vcpu: 8
-ocp_master_disk: 120
+ocp_master_disk: 30
 ocp_worker_memory: 30000
 ocp_worker_vcpu: 8
-ocp_worker_disk: 120
+ocp_worker_disk: 50
 
 # OCP cluster name
 ocp_cluster_name: ostest
@@ -91,7 +91,7 @@ openstackclient_pod_worker: worker-0
 osp_controller_count: 1
 osp_controller_cores: 6
 osp_controller_memory: 12
-osp_controller_disk_size: 50
+osp_controller_disk_size: 40
 # use http://download.devel.redhat.com to get the local mirror depending on where the server is
 osp_controller_base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/8.3/417/images/rhel-guest-image-8.3-417.x86_64.qcow2
 osp_controller_storage_class: host-nfs-storageclass


### PR DESCRIPTION
This reduces disk size for VMs to the level which should be
sufficient for standard deployment. Usually master nodes
were around 15G each, similarly for worker nodes.