### PR TITLE
Bump to OCP 4.7, CNV 2.6

### DIFF
--- a/ansible/files/cnv/1/subscription.yaml
+++ b/ansible/files/cnv/1/subscription.yaml
@@ -7,5 +7,5 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   name: kubevirt-hyperconverged
-  startingCSV: kubevirt-hyperconverged-operator.v2.5.3
+  startingCSV: kubevirt-hyperconverged-operator.v2.6.0
   channel: "stable"

--- a/ansible/ocp_cnv.yaml
+++ b/ansible/ocp_cnv.yaml
@@ -71,10 +71,10 @@
 
   - name: install kubevirt client
     block:
-    - name: enable cnv-2.5-for-rhel-8-x86_64-rpms to install kubevirt-virtctl
+    - name: enable cnv-2.6-for-rhel-8-x86_64-rpms to install kubevirt-virtctl
       become: true
       become_user: root
-      command: subscription-manager repos --enable=cnv-2.5-for-rhel-8-x86_64-rpms
+      command: subscription-manager repos --enable=cnv-2.6-for-rhel-8-x86_64-rpms
 
     - name: Install kubevirt-virtctl package
       become: true

--- a/ansible/olm.yaml
+++ b/ansible/olm.yaml
@@ -33,12 +33,6 @@
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"
 
-  - name: Wait for the catalogSource to be available
-    shell: |
-      oc wait pod -l olm.catalogSource=osp-director-operator-index --for condition=ready -n "{{ namespace }}" --timeout={{ default_timeout }}s
-    environment:
-      <<: *oc_env
-
   - name: Waiting for packagemanifest 'osp-director-operator' to be created
     shell: |
       oc get -n "{{ namespace }}" packagemanifest/osp-director-operator

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -4,8 +4,8 @@ base_path: /home/ocp
 #dev_scripts_branch: defaults to "HEAD"
 
 # To set a specific release to install.
-ocp_version: 4.6
-ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.6.15-x86_64
+ocp_version: 4.7
+ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.7.4-x86_64
 ocp_release_type: ga
 
 # private repo to read required secret files from
@@ -52,10 +52,10 @@ kustomize_version: v4.0.1
 kuttl_version: 0.9.0
 
 # SRIOV network operator version (usually should correspond to X.X release)
-sriov_version: 4.6
+sriov_version: 4.7
 
 # Performance addon operator version (usually should correspond to X.X release)
-perf_version: 4.6
+perf_version: 4.7
 
 # namespace to deploy the operator to
 # Note: right now only openstack is supported as it is hardcoded in the Dockerfile


### PR DESCRIPTION
The check for osp-director-operator-index was removed as this
pod is now named with a unique ID appended. Also the check isn't
explicitly needed as the packagemanifest check below is really what matters.