### PR TITLE
Use skip list instead of warn list to provide better feedback

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,4 @@
-warn_list:
+skip_list:
   - '204'
   - '301'
   - '306'


### PR DESCRIPTION
We do skip couple of lint rules as they are not yet fixed,
so far they were shown but did not cause job to report
failure. This is fine, however github actions shows 10 first
problems and so the relevant errors are hidden as the warn
list is shown in the first 10 error/warn list.