### PR TITLE
rhel-subscription does not need to be mandatory

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -31,14 +31,23 @@ dnf install -y ansible git libvirt-client python3-netaddr python3-lxml
 
 First create the following files relative to the project root:
 
-`vars/rhel-subscription.yaml` in the format:
+`files/pull-secret` which contains your OCP pull-secrets file.
+
+`vars/rhel-subscription.yaml` is optional. File format:
 
 ```
 rhel_subscription_activation_key: xyz
 rhel_subscription_org_id: "123123123"
 ```
 
-`files/pull-secret` which contains your OCP pull-secrets file.
+If `vars/rhel-subscription.yaml` is not specified, a subscription must have been configured manually prior to running the ansible. The manual subscription must give access to the following repositories:
+
+```
+advanced-virt-for-rhel-8-x86_64-rpms                    Advanced Virtualization for RHEL 8 x86_64 (RPMs)
+ansible-2-for-rhel-8-x86_64-rpms                        Red Hat Ansible Engine 2 for RHEL 8 x86_64 (RPMs)
+rhel-8-for-x86_64-appstream-rpms                        Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
+rhel-8-for-x86_64-baseos-rpms                           Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
+```
 
 Any other parameter from `vars/default.yaml` can be customized using
 `local-defaults.yaml`. Add parameters to meet your req.

--- a/ansible/host_prep.yaml
+++ b/ansible/host_prep.yaml
@@ -30,13 +30,19 @@
       - name: Include rhel-subscription info
         include_vars: vars/rhel-subscription.yaml
       rescue:
-      - fail:
-          msg: |
-            vars/rhel-subscription.yaml is not present. You must create this
+      - name: No rhel-subscription info
+        pause:
+          seconds: 1
+          prompt: |
+            vars/rhel-subscription.yaml is not present. You can create this
             file manually. The format of the file is:
 
             rhel_subscription_activation_key: <activation key>
             rhel_subscription_org_id: "xxxxxxx"
+
+            If you do not have the file, we will use your manually provisioned
+            subscription
+        register: manual_rhel_subscription
 
     - name: use secrets_repo
       when: secrets_repo is defined
@@ -58,13 +64,19 @@
       - name: Include rhel-subscription info
         include_vars: "{{ secrets_repo_path }}/rhel-subscription.yaml"
       rescue:
-      - fail:
-          msg: |
+      - name: No rhel-subscription info
+        pause:
+          seconds: 1
+          prompt: |
             rhel-subscription.yaml is not present in {{ secrets_repo }}. You must create this
             file. The format of the file is:
 
             rhel_subscription_activation_key: <activation key>
             rhel_subscription_org_id: "xxxxxxx"
+
+            If you do not have the file, we will use your manually provisioned
+            subscription
+        register: manual_rhel_subscription
 
     - name: unregister node
       retries: 3
@@ -75,6 +87,7 @@
         activationkey: "{{ rhel_subscription_activation_key }}"
         org_id: "{{ rhel_subscription_org_id }}"
         pool: '^(Red Hat Enterprise Server for x86_64)$'
+      when: manual_rhel_subscription is undefined
 
     - name: Register with activationkey and consume subscriptions matching Red Hat Enterprise Server
       retries: 3
@@ -85,6 +98,7 @@
         activationkey: "{{ rhel_subscription_activation_key }}"
         org_id: "{{ rhel_subscription_org_id }}"
         pool: '^(Red Hat Enterprise Server for x86_64)$'
+      when: manual_rhel_subscription is undefined
 
     - name: enable rhel-8-for-x86_64-appstream-rpms and advanced-virt-for-rhel-8-x86_64-rpms
       command: subscription-manager repos --enable=rhel-8-for-x86_64-appstream-rpms --enable=advanced-virt-for-rhel-8-x86_64-rpms


### PR DESCRIPTION
This PR does not need to go through if you think it is an option you do not want to give, but it is pretty useful for me, so I thought I might help others too. Feel free to dismiss if it is not something you would like.

Currently, passing a rhel subscription key and orgid are required. If you are using RHEL8 to run the playbook (which is necessary due to the use of rhel-8 repositories), the machine should have already been subscribed in order to download the ansible executable. As long as most of the subscriptions currently give access to the two needed repos, it is not needed to unsubscribe and resuscribe, just to import the repos.

So, I made a little modification in which, if the rhel-subscription.yaml file is not found, we just log a message indicating that the current subscription will be used by the script to add the repos.

The main motivator for this change (although not the unique) is that it does not seem possible (or at least I did not find anywhere or anywho who knows how) to obtain an apikey and an orgid from a "developer" subscription, which is mainly what the people running this playbooks will be using.