### PR TITLE
Openstackclient image

### DIFF
--- a/ansible/templates/osp/ctlplane/osp-director_controlplane.yaml.j2
+++ b/ansible/templates/osp/ctlplane/osp-director_controlplane.yaml.j2
@@ -4,7 +4,7 @@ metadata:
   name: overcloud
   namespace: {{ namespace }}
 spec:
-  openStackClientImageURL: quay.io/openstack-k8s-operators/tripleo-deploy:cloud-admin
+  openStackClientImageURL: {{ openstackclient_image }}
   passwordSecret: userpassword
   controller:
     networks:

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -97,7 +97,7 @@ osp_controller_base_image_url: http://download.devel.redhat.com/brewroot/package
 osp_controller_storage_class: host-nfs-storageclass
 # Interface connected to osp network, will be configured as linux-bridge using nmstate
 osp_interface: enp6s0
-osp_container_tag: 16.2_20210112.4
+osp_container_tag: 16.2_20210129.1
 
 # number of OCP worker nodes should be OSP compute hosts
 osp_compute_count: 1

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -84,8 +84,8 @@ nfs_export_dir: /home/nfs
 
 default_timeout: 240
 
-# worker node where openstackclient pod will run
-openstackclient_pod_worker: worker-0
+# openstackclient container image
+openstackclient_image: quay.io/openstack-k8s-operators/tripleo-deploy:latest
 
 # OSP controller VM sizing
 osp_controller_count: 1
@@ -97,7 +97,7 @@ osp_controller_base_image_url: http://download.devel.redhat.com/brewroot/package
 osp_controller_storage_class: host-nfs-storageclass
 # Interface connected to osp network, will be configured as linux-bridge using nmstate
 osp_interface: enp6s0
-osp_container_tag: 16.2_20210129.1
+osp_container_tag: 16.2_20210215.1
 
 # number of OCP worker nodes should be OSP compute hosts
 osp_compute_count: 1


### PR DESCRIPTION
Adds openstackclient_image to customize the container image used
for the openstackclient pod.

Also:
 - removes the not used openstackclient_pod_worker
 - bumps the osp_container_tag