### PR TITLE
Use ocp user when downloading RHEL guest image

### DIFF
--- a/ansible/install_computes.yaml
+++ b/ansible/install_computes.yaml
@@ -21,21 +21,23 @@
   - name: register dev-tools prepared extra_hosts
     shell: |
       set -e
-      oc apply -f /home/ocp/dev-scripts/ocp/ostest/extra_host_manifests.yaml
+      oc apply -f {{ base_path }}/dev-scripts/ocp/ostest/extra_host_manifests.yaml
     environment: &oc_env
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"
 
   - name: Check if {{ osp_controller_base_image_url | basename }} already exist
     stat:
-      path: "/home/ocp/ironic/html/images/{{ osp_controller_base_image_url | basename }}"
+      path: "{{ base_path }}/ironic/html/images/{{ osp_controller_base_image_url | basename }}"
     register: stat_result
 
   - name: Get RHEL guest base image
+    become: true
+    become_user: ocp
     when: not stat_result.stat.exists
     get_url:
       url: "{{ osp_controller_base_image_url }}"
-      dest: "/home/ocp/ironic/html/images/{{ osp_controller_base_image_url | basename }}"
+      dest: "{{ base_path }}/ironic/html/images/{{ osp_controller_base_image_url | basename }}"
       mode: '0644'
 
   - name: Render templates to yaml dir


### PR DESCRIPTION
RHEL guest image is downloaded into ironic subfolder
owned by the ocp user, and downloading of RHEL guest
image must be perfomed by the same user to succeed.

Changing also from /home/ocp to the variable base_path
defined in defaults.yaml.