### PR TITLE
Remove cleanup before dev-scripts deploy

### DIFF
--- a/ansible/ocp_dev_scripts.yaml
+++ b/ansible/ocp_dev_scripts.yaml
@@ -7,13 +7,6 @@
   - name: Include variables
     include_vars: vars/default.yaml
 
-  - name: cleanup previous dev-script deployment
-    shell: |
-      export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-      make clean
-    args:
-      chdir: "{{ base_path }}/dev-scripts"
-
   - debug:
       msg: |
         Executing dev-script. You can tail the logs at ~ocp/dev-script.log on


### PR DESCRIPTION
With enabling assisted installer in dev-scripts, cleanup job fail
if connection to the ocp cluster is not possible using oc client.

For now disable dev-scripts cleanup run.