### PR TITLE
Move to rhel 8.4 guest image for overcloud systems

### DIFF
--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -102,7 +102,7 @@ osp_controller_cores: 6
 osp_controller_memory: 12
 osp_controller_disk_size: 40
 # use http://download.devel.redhat.com to get the local mirror depending on where the server is
-osp_controller_base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/8.3/417/images/rhel-guest-image-8.3-417.x86_64.qcow2
+osp_controller_base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/8.4/825/images/rhel-guest-image-8.4-825.x86_64.qcow2
 osp_controller_storage_class: host-nfs-storageclass
 # Interface connected to osp network, will be configured as linux-bridge using nmstate
 osp_interface: enp6s0


### PR DESCRIPTION
The OSP 16.2 container images are now RHEL 8.4 bases, lets also
move the rhel guest image to RHEL8.4 to keep container/host os
in sync.