### PR TITLE
Align OLM cleanup for webUI and CLI

### DIFF
--- a/ansible/demo.yaml
+++ b/ansible/demo.yaml
@@ -54,13 +54,13 @@
 
   - name: delete OLM subscription
     shell: |
-      oc delete --ignore-not-found -n openstack subscription osp-director-operator-subscription
+      oc delete --ignore-not-found -n openstack subscription osp-director-operator
     environment:
       <<: *oc_env
 
   - name: delete OLM operator group
     shell: |
-      oc delete --ignore-not-found -n openstack operatorgroup osp-director-operator-group
+      oc delete --ignore-not-found -n openstack operatorgroup osp-director-operator
     environment:
       <<: *oc_env
 

--- a/ansible/olm_cleanup.yaml
+++ b/ansible/olm_cleanup.yaml
@@ -5,14 +5,27 @@
   - oc_local
 
   tasks:
+
+  #NOTE: operatorgroup is named differently depending if it is created via
+  # the webUI so we register the name here and delete it below by name
+  - name: set operatorgroup name
+    ignore_errors: true
+    shell: >
+      oc get operatorgroup -n {{ namespace }} -o name
+    environment: &oc_env
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
+    register: operatorgroup_name
+
+
   - name: olm cleanup
     command: "{{ item }}"
     environment:
-      PATH: "{{ oc_env_path }}"
-      KUBECONFIG: "{{ kubeconfig }}"
+      <<: *oc_env
     ignore_errors: true
     with_items:
       - "oc delete -n {{ namespace }} csv osp-director-operator.v{{ csv_version }}"
-      - "oc delete -n {{ namespace }} subscription osp-director-operator-subscription"
+      - "oc delete -n {{ namespace }} subscription osp-director-operator"
       - "oc delete -n {{ namespace }} catalogsource osp-director-operator-index"
-      - "oc delete -n {{ namespace }} operatorgroup osp-director-operator-group"
+      - "oc delete -n {{ namespace }} {{ operatorgroup_name.stdout }}"
+

--- a/ansible/templates/osp-director-operator/operatorgroup.yaml.j2
+++ b/ansible/templates/osp-director-operator/operatorgroup.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: osp-director-operator-group
+  name: osp-director-operator
   namespace: {{ namespace }}
 spec:
   targetNamespaces:

--- a/ansible/templates/osp-director-operator/subscription.yaml.j2
+++ b/ansible/templates/osp-director-operator/subscription.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: osp-director-operator-subscription
+  name: osp-director-operator
   namespace: {{ namespace }}
 spec:
   config:


### PR DESCRIPTION
The naming schemes for the subscription and operator group
were slightly different. This patch aligns things so that
olm_cleanup will remove the installed OLM resources regardless
of whether the CLI or UI is used to install them.

The operatorgroup resource gets auto-created with a generated
name via the UI so we add logic to the playbook to lookup and use
that for deletion accordingly.