### PR TITLE
Create shared provisionserver

### DIFF
--- a/ansible/install_computes.yaml
+++ b/ansible/install_computes.yaml
@@ -37,11 +37,28 @@
       dest: "{{ compute_yaml_dir }}/{{ item }}"
       mode: '0644'
     with_items:
+    - "openstackprovisionserver.yaml"
     - "openstackbaremetalset.yaml"
 
-  - name: Start openstackbaremetalset
+  - name: does the provisionserver already exist
+    ignore_errors: true
+    shell: >
+      oc get osprovserver openstack -o json --ignore-not-found
+    environment:
+      <<: *oc_env
+    register: provisionserver_switch
+
+  - name: Start provisionserver
     shell: |
       set -e
-      oc apply -n openstack -f "{{ compute_yaml_dir }}"
+      oc apply -n openstack -f "{{ compute_yaml_dir }}/openstackprovisionserver.yaml"
+    environment:
+      <<: *oc_env
+    when: provisionserver_switch.stdout | length == 0
+
+  - name: Start baremetalset
+    shell: |
+      set -e
+      oc apply -n openstack -f "{{ compute_yaml_dir }}/openstackbaremetalset.yaml"
     environment:
       <<: *oc_env

--- a/ansible/install_computes.yaml
+++ b/ansible/install_computes.yaml
@@ -41,9 +41,8 @@
     - "openstackbaremetalset.yaml"
 
   - name: does the provisionserver already exist
-    ignore_errors: true
     shell: >
-      oc get osprovserver openstack -o json --ignore-not-found
+      oc get -n openstack osprovserver openstack -o json --ignore-not-found
     environment:
       <<: *oc_env
     register: provisionserver_switch

--- a/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
+++ b/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
@@ -8,6 +8,7 @@ spec:
   replicas: {{ osp_compute_count }}
   # The image to install on the provisioned nodes
   baseImageUrl: http://172.22.0.1/images/{{ osp_controller_base_image_url | basename }}
+  provisionServerName: openstack
   # The secret containing the SSH pub key to place on the provisioned nodes
   deploymentSSHSecret: osp-controlplane-ssh-keys
   # The interface on the nodes that will be assigned an IP from the mgmtCidr

--- a/ansible/templates/osp/compute/openstackprovisionserver.yaml.j2
+++ b/ansible/templates/osp/compute/openstackprovisionserver.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackProvisionServer
+metadata:
+  name: openstack
+  namespace: openstack
+spec:
+  port: 8080
+  baseImageUrl: http://172.22.0.1/images/{{ osp_controller_base_image_url | basename }}


### PR DESCRIPTION
This uses the new ProvisionServerName feature on BaremetalSet
to leverage use of a pre-created ProvisionServer when creating
the CR. Should speed up subsequent deployments of BaremetalSets.