### PR TITLE
Upgrade pip version before installing oc client

### DIFF
--- a/ansible/local_oc_client.yaml
+++ b/ansible/local_oc_client.yaml
@@ -12,6 +12,10 @@
       - python3-pip
     become: yes
 
+  - name: Upgrade pip
+    shell: |
+      pip3 install --upgrade pip
+
   - name: Install openstack client
     shell: |
       pip3 install --user python-openstackclient osc-placement

--- a/ansible/local_oc_client.yaml
+++ b/ansible/local_oc_client.yaml
@@ -15,6 +15,7 @@
   - name: Upgrade pip
     shell: |
       pip3 install --upgrade pip
+    become: yes
 
   - name: Install openstack client
     shell: |


### PR DESCRIPTION
If pip is not the last version, it fails to install the necesary cryptography dependency.