### PR TITLE
Pin ansible-lint version to the latest 4.x

### DIFF
--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -16,3 +16,7 @@ jobs:
           targets: |
             **/*.yaml
           args: "--exclude ansible/roles/prepare_rhos_release"
+          override-deps: |
+            ansible==2.10.7
+            ansible-base==2.10.5
+            ansible-lint==4.3.7


### PR DESCRIPTION
Ansible-lint introduced number of changes in 5.x which
gives errors until the playbooks. Until playbooks are fixed
to work with 5.x we need to pin to use 4.x.

See:
  https://github.com/ansible-community/ansible-lint/discussions/1150