### PR TITLE
Assisted installer deploy option

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -15,7 +15,10 @@ local-defaults.yaml:
 	echo -e "vars:" > $@
 
 local-deps:
-	ansible-galaxy install -r requirements.yml
+	# This should work for both roles and collections, but does not:
+	# ansible-galaxy install -r requirements.yml
+	# ...so we install requirements twice, once for roles and once for collections
+	ansible-galaxy role install -r requirements.yml && ansible-galaxy collection install -r requirements.yml
 
 download_tools: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
@@ -24,22 +27,23 @@ download_tools: hosts local-defaults.yaml
 
 ocp_install:
 	$(MAKE) host_prep
-	$(MAKE) dev_scripts
+	$(MAKE) ocp_installer
 	$(MAKE) post_install
 
 host_prep: hosts local-deps local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook -i hosts -e @local-defaults.yaml \
 	host_prep.yaml \
-	ocp_dev_scripts_prep.yaml
+	ocp_installer_prep.yaml
 
-dev_scripts: hosts local-defaults.yaml
+ocp_installer: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook -i hosts -e @local-defaults.yaml \
-	ocp_dev_scripts.yaml
+	ocp_installer.yaml
 
 post_install: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
 	-i hosts -e @local-defaults.yaml \
 	local_oc_client.yaml \
+	ocp_ai_post_install.yaml \
 	ocp_default_storageclass.yaml \
 	ocp_image_registry.yaml \
 	ocp_vm_setup_extra_nics.yaml
@@ -146,10 +150,9 @@ nfs_cleanup: hosts
 	 cat \$$temp > /etc/fstab; \
 	 rm \$$temp"
 
-destroy_ocp: hosts
-	ANSIBLE_FORCE_COLOR=true ansible -i hosts convergence_base \
-	--become --become-user ocp \
-	-m shell -a "cd /home/ocp/dev-scripts && make clean"
+destroy_ocp: hosts local-defaults.yaml
+	ANSIBLE_FORCE_COLOR=true ansible-playbook -i hosts -e @local-defaults.yaml \
+	ocp_installer_destroy.yaml
 	$(MAKE) nfs_cleanup
 
 demo: hosts

--- a/ansible/datavolume.yaml
+++ b/ansible/datavolume.yaml
@@ -7,23 +7,31 @@
 
   tasks:
 
+  - name: Set path to RHEL base image for dev-scripts
+    set_fact:
+      osp_controller_base_image_url_path: "{{ base_path }}/ironic/html/images/{{ osp_controller_base_image_url | basename }}"
+    when: ocp_ai|bool == False
+
+  - name: Set path to RHEL base image for assisted installer
+    set_fact:
+      osp_controller_base_image_url_path: "{{ ocp_ai_http_store_dir | default('/opt/http_store/data', true) }}/{{ osp_controller_base_image_url | basename }}"
+    when: ocp_ai|bool
+
   # NOTE: we copy this to the Ironic images directory to reuse it for
   # the provision server (openstackbaremetalsets). This avoids downloading
   # the same image twice.
   - name: Check if {{ osp_controller_base_image_url | basename }} already exist
-    become: true
-    become_user: ocp
     stat:
-      path: "{{ base_path }}/ironic/html/images/{{ osp_controller_base_image_url | basename }}"
+      path: "{{ osp_controller_base_image_url_path }}"
     register: stat_result
 
   - name: Get RHEL guest base image
-    become: true
-    become_user: ocp
     when: not stat_result.stat.exists
     get_url:
       url: "{{ osp_controller_base_image_url }}"
-      dest: "{{ base_path }}/ironic/html/images/{{ osp_controller_base_image_url | basename }}"
+      dest: "{{ osp_controller_base_image_url_path }}"
+      owner: ocp
+      group: ocp
       mode: '0644'
 
   - name: does the datavolume already exist
@@ -37,7 +45,7 @@
 
   - name: Deploy the datavolume
     shell: |
-      virtctl image-upload dv openstack-base-img -n {{ namespace }} --size={{ osp_controller_disk_size }}G --image-path={{ base_path }}/ironic/html/images/{{ osp_controller_base_image_url | basename }}
+      virtctl image-upload dv openstack-base-img -n {{ namespace }} --size={{ osp_controller_disk_size }}G --image-path={{ osp_controller_base_image_url_path }} --insecure
     environment:
       <<: *oc_env
     when: datavolume_switch.rc == 1

--- a/ansible/datavolume.yaml
+++ b/ansible/datavolume.yaml
@@ -10,7 +10,7 @@
   - name: Set path to RHEL base image for dev-scripts
     set_fact:
       osp_controller_base_image_url_path: "{{ base_path }}/ironic/html/images/{{ osp_controller_base_image_url | basename }}"
-    when: ocp_ai|bool == False
+    when: not (ocp_ai|bool)
 
   - name: Set path to RHEL base image for assisted installer
     set_fact:

--- a/ansible/host_prep.yaml
+++ b/ansible/host_prep.yaml
@@ -83,6 +83,35 @@
     - name: enable rhel-8-for-x86_64-appstream-rpms and advanced-virt-for-rhel-8-x86_64-rpms
       command: subscription-manager repos --enable=rhel-8-for-x86_64-appstream-rpms --enable=advanced-virt-for-rhel-8-x86_64-rpms
 
+    - name: validation and tweaks for assisted installer
+      block:
+      # FIXME: Here to enforce use of RHEL 8.3+ and OCP 4.7 for now
+      - fail:
+          msg: RHEL 8.3+ is required for the assisted installer deployments
+        when: ansible_distribution != "RedHat" or ansible_distribution_version|float < 8.3
+
+      - fail:
+          msg: "OCP version {{ ocp_version }} is not allowed.  Only OCP 4.7 is currently supported for assisted installer deployments."
+        when: ocp_version != 4.7
+
+      - name: disable virt module for rhel and enable it for 8.3
+        shell: |
+          dnf module disable virt:rhel -y
+          dnf module enable virt:8.3 -y
+
+      - name: Install the latest version of qemu-kvm
+        block:
+        - name: Uninstall qemu-kvm
+          dnf:
+            name: qemu-kvm
+            state: absent
+
+        - name: Install latest qemu-kvm
+          dnf:
+            name: qemu-kvm
+            state: latest
+      when: ocp_ai|bool
+
   - name: install packages and enable services
     block:
     - name: Install packages
@@ -104,6 +133,14 @@
           - buildah
           - git
           - make
+
+          # Required for assisted installer
+          - dnsmasq
+          - libvirt-devel
+          - python3-netaddr
+          - python3-pip
+          - qemu-kvm
+          - virt-install
 
     - name: Enable helpful services
       service: name={{ item }} enabled=yes state=started

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,3 +1,6 @@
+[all:vars]
+ocp_ai=False
+
 localhost ansible_connection=local
 
 [convergence_base]

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,7 +1,7 @@
-[all:vars]
-ocp_ai=False
-
 localhost ansible_connection=local
 
 [convergence_base]
 localhost
+
+[all:vars]
+ocp_ai=False

--- a/ansible/install_computes.yaml
+++ b/ansible/install_computes.yaml
@@ -53,11 +53,11 @@
     environment:
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"
-    when: ocp_ai|bool == False
+    when: not (ocp_ai|bool)
 
   - name: Include AI variables
     include_vars: vars/ocp_ai.yaml
-  
+
   - name: Register assisted installer prepared extra_hosts
     shell: |
       set -e

--- a/ansible/install_computes.yaml
+++ b/ansible/install_computes.yaml
@@ -46,13 +46,26 @@
     become: true
     become_user: root
 
-  - name: register dev-tools prepared extra_hosts
+  - name: register dev-scripts prepared extra_hosts
     shell: |
       set -e
       oc apply -f {{ base_path }}/dev-scripts/ocp/ostest/extra_host_manifests.yaml
-    environment: &oc_env
+    environment:
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"
+    when: ocp_ai|bool == False
+
+  - name: Include AI variables
+    include_vars: vars/ocp_ai.yaml
+  
+  - name: Register assisted installer prepared extra_hosts
+    shell: |
+      set -e
+      oc apply -f {{ working_yamls_dir }}/ai_metal3/extra_workers_bmhs.yml
+    environment:
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
+    when: ocp_ai|bool
 
   - name: Render templates to yaml dir
     template:
@@ -66,8 +79,9 @@
   - name: does the provisionserver already exist
     shell: >
       oc get -n openstack osprovserver openstack -o json --ignore-not-found
-    environment:
-      <<: *oc_env
+    environment: &oc_env
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
     register: provisionserver_switch
 
   - name: Start provisionserver

--- a/ansible/install_networks.yaml
+++ b/ansible/install_networks.yaml
@@ -23,6 +23,11 @@
       state: directory
       mode: '0755'
 
+  - name: Override osp_interface for assisted installer deployments
+    set_fact:
+      osp_interface: enp8s0
+    when: ocp_ai|bool
+
   - name: Render templates to yaml dir
     template:
       src: "osp/networks/{{ item }}.j2"

--- a/ansible/local_oc_client.yaml
+++ b/ansible/local_oc_client.yaml
@@ -39,11 +39,20 @@
   vars_files: vars/default.yaml
   tasks:
 
-  - name: Copy kubeconfig
+  - name: Copy kubeconfig for dev-scripts
     fetch:
       dest: "{{ hostvars['localhost']['kubeconfig'] }}"
       src: "{{ base_path }}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
       flat: true
+    when: ocp_ai|bool == False
+
+  - name: Copy kubeconfig for assisted installer
+    fetch:
+      dest: "{{ hostvars['localhost']['kubeconfig'] }}"
+      src: "{{ base_path }}/cluster_mgnt_roles/kubeconfig.{{ ocp_cluster_name }}"
+      flat: true
+      become: true
+    when: ocp_ai|bool
 
   - name: Copy oc binary
     fetch:

--- a/ansible/local_oc_client.yaml
+++ b/ansible/local_oc_client.yaml
@@ -44,7 +44,7 @@
       dest: "{{ hostvars['localhost']['kubeconfig'] }}"
       src: "{{ base_path }}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
       flat: true
-    when: ocp_ai|bool == False
+    when: not (ocp_ai|bool)
 
   - name: Copy kubeconfig for assisted installer
     fetch:

--- a/ansible/ocp_ai.yaml
+++ b/ansible/ocp_ai.yaml
@@ -32,14 +32,16 @@
         the host for progress.
 
   - name: Run the assisted installer playbook
-    shell: ./run_playbook.sh
+    shell: |
+      ./run_playbook.sh
     args:
       chdir: "{{ base_path }}/cluster_mgnt_roles"
     environment:
       ANSIBLE_HOST_KEY_CHECKING: false
 
   - name: Download assisted installer cluster kubeconfig
-    shell: "aicli -U http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_service_port | default('8090', true) }} download kubeconfig {{ ocp_cluster_name }}"
+    shell: |
+      aicli -U http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_service_port | default('8090', true) }} download kubeconfig {{ ocp_cluster_name }}
     args:
       chdir: "{{ base_path }}/cluster_mgnt_roles"
     environment:

--- a/ansible/ocp_ai.yaml
+++ b/ansible/ocp_ai.yaml
@@ -1,0 +1,95 @@
+---
+- hosts: convergence_base
+  become: true
+  gather_facts: false
+
+  tasks:
+  - name: Include default variables
+    include_vars: vars/default.yaml
+
+  - name: Include AI variables
+    include_vars: vars/ocp_ai.yaml
+
+
+  ### EXECUTE ASSISTED INSTALLER PLAYBOOK
+
+  - name: Delete existing AI cluster (if any)
+    command: "aicli -U http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_service_port | default('8090', true) }} delete cluster {{ ocp_cluster_name }}"
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin
+    register: delete_ai_cluster
+    failed_when: delete_ai_cluster.stderr != "" and "Cluster {{ ocp_cluster_name }} not found" not in delete_ai_cluster.stderr
+
+  - name: Create assisted installer execution bash script
+    template:
+      src: ai/cluster_mgnt_roles/run_playbook.sh.j2
+      dest: "{{ base_path }}/cluster_mgnt_roles/run_playbook.sh"
+      mode: '0755'
+
+  - debug:
+      msg: |
+        Executing the assisted installer playbook. You can tail the logs at {{ base_path }}/ai.log on
+        the host for progress.
+
+  - name: Run the assisted installer playbook
+    shell: ./run_playbook.sh
+    args:
+      chdir: "{{ base_path }}/cluster_mgnt_roles"
+    environment:
+      ANSIBLE_HOST_KEY_CHECKING: false
+
+  - name: Download assisted installer cluster kubeconfig
+    shell: "aicli -U http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_service_port | default('8090', true) }} download kubeconfig {{ ocp_cluster_name }}"
+    args:
+      chdir: "{{ base_path }}/cluster_mgnt_roles"
+    environment:
+      PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin
+
+  - name: Set kubeconfig fact
+    set_fact:
+      ai_kubeconfig: "{{ lookup('file', '{{ base_path }}/cluster_mgnt_roles/kubeconfig.{{ ocp_cluster_name }}') }}"
+
+  - name: Create assisted installer kubeconfig locally
+    block:
+    - name: Include oc_local role
+      include_role:
+        name: oc_local
+
+    - name: Include default variables
+      include_vars: vars/default.yaml
+
+    - name: Render kubeconfig
+      template:
+        src: ai/cluster_mgnt_roles/kubeconfig.j2
+        dest: "{{ working_dir }}/kubeconfig"
+        mode: '0664'
+
+    delegate_to: localhost
+
+
+- hosts: localhost
+  vars_files: vars/default.yaml
+  roles:
+  - oc_local
+
+  ### OC CLIENT
+
+  tasks:
+  - name: Get the ocp client tar gunzip file
+    get_url:
+      url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-{{ ocp_version }}/openshift-client-linux.tar.gz"
+      dest: "/tmp/openshift-client-linux.tar.gz"
+      mode: '0755'
+
+  - name: "Untar the openshift-client-linux.tar.gz"
+    unarchive:
+      src: "/tmp/openshift-client-linux.tar.gz"
+      dest: "/tmp"
+      mode: '0755'
+
+  - name: Copy oc binary to /usr/local/bin
+    copy:
+      src: "/tmp/oc"
+      dest: /usr/local/bin/
+      mode: '0755'
+    become: yes

--- a/ansible/ocp_ai.yaml
+++ b/ansible/ocp_ai.yaml
@@ -29,7 +29,11 @@
   - debug:
       msg: |
         Executing the assisted installer playbook. You can tail the logs at {{ base_path }}/ai.log on
-        the host for progress.
+        the host for progress.  Furthermore, you can view the assisted installer console by entering the
+        URL http://{{ ocp_ai_bm_ip }}:8888/clusters/.  If you do not have direct access to that IP from
+        your browser, you can use a tool like "sshuttle" to provide connectivity like so:
+        sshuttle --dns -r <user>@<cluster host> {{ ocp_ai_bm_bridge_cidr }}.  You would then hit this
+        URL in your browser: http://<cluster host>:8888/clusters/
 
   - name: Run the assisted installer playbook
     shell: |
@@ -49,7 +53,7 @@
 
   - name: Set kubeconfig fact
     set_fact:
-      ai_kubeconfig: "{{ lookup('file', '{{ base_path }}/cluster_mgnt_roles/kubeconfig.{{ ocp_cluster_name }}') }}"
+      ai_kubeconfig: lookup('file', '{{ base_path }}/cluster_mgnt_roles/kubeconfig.{{ ocp_cluster_name }}')
 
   - name: Create assisted installer kubeconfig locally
     block:

--- a/ansible/ocp_ai_destroy.yaml
+++ b/ansible/ocp_ai_destroy.yaml
@@ -1,0 +1,108 @@
+---
+- hosts: convergence_base
+  become: true
+  gather_facts: false
+
+  tasks:
+  - name: Include default variables
+    include_vars: vars/default.yaml
+
+  - name: Include AI variables
+    include_vars: vars/ocp_ai.yaml
+    
+
+  ### DNSMASQ
+    
+  - name: Remove dnsmasq conf
+    file:
+      path: "/etc/dnsmasq.d/dnsmasq_ai.conf"
+      state: absent
+
+  - name: Remove dnsmasq DNS conf
+    file:
+      path: "/etc/NetworkManager/conf.d/dnsmasq.conf"
+      state: absent
+
+  - name: Restart NetworkManager
+    service:
+      name: NetworkManager
+      state: restarted
+      enabled: yes
+
+  - name: Stop dnsmasq
+    service:
+      name: dnsmasq
+      state: stopped
+
+
+  ### VMs
+
+  - name: Delete VMs and disk QCOW2s
+    shell: |
+      for i in $(virsh list | grep "{{ ocp_cluster_name }}-" | awk {"print $2"}); do
+        virsh destroy $i
+      done
+
+      for i in $(virsh list --all | grep "{{ ocp_cluster_name }}-" | awk {"print $2"}); do
+        virsh undefine --nvram $i
+        rm -f /var/lib/libvirt/images/$i.qcow2
+      done
+
+
+  ### SUSHY-TOOLS
+
+  - name: Stop sushy-tools service
+    service:
+      name: sushy-tools
+      state: stopped
+      enabled: no
+    ignore_errors: true
+
+  - name: Delete sushy-tools service
+    file:
+      path: /etc/systemd/system/sushy-tools.service
+      state: absent
+
+  - name: Reload systemd service
+    systemd:
+      daemon_reexec: yes
+    
+
+  ### HTTP STORE
+
+  - name: Stop and remove httpd container
+    containers.podman.podman_container:
+      name: httpd
+      image: registry.centos.org/centos/httpd-24-centos7:latest
+      state: absent
+    
+
+  ### ASSISTED INSTALLER SERVICE SCRIPT
+
+  - name: Stop and remove assisted installer service container
+    shell: |
+      ./stop-assisted-service.sh
+    args:
+      chdir: "{{ base_path }}/assisted-service-onprem"
+
+
+  ### BRIDGES
+
+  - name: Delete AI bridges
+    block:
+    - name: Delete existing bridges (if any)
+      community.general.nmcli:
+        conn_name: "{{ ocp_cluster_name }}{{ item }}"
+        type: bridge
+        state: absent
+      with_items:
+        - bm
+        - pr
+
+    - name: Make sure bridge ifcfg files are removed
+      file:
+        path: "/etc/sysconfig/network-scripts/ifcfg-{{ ocp_cluster_name }}{{ item }}"
+        state: absent
+      with_items:
+        - bm
+        - pr

--- a/ansible/ocp_ai_destroy.yaml
+++ b/ansible/ocp_ai_destroy.yaml
@@ -9,10 +9,10 @@
 
   - name: Include AI variables
     include_vars: vars/ocp_ai.yaml
-    
+
 
   ### DNSMASQ
-    
+
   - name: Remove dnsmasq conf
     file:
       path: "/etc/dnsmasq.d/dnsmasq_ai.conf"
@@ -66,7 +66,7 @@
   - name: Reload systemd service
     systemd:
       daemon_reexec: yes
-    
+
 
   ### HTTP STORE
 
@@ -75,7 +75,7 @@
       name: httpd
       image: registry.centos.org/centos/httpd-24-centos7:latest
       state: absent
-    
+
 
   ### ASSISTED INSTALLER SERVICE SCRIPT
 

--- a/ansible/ocp_ai_post_install.yaml
+++ b/ansible/ocp_ai_post_install.yaml
@@ -82,7 +82,7 @@
 
     - name: Wait for Metal3 pods to restart
       shell: |
-        oc wait pod --for condition=ready -n openshift-machine-api -l k8s-app=metal3 --timeout={{ default_timeout }}s
+        oc wait pod --for condition=ready -n openshift-machine-api -l k8s-app=metal3 --timeout={{ default_timeout*2 }}s
       environment:
         <<: *oc_env
 

--- a/ansible/ocp_ai_post_install.yaml
+++ b/ansible/ocp_ai_post_install.yaml
@@ -1,0 +1,86 @@
+---
+- hosts: localhost
+  vars_files: vars/default.yaml
+  roles:
+  - oc_local
+
+  tasks:
+  - name: Extra post-install steps for assisted installer
+    block:
+    - name: Include AI variables
+      include_vars: vars/ocp_ai.yaml
+
+
+    ### UN-SCHEDULABLE MASTERS
+
+    - name: Set directory for storing schedule/ingress yaml files
+      set_fact:
+        ai_sched_ingress_yaml_dir: "{{ working_yamls_dir }}/ai_schedule_ingress"
+
+    - name: Set facts to disable schedulable masters and reduce ingress replica count
+      set_fact:
+        ocp_ai_masters_schedulable: false
+        ocp_ai_ingress_replicas: 2
+
+    - name: Create local yaml dir for schedule/ingress CRs
+      file:
+        path: "{{ ai_sched_ingress_yaml_dir }}"
+        state: directory
+        mode: '0755'
+        owner: root
+        group: root
+
+    - name: Create schedule/ingress CRs
+      template:
+        src: ai/cluster_mgnt_roles/{{ item }}.j2
+        dest: "{{ ai_sched_ingress_yaml_dir }}/{{ item }}"
+        mode: '0664'
+      with_items:
+        - 50-master-scheduler.yml
+        - 60-ingress-controller.yml
+
+    - name: Apply schedule/ingress CRs
+      shell: "oc apply -f {{ ai_sched_ingress_yaml_dir }}/{{ item }}"
+      environment: &oc_env
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ base_path }}/cluster_mgnt_roles/kubeconfig.{{ ocp_cluster_name }}"
+      with_items:
+        - 50-master-scheduler.yml
+        - 60-ingress-controller.yml
+
+
+    ### PROVISIONING NETWORK
+
+    - name: Set directory for storing AI Metal3 yaml files
+      set_fact:
+        ai_metal3_yaml_dir: "{{ working_yamls_dir }}/ai_metal3"
+
+    - name: Create local yaml dir for Metal3 CRs
+      file:
+        path: "{{ ai_metal3_yaml_dir }}"
+        state: directory
+        mode: '0755'
+        owner: root
+        group: root
+
+    - name: Create Metal3 provisioning CR
+      template:
+        src: ai/metal3/provisioning.yml.j2
+        dest: "{{ ai_metal3_yaml_dir }}/provisioning.yml"
+        mode: '0664'
+
+    - name: Apply Metal3 provisioning CR
+      shell: "oc apply -f {{ ai_metal3_yaml_dir }}/provisioning.yml"
+      environment: 
+        <<: *oc_env
+
+    - name: Pause for 15 seconds to allow Metal3 to begin reconciliation
+      pause:
+        seconds: 15
+
+    - name: Wait for Metal3 pods to restart
+      shell: oc wait pod --for condition=ready -n openshift-machine-api -l k8s-app=metal3 --timeout={{ default_timeout }}s
+      environment:
+        <<: *oc_env
+
+    when: ocp_ai|bool

--- a/ansible/ocp_ai_post_install.yaml
+++ b/ansible/ocp_ai_post_install.yaml
@@ -40,7 +40,8 @@
         - 60-ingress-controller.yml
 
     - name: Apply schedule/ingress CRs
-      shell: "oc apply -f {{ ai_sched_ingress_yaml_dir }}/{{ item }}"
+      shell: |
+        oc apply -f {{ ai_sched_ingress_yaml_dir }}/{{ item }}
       environment: &oc_env
         PATH: "{{ oc_env_path }}"
         KUBECONFIG: "{{ base_path }}/cluster_mgnt_roles/kubeconfig.{{ ocp_cluster_name }}"
@@ -70,8 +71,9 @@
         mode: '0664'
 
     - name: Apply Metal3 provisioning CR
-      shell: "oc apply -f {{ ai_metal3_yaml_dir }}/provisioning.yml"
-      environment: 
+      shell: |
+        oc apply -f {{ ai_metal3_yaml_dir }}/provisioning.yml
+      environment:
         <<: *oc_env
 
     - name: Pause for 15 seconds to allow Metal3 to begin reconciliation
@@ -79,7 +81,8 @@
         seconds: 15
 
     - name: Wait for Metal3 pods to restart
-      shell: oc wait pod --for condition=ready -n openshift-machine-api -l k8s-app=metal3 --timeout={{ default_timeout }}s
+      shell: |
+        oc wait pod --for condition=ready -n openshift-machine-api -l k8s-app=metal3 --timeout={{ default_timeout }}s
       environment:
         <<: *oc_env
 

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -9,7 +9,7 @@
 
   - name: Include AI variables
     include_vars: vars/ocp_ai.yaml
-  
+
 
   ### ASSISTED INSTALLER CLI BINARY
 
@@ -62,20 +62,22 @@
 
     - name: Delete existing bridges (if any)
       community.general.nmcli:
-        conn_name: "{{ ocp_cluster_name }}{{ item }}"
+        conn_name: "{{ item }}"
         type: bridge
         state: absent
       with_items:
-        - bm
-        - pr
+        - "{{ ocp_cluster_name }}bm"
+        - "{{ ocp_cluster_name }}pr"
+        - "ospnetwork"
 
     - name: Make sure bridge ifcfg files are removed
       file:
-        path: "/etc/sysconfig/network-scripts/ifcfg-{{ ocp_cluster_name }}{{ item }}"
+        path: "/etc/sysconfig/network-scripts/ifcfg-{{ item }}"
         state: absent
       with_items:
-        - bm
-        - pr
+        - "{{ ocp_cluster_name }}bm"
+        - "{{ ocp_cluster_name }}pr"
+        - "ospnetwork"
 
     - name: Create BM bridge
       community.general.nmcli:
@@ -87,7 +89,7 @@
         # TODO: Support any netmask?
         ip4: "{{ ocp_ai_bm_ip }}/24"
         state: present
-    
+
     - name: Create provisioning bridge
       community.general.nmcli:
         conn_name: "{{ ocp_cluster_name }}pr"
@@ -105,7 +107,7 @@
       with_items:
         - bm
         - pr
-        
+
 
   ### FIREWALL
 
@@ -113,10 +115,11 @@
     block:
     - name: Acquire default external interface
       shell: |
-        ip r | grep default | head -1 | cut -d ' ' -f 5 
+        ip r | grep default | head -1 | cut -d ' ' -f 5
       register: ocp_ai_ext_intf
 
-    - fail: 
+    - name: Fail when unable to determine external interface
+      fail:
         msg: |
           Unable to determine external interface
       when: ocp_ai_ext_intf.stdout == ""
@@ -150,12 +153,12 @@
         immediate: yes
       with_items:
         - 80
-        - 2049 
-        - 5000 
+        - 2049
+        - 5000
         - 5050
         - 6180
         - 6385
-        - 8000 
+        - 8000
         - 9999
 
     - name: Add UDP firewall rules for provisioning bridge
@@ -167,13 +170,13 @@
         immediate: yes
       with_items:
         - 53
-        - 5353 
+        - 5353
         - 546
         - 547
         - 6230-6239
-        - 67 
-        - 68   
-        - 69 
+        - 67
+        - 68
+        - 69
 
     # FIXME: Use firewalld rich-rules instead?
     - name: Add direct firewall rules for BM bridge
@@ -183,7 +186,7 @@
         firewall-cmd --direct --permanent --add-rule ipv4 filter FORWARD 0 -i "{{ ocp_ai_ext_intf.stdout }}" -o "{{ ocp_cluster_name }}bm" -m state --state RELATED,ESTABLISHED -j ACCEPT;
         firewall-cmd --reload
 
-  
+
   ### HTTP STORE
 
   - name: Create an HTTP server container to hold ISOs/QCOW2s
@@ -227,7 +230,7 @@
         src: "ai/dnsmasq/dnsmasq.conf.j2"
         dest: "/etc/dnsmasq.d/dnsmasq_ai.conf"
         mode: '0644'
-    
+
     - name: Create NetworkManager dnsmasq DNS conf (to disable it)
       template:
         src: "ai/dnsmasq/nm_dnsmasq.conf.j2"
@@ -281,7 +284,7 @@
       register: libvirt_default_pool
       failed_when: libvirt_default_pool.stderr != "" and "no storage pool with matching name" not in libvirt_default_pool.stderr
 
-    - name: Handle default storage pool 
+    - name: Handle default storage pool
       block:
       - name: Render libvirt default storage pool XML
         template:
@@ -297,7 +300,7 @@
               virsh pool-undefine $i
             fi
           done
-      
+
       - name: Create default storage pool
         shell: |
           virsh pool-define /tmp/storage-pool.xml
@@ -324,7 +327,7 @@
             --events on_reboot=restart \
             --print-xml > /tmp/{{ ocp_cluster_name }}-master-$((i-1)).xml
         done
-        
+
         for i in {1..{{ ocp_num_workers + ocp_num_extra_workers }}}; do
             sudo virt-install \
             --virt-type=kvm \
@@ -359,7 +362,7 @@
 
     - name: Print extra worker domain UUIDs
       shell: virsh dumpxml {{ item }} | grep uuid | cut -d '>' -f 2 | cut -d '<' -f 1
-      when: index >= {{ ocp_num_workers }}
+      when: index >= ocp_num_workers
       loop: "{{ worker_list.stdout_lines }}"
       loop_control:
         index_var: index
@@ -400,11 +403,11 @@
   - name: Install sushy-tools
     block:
     - name: Install sushy-tools via pip3
-      command: "pip3 install {{ item }}" 
+      command: "pip3 install {{ item }}"
       with_items:
-        - sushy-tools 
+        - sushy-tools
         - libvirt-python
-    
+
     - name: Create sushy-tools conf directory
       file:
         path: /opt/sushy-tools
@@ -432,7 +435,7 @@
         name: sushy-tools
         state: restarted
         enabled: yes
-    
+
 
   ### ASSISTED INSTALLER SERVICE SCRIPT
 
@@ -449,7 +452,7 @@
       file:
         path: "{{ ocp_ai_service_store_dir | default('/opt/assisted-service', true) }}"
         state: directory
-        mode: '0755' 
+        mode: '0755'
 
     - name: Set assisted installer service storage directory
       replace:
@@ -511,7 +514,7 @@
           src: ai/cluster_mgnt_roles/50-master-scheduler.yml.j2
           dest: "{{ base_path }}/cluster_mgnt_roles/create_cluster/templates/50-master-scheduler.yml.j2"
           mode: '0664'
-        
+
       - name: Inject schedulable-master manifest
         lineinfile:
           path: "{{ base_path }}/cluster_mgnt_roles/create_cluster/tasks/main.yml"
@@ -526,7 +529,7 @@
           src: ai/cluster_mgnt_roles/60-ingress-controller.yml.j2
           dest: "{{ base_path }}/cluster_mgnt_roles/create_cluster/templates/60-ingress-controller.yml.j2"
           mode: '0664'
-        
+
       - name: Inject ingress controller manifest
         lineinfile:
           path: "{{ base_path }}/cluster_mgnt_roles/create_cluster/tasks/main.yml"
@@ -547,6 +550,3 @@
           src: ai/cluster_mgnt_roles/inventory.ospd.j2
           dest: "{{ base_path }}/cluster_mgnt_roles/inventory.ospd"
           mode: '0664'
-
-
-    

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -280,7 +280,7 @@
     # FIXME: Sushy-tools does not allow you to specify the libvirt storage pool, and assumes
     #        that default exists, so we need to make sure that it does
     - name: Check if default storage pool exists
-      shell: virsh pool-list | grep default 
+      shell: virsh pool-list | grep default
       register: libvirt_default_pool
       failed_when: libvirt_default_pool.stderr != "" and "no storage pool with matching name" not in libvirt_default_pool.stderr
 
@@ -311,7 +311,7 @@
     - name: Create AI OCP VM XML definitions
       shell: |
         for i in {1..{{ ocp_num_masters }}}; do
-            sudo virt-install \
+            virt-install \
             --virt-type=kvm \
             --name "{{ ocp_cluster_name }}-master-$((i-1))" \
             --memory {{ ocp_master_memory }} \
@@ -320,7 +320,8 @@
             --os-type linux \
             --network=bridge:{{ ocp_cluster_name }}bm,mac="{{ ocp_ai_bm_bridge_master_mac_prefix }}$((i-1))" \
             --network=bridge:{{ ocp_cluster_name }}pr,mac="{{ ocp_ai_prov_bridge_master_mac_prefix }}$((i-1))" \
-            --disk path=/var/lib/libvirt/images/{{ ocp_cluster_name }}-master-$((i-1)).qcow2,size={{ ocp_master_disk }},bus=virtio,format=qcow2 \
+            --controller type=scsi,model=virtio-scsi \
+            --disk path=/var/lib/libvirt/images/{{ ocp_cluster_name }}-master-$((i-1)).qcow2,size={{ ocp_master_disk }},bus=scsi,format=qcow2 \
             --graphics vnc \
             --noautoconsole --wait=-1 \
             --boot uefi \
@@ -329,7 +330,7 @@
         done
 
         for i in {1..{{ ocp_num_workers + ocp_num_extra_workers }}}; do
-            sudo virt-install \
+            virt-install \
             --virt-type=kvm \
             --name "{{ ocp_cluster_name }}-worker-$((i-1))" \
             --memory {{ ocp_worker_memory }} \
@@ -338,7 +339,8 @@
             --os-type linux \
             --network=bridge:{{ ocp_cluster_name }}bm,mac="{{ ocp_ai_bm_bridge_worker_mac_prefix }}$((i-1))" \
             --network=bridge:{{ ocp_cluster_name }}pr,mac="{{ ocp_ai_prov_bridge_worker_mac_prefix }}$((i-1))" \
-            --disk path=/var/lib/libvirt/images/{{ ocp_cluster_name }}-worker-$((i-1)).qcow2,size={{ ocp_worker_disk }},bus=virtio,format=qcow2 \
+            --controller type=scsi,model=virtio-scsi \
+            --disk path=/var/lib/libvirt/images/{{ ocp_cluster_name }}-worker-$((i-1)).qcow2,size={{ ocp_worker_disk }},bus=scsi,format=qcow2 \
             --graphics vnc \
             --noautoconsole --wait=-1 \
             --boot uefi \
@@ -349,11 +351,11 @@
     - name: Create VMs
       shell: |
         for i in {1..{{ ocp_num_masters }}}; do
-          sudo virsh define --file /tmp/{{ ocp_cluster_name }}-master-$((i-1)).xml
+          virsh define --file /tmp/{{ ocp_cluster_name }}-master-$((i-1)).xml
         done
 
         for i in {1..{{ ocp_num_workers + ocp_num_extra_workers }}}; do
-          sudo virsh define --file /tmp/{{ ocp_cluster_name }}-worker-$((i-1)).xml
+          virsh define --file /tmp/{{ ocp_cluster_name }}-worker-$((i-1)).xml
         done
 
     - name: Get worker domain names
@@ -485,7 +487,7 @@
         aicli -U http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_service_port | default('8090', true) }} list cluster
       register: assisted_service_ready
       until: '"Dns Domain" in assisted_service_ready.stdout'
-      retries: 36
+      retries: 48
       delay: 5
       environment:
         PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -1,0 +1,552 @@
+---
+- hosts: convergence_base
+  become: true
+  gather_facts: false
+
+  tasks:
+  - name: Include default variables
+    include_vars: vars/default.yaml
+
+  - name: Include AI variables
+    include_vars: vars/ocp_ai.yaml
+  
+
+  ### ASSISTED INSTALLER CLI BINARY
+
+  - name: Install assisted installer CLI
+    shell: |
+      pip3 install aicli
+      pip3 install --user aicli
+
+  ### ADDITIONAL SET-FACTS
+
+  - name: Set fact for full cluster name
+    set_fact:
+      ocp_ai_full_cluster_name: "{{ ocp_cluster_name }}.{{ ocp_domain_name | default('test.metalkube.org', true) }}"
+
+  # TODO: Add support for ipv6 for this and the following set_facts
+  - name: Set fact for BM CIDR prefix
+    set_fact:
+      ocp_ai_bm_cidr_prefix: "{{ ((ocp_ai_bm_bridge_cidr.split('.'))[0:3])|join('.') }}"
+
+  - name: Set fact for reverse BM CIDR suffix
+    set_fact:
+      ocp_ai_bm_cidr_rev_suffix: "{{ ((ocp_ai_bm_bridge_cidr.split('.'))[:-1]|join('.')|ipaddr('revdns'))[2:-1] }}"
+
+  - name: Set fact for provisioning CIDR prefix
+    set_fact:
+        ocp_ai_pr_cidr_prefix: "{{ ((ocp_ai_bm_bridge_cidr.split('.'))[0:3])|join('.') }}"
+
+
+  ### BRIDGES
+
+  # FIXME?: Should this task target the playbook host instead?
+  - name: Install needed network manager libs
+    package:
+      name:
+        - NetworkManager-libnm
+        - nm-connection-editor
+      state: present
+
+  - name: Create AI bridges
+    block:
+    - name: Remove lingering bridges from dev-scripts (if any)
+      shell: |
+        virsh net-destroy {{ ocp_cluster_name }}{{ item }};
+        virsh net-undefine {{ ocp_cluster_name }}{{ item }}
+      with_items:
+        - bm
+        - pr
+      register: dev_scripts_br_rm
+      failed_when: dev_scripts_br_rm.stderr != "" and "no network with matching name" not in dev_scripts_br_rm.stderr and "is not active" not in dev_scripts_br_rm.stderr
+
+    - name: Delete existing bridges (if any)
+      community.general.nmcli:
+        conn_name: "{{ ocp_cluster_name }}{{ item }}"
+        type: bridge
+        state: absent
+      with_items:
+        - bm
+        - pr
+
+    - name: Make sure bridge ifcfg files are removed
+      file:
+        path: "/etc/sysconfig/network-scripts/ifcfg-{{ ocp_cluster_name }}{{ item }}"
+        state: absent
+      with_items:
+        - bm
+        - pr
+
+    - name: Create BM bridge
+      community.general.nmcli:
+        conn_name: "{{ ocp_cluster_name }}bm"
+        type: bridge
+        ifname: "{{ ocp_cluster_name }}bm"
+        autoconnect: yes
+        stp: off
+        # TODO: Support any netmask?
+        ip4: "{{ ocp_ai_bm_ip }}/24"
+        state: present
+    
+    - name: Create provisioning bridge
+      community.general.nmcli:
+        conn_name: "{{ ocp_cluster_name }}pr"
+        type: bridge
+        ifname: "{{ ocp_cluster_name }}pr"
+        autoconnect: yes
+        stp: off
+        # TODO: Support any netmask?
+        ip4: "{{ ocp_ai_pr_ip }}/24"
+        state: present
+
+    - name: Reload bridges
+      shell: |
+        /usr/bin/nmcli con reload {{ ocp_cluster_name }}{{ item }}; /usr/bin/nmcli con up {{ ocp_cluster_name }}{{ item }}
+      with_items:
+        - bm
+        - pr
+        
+
+  ### FIREWALL
+
+  - name: Prepare firewall
+    block:
+    - name: Acquire default external interface
+      shell: |
+        ip r | grep default | head -1 | cut -d ' ' -f 5 
+      register: ocp_ai_ext_intf
+
+    - fail: 
+        msg: |
+          Unable to determine external interface
+      when: ocp_ai_ext_intf.stdout == ""
+
+    - name: Add BM bridge to libvirt zone
+      command: firewall-cmd --zone libvirt --change-interface ostestbm --permanent
+
+    - name: Add TCP firewall rules for BM bridge
+      firewalld:
+        port: "{{ item }}/tcp"
+        state: enabled
+        zone: libvirt
+        permanent: yes
+        immediate: yes
+      with_items:
+        - 8000
+        - 8080
+        - 8082
+        - 8090
+        - 8888
+
+    - name: Add provisioning bridge to libvirt zone
+      command: firewall-cmd --zone libvirt --change-interface ostestpr --permanent
+
+    - name: Add TCP firewall rules for provisioning bridge
+      firewalld:
+        port: "{{ item }}/tcp"
+        state: enabled
+        zone: libvirt
+        permanent: yes
+        immediate: yes
+      with_items:
+        - 80
+        - 2049 
+        - 5000 
+        - 5050
+        - 6180
+        - 6385
+        - 8000 
+        - 9999
+
+    - name: Add UDP firewall rules for provisioning bridge
+      firewalld:
+        port: "{{ item }}/udp"
+        state: enabled
+        zone: libvirt
+        permanent: yes
+        immediate: yes
+      with_items:
+        - 53
+        - 5353 
+        - 546
+        - 547
+        - 6230-6239
+        - 67 
+        - 68   
+        - 69 
+
+    # FIXME: Use firewalld rich-rules instead?
+    - name: Add direct firewall rules for BM bridge
+      shell: |
+        firewall-cmd --direct --permanent --add-rule ipv4 nat POSTROUTING 0 -o "{{ ocp_ai_ext_intf.stdout }}" -j MASQUERADE;
+        firewall-cmd --direct --permanent --add-rule ipv4 filter FORWARD 0 -i "{{ ocp_cluster_name }}bm" -o "{{ ocp_ai_ext_intf.stdout }}" -j ACCEPT;
+        firewall-cmd --direct --permanent --add-rule ipv4 filter FORWARD 0 -i "{{ ocp_ai_ext_intf.stdout }}" -o "{{ ocp_cluster_name }}bm" -m state --state RELATED,ESTABLISHED -j ACCEPT;
+        firewall-cmd --reload
+
+  
+  ### HTTP STORE
+
+  - name: Create an HTTP server container to hold ISOs/QCOW2s
+    block:
+    - name: Create HTTP server storage directory
+      file:
+        path: "{{ ocp_ai_http_store_dir | default('/opt/http_store/data', true) }}"
+        state: directory
+        mode: '0755'
+
+    - name: Stop httpd container
+      containers.podman.podman_container:
+        name: httpd
+        image: registry.centos.org/centos/httpd-24-centos7:latest
+        state: stopped
+
+    - name: Download RHEL QCOW2
+      get_url:
+        url:  "{{ osp_controller_base_image_url }}"
+        dest: "{{ ocp_ai_http_store_dir | default('/opt/http_store/data', true) }}/{{ osp_controller_base_image_url | basename }}"
+        mode: '0644'
+        setype: httpd_sys_content_t
+
+    - name: Start httpd container
+      containers.podman.podman_container:
+        name: httpd
+        image: registry.centos.org/centos/httpd-24-centos7:latest
+        state: started
+        ports:
+          - "8080:8080"
+        volumes:
+          - "{{ ocp_ai_http_store_dir | default('/opt/http_store/data', true) }}:/var/www/html:z"
+
+
+  ### DNSMASQ
+
+  - name: Prepare dnsmasq
+    block:
+    - name: Create dnsmasq conf
+      template:
+        src: "ai/dnsmasq/dnsmasq.conf.j2"
+        dest: "/etc/dnsmasq.d/dnsmasq_ai.conf"
+        mode: '0644'
+    
+    - name: Create NetworkManager dnsmasq DNS conf (to disable it)
+      template:
+        src: "ai/dnsmasq/nm_dnsmasq.conf.j2"
+        dest: "/etc/NetworkManager/conf.d/dnsmasq.conf"
+        mode: '0644'
+
+  - name: Restart NetworkManager
+    service:
+      name: NetworkManager
+      state: restarted
+      enabled: yes
+
+  - name: Stop all libvirt networks to clear DHCP socket bindings
+    shell: |
+      #!/bin/bash
+      for i in $(virsh net-list | grep -v Autostart | grep -v "---------------" | awk {'print $1'}); do
+        virsh net-destroy $i
+      done
+
+  - name: Start dnsmasq
+    service:
+      name: dnsmasq
+      state: restarted
+      enabled: yes
+
+  - name: Configure /etc/resolv.conf
+    template:
+        src: "ai/dnsmasq/resolv.conf.j2"
+        dest: "/etc/resolv.conf"
+        mode: '0644'
+
+  ### VMs
+
+  - name: Provision VMs for use with the assisted installer
+    block:
+    - name: Delete existing VMs and disk QCOW2s (if any)
+      shell: |
+        for i in $(virsh list | grep "{{ ocp_cluster_name }}-" | awk {"print $2"}); do
+          virsh destroy $i
+        done
+
+        for i in $(virsh list --all | grep "{{ ocp_cluster_name }}-" | awk {"print $2"}); do
+          virsh undefine --nvram $i
+          rm -f /var/lib/libvirt/images/$i.qcow2
+        done
+
+    # FIXME: Sushy-tools does not allow you to specify the libvirt storage pool, and assumes
+    #        that default exists, so we need to make sure that it does
+    - name: Check if default storage pool exists
+      shell: virsh pool-list | grep default 
+      register: libvirt_default_pool
+      failed_when: libvirt_default_pool.stderr != "" and "no storage pool with matching name" not in libvirt_default_pool.stderr
+
+    - name: Handle default storage pool 
+      block:
+      - name: Render libvirt default storage pool XML
+        template:
+          src: ai/libvirt/storage-pool.xml.j2
+          dest: "/tmp/storage-pool.xml"
+          mode: '0664'
+
+      - name: Remove any storage pools currently using /var/lib/libvirt/images
+        shell: |
+          for i in $(virsh pool-list --all | grep -v "Autostart" | grep -v "\-\-\-\-\-\-\-\-\-" | awk {'print $1'}); do
+            if [[ -n '$(virsh pool-dumpxml $i | grep "/var/lib/libvirt/images")' ]]; then
+              virsh pool-destroy $i
+              virsh pool-undefine $i
+            fi
+          done
+      
+      - name: Create default storage pool
+        shell: |
+          virsh pool-define /tmp/storage-pool.xml
+          virsh pool-autostart default
+          virsh pool-start default
+      when: libvirt_default_pool.stdout == ""
+
+    - name: Create AI OCP VM XML definitions
+      shell: |
+        for i in {1..{{ ocp_num_masters }}}; do
+            sudo virt-install \
+            --virt-type=kvm \
+            --name "{{ ocp_cluster_name }}-master-$((i-1))" \
+            --memory {{ ocp_master_memory }} \
+            --vcpus={{ ocp_master_vcpu }} \
+            --os-variant=rhel8.2 \
+            --os-type linux \
+            --network=bridge:{{ ocp_cluster_name }}bm,mac="{{ ocp_ai_bm_bridge_master_mac_prefix }}$((i-1))" \
+            --network=bridge:{{ ocp_cluster_name }}pr,mac="{{ ocp_ai_prov_bridge_master_mac_prefix }}$((i-1))" \
+            --disk path=/var/lib/libvirt/images/{{ ocp_cluster_name }}-master-$((i-1)).qcow2,size={{ ocp_master_disk }},bus=virtio,format=qcow2 \
+            --graphics vnc \
+            --noautoconsole --wait=-1 \
+            --boot uefi \
+            --events on_reboot=restart \
+            --print-xml > /tmp/{{ ocp_cluster_name }}-master-$((i-1)).xml
+        done
+        
+        for i in {1..{{ ocp_num_workers + ocp_num_extra_workers }}}; do
+            sudo virt-install \
+            --virt-type=kvm \
+            --name "{{ ocp_cluster_name }}-worker-$((i-1))" \
+            --memory {{ ocp_worker_memory }} \
+            --vcpus={{ ocp_worker_vcpu }} \
+            --os-variant=rhel8.2 \
+            --os-type linux \
+            --network=bridge:{{ ocp_cluster_name }}bm,mac="{{ ocp_ai_bm_bridge_worker_mac_prefix }}$((i-1))" \
+            --network=bridge:{{ ocp_cluster_name }}pr,mac="{{ ocp_ai_prov_bridge_worker_mac_prefix }}$((i-1))" \
+            --disk path=/var/lib/libvirt/images/{{ ocp_cluster_name }}-worker-$((i-1)).qcow2,size={{ ocp_worker_disk }},bus=virtio,format=qcow2 \
+            --graphics vnc \
+            --noautoconsole --wait=-1 \
+            --boot uefi \
+            --events on_reboot=restart \
+            --print-xml > /tmp/{{ ocp_cluster_name }}-worker-$((i-1)).xml
+        done
+
+    - name: Create VMs
+      shell: |
+        for i in {1..{{ ocp_num_masters }}}; do
+          sudo virsh define --file /tmp/{{ ocp_cluster_name }}-master-$((i-1)).xml
+        done
+
+        for i in {1..{{ ocp_num_workers + ocp_num_extra_workers }}}; do
+          sudo virsh define --file /tmp/{{ ocp_cluster_name }}-worker-$((i-1)).xml
+        done
+
+    - name: Get worker domain names
+      shell: "virsh list --all | grep {{ ocp_cluster_name }}-worker- | awk {'print $2'}"
+      register: worker_list
+
+    - name: Print extra worker domain UUIDs
+      shell: virsh dumpxml {{ item }} | grep uuid | cut -d '>' -f 2 | cut -d '<' -f 1
+      when: index >= {{ ocp_num_workers }}
+      loop: "{{ worker_list.stdout_lines }}"
+      loop_control:
+        index_var: index
+      register: extra_worker_uuids
+
+    - name: Create Metal3 extra baremetal hosts CRs
+      block:
+      - name: Include oc_local role
+        include_role:
+          name: oc_local
+
+      - name: Include default variables
+        include_vars: vars/default.yaml
+
+      - name: Set directory for storing AI Metal3 yaml files
+        set_fact:
+          ai_metal3_yaml_dir: "{{ working_yamls_dir }}/ai_metal3"
+
+      - name: Create local yamldir for AI Metal3 yaml files
+        file:
+          path: "{{ ai_metal3_yaml_dir }}"
+          state: directory
+          mode: '0755'
+          owner: root
+          group: root
+
+      - name: Render Metal3 extra baremetal hosts CRs
+        template:
+          src: ai/metal3/extra_workers_bmhs.yml.j2
+          dest: "{{ ai_metal3_yaml_dir }}/extra_workers_bmhs.yml"
+          mode: '0664'
+
+      delegate_to: localhost
+
+
+  ### SUSHY-TOOLS
+
+  - name: Install sushy-tools
+    block:
+    - name: Install sushy-tools via pip3
+      command: "pip3 install {{ item }}" 
+      with_items:
+        - sushy-tools 
+        - libvirt-python
+    
+    - name: Create sushy-tools conf directory
+      file:
+        path: /opt/sushy-tools
+        state: directory
+        mode: '0755'
+
+    - name: Create sushy-tools conf
+      template:
+        src: ai/sushy-tools/sushy-emulator.conf.j2
+        dest: /opt/sushy-tools/sushy-emulator.conf
+        mode: '0664'
+
+    - name: Create sushy-tools service
+      template:
+        src: ai/sushy-tools/sushy-tools.service.j2
+        dest: /etc/systemd/system/sushy-tools.service
+        mode: '0664'
+
+    - name: Reload systemd service
+      systemd:
+        daemon_reexec: yes
+
+    - name: Start sushy-tools service
+      service:
+        name: sushy-tools
+        state: restarted
+        enabled: yes
+    
+
+  ### ASSISTED INSTALLER SERVICE SCRIPT
+
+  - name: Prepare assisted installer service
+    block:
+    - name: Clone the assisted installer service repo
+      git:
+        repo: "{{ ocp_ai_service_repo | default('https://github.com/sonofspike/assisted-service-onprem.git', true) }}"
+        dest: "{{ base_path }}/assisted-service-onprem"
+        force: yes
+        version: "{{ ocp_ai_service_branch | default('a55b218e3176ed920200c1283256337db94ae4b6', true) }}"
+
+    - name: Create assisted installer service storage directory
+      file:
+        path: "{{ ocp_ai_service_store_dir | default('/opt/assisted-service', true) }}"
+        state: directory
+        mode: '0755' 
+
+    - name: Set assisted installer service storage directory
+      replace:
+        path: "{{ base_path }}/assisted-service-onprem/start-assisted-service.sh"
+        regexp: 'OAS_HOSTDIR=.*'
+        replace: 'OAS_HOSTDIR={{ ocp_ai_service_store_dir | default("/opt/assisted-service", true) }}'
+
+    # FIXME: Hard-coded to OCP 4.7 discovery ISO image for now
+    - name: Set assisted installer service discovery ISO location
+      replace:
+        path: "{{ base_path }}/assisted-service-onprem/start-assisted-service.sh"
+        regexp: 'BASE_OS_IMAGE=.*'
+        replace: 'BASE_OS_IMAGE=https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.0/rhcos-live.x86_64.iso'
+
+    - name: Set assisted installer service base URL
+      replace:
+        path: "{{ base_path }}/assisted-service-onprem/onprem-environment"
+        regexp: 'SERVICE_BASE_URL=.*'
+        replace: 'SERVICE_BASE_URL=http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_service_port | default("8090", true) }}'
+
+    - name: Start assisted installer service container
+      shell: |
+        ./stop-assisted-service.sh;
+        ./start-assisted-service.sh
+      args:
+        chdir: "{{ base_path }}/assisted-service-onprem"
+
+    - name: Wait until the assisted installer service is fully available
+      shell: |
+        aicli -U http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_service_port | default('8090', true) }} list cluster
+      register: assisted_service_ready
+      until: '"Dns Domain" in assisted_service_ready.stdout'
+      retries: 36
+      delay: 5
+      environment:
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin
+
+
+  ### ASSISTED INSTALLER EXECUTION PLAYBOOKS
+
+  - name: Download and configure assisted installer playbooks
+    become: true
+    become_user: ocp
+    block:
+    - name: Pull secret processing
+      include_tasks: pull-secret.yaml
+
+    - name: Clone the assisted installer playbooks repo
+      git:
+        repo: "{{ ocp_ai_ansible_repo | default('https://github.com/sonofspike/cluster_mgnt_roles.git', true) }}"
+        dest: "{{ base_path }}/cluster_mgnt_roles"
+        force: true
+        version: "{{ ocp_ai_ansible_branch | default('ccb34826a671f6c3435869303b6abb538638252b', true) }}"
+
+    - name: Add schedulable-master manifest
+      block:
+      - name: Create schedulable-master manifest
+        template:
+          src: ai/cluster_mgnt_roles/50-master-scheduler.yml.j2
+          dest: "{{ base_path }}/cluster_mgnt_roles/create_cluster/templates/50-master-scheduler.yml.j2"
+          mode: '0664'
+        
+      - name: Inject schedulable-master manifest
+        lineinfile:
+          path: "{{ base_path }}/cluster_mgnt_roles/create_cluster/tasks/main.yml"
+          regexp: '^\s\s\s\s-\s50-master-scheduler\.yml'
+          insertafter: '^\s\s\s\s-\s50-worker-remove-ipi-leftovers\.yml'
+          line: '    - 50-master-scheduler.yml'
+
+    - name: Add ingress controller manifest
+      block:
+      - name: Create ingress controller manifest
+        template:
+          src: ai/cluster_mgnt_roles/60-ingress-controller.yml.j2
+          dest: "{{ base_path }}/cluster_mgnt_roles/create_cluster/templates/60-ingress-controller.yml.j2"
+          mode: '0664'
+        
+      - name: Inject ingress controller manifest
+        lineinfile:
+          path: "{{ base_path }}/cluster_mgnt_roles/create_cluster/tasks/main.yml"
+          regexp: '^\s\s\s\s-\s60-ingress-controller\.yml'
+          insertafter: '^\s\s\s\s-\s50-master-scheduler\.yml'
+          line: '    - 60-ingress-controller.yml'
+
+    - name: Force serial execution of boot_iso role
+      replace:
+        after: "Mounting, Booting the Assisted Installer Discovery ISO"
+        before: "- boot_iso"
+        path: "{{ base_path }}/cluster_mgnt_roles/deploy_cluster.yml"
+        regexp: 'strategy: free'
+        replace: 'serial: 1'
+
+    - name: Configure inventory variables
+      template:
+          src: ai/cluster_mgnt_roles/inventory.ospd.j2
+          dest: "{{ base_path }}/cluster_mgnt_roles/inventory.ospd"
+          mode: '0664'
+
+
+    

--- a/ansible/ocp_dev_scripts_destroy.yaml
+++ b/ansible/ocp_dev_scripts_destroy.yaml
@@ -1,0 +1,15 @@
+---
+- hosts: convergence_base
+  become: true
+  become_user: ocp
+
+  tasks:
+  - name: Include variables
+    include_vars: vars/default.yaml
+
+  - name: Clean dev-scripts deployment
+    shell: |
+      export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+      make clean
+    args:
+      chdir: "{{ base_path }}/dev-scripts"

--- a/ansible/ocp_dev_scripts_destroy.yaml
+++ b/ansible/ocp_dev_scripts_destroy.yaml
@@ -13,3 +13,10 @@
       make clean
     args:
       chdir: "{{ base_path }}/dev-scripts"
+
+  - name: Remove ospnetwork libvirt network
+    shell: |
+      virsh net-destroy ospnetwork
+      virsh net-undefine ospnetwork
+    become: true
+    become_user: root

--- a/ansible/ocp_dev_scripts_prep.yaml
+++ b/ansible/ocp_dev_scripts_prep.yaml
@@ -2,30 +2,6 @@
 - hosts: convergence_base
   gather_facts: false
   become: true
-
-  tasks:
-    - name: create ocp group
-      group:
-        name: ocp
-        state: present
-
-    - name: Create user to run metal3 installer dev scripts
-      user:
-        name: ocp
-        comment: ocp user
-        shell: /bin/bash
-        group: ocp
-        groups: wheel
-
-    - name: make sure /home/ocp is world readable
-      file:
-        path: /home/ocp
-        state: directory
-        mode: '0755'
-
-- hosts: convergence_base
-  gather_facts: false
-  become: true
   become_user: ocp
 
   tasks:
@@ -45,49 +21,13 @@
         mode: 0755
         remote_src: yes
 
-    - name: Copy pull-secret file
-      when: secrets_repo is undefined
-      block:
-      - name: Set secrets repo path
-        set_fact:
-          secrets_repo_path: "{{ base_path }}"
-
-      - name: Copy pull-secret
-        copy:
-          dest: "{{ base_path }}/pull-secret"
-          src: files/pull-secret
-          mode: "0644"
-      rescue:
-      - name: Fail when pull-secrets is not found
-        fail:
-          msg: |
-            files/pull-secret is not present. You must obtain it from
-            https://cloud.redhat.com/openshift/install/pull-secret and copy it
-            there manually.
+    - name: Pull secret processing
+      include_tasks: pull-secret.yaml
 
     - name: Verify ci_token variable is present
       fail:
         msg: ci_token is not set in your vars or as environment variable. You must obtain it from https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/ (by clicking the upper right drop-down and selecting "Copy Login Command").
       when: (ci_token is undefined or (ci_token|string|length == 0)) and (lookup('env','CI_TOKEN')|length == 0)
-
-    - name: use secrets_repo
-      when: secrets_repo is defined
-      block:
-      - name: Set secrets_repo path
-        set_fact:
-          secrets_repo_path: "{{ base_path }}/{{ secrets_repo | urlsplit('hostname') }}/{{ (secrets_repo | urlsplit('path') | splitext)[0] }}"
-
-      - name: create base dir for secrets_repo repo
-        file:
-          path: "{{ secrets_repo_path }}"
-          state: directory
-          mode: "0755"
-
-      - name: Clone the repo specified in secrets_repo
-        git:
-          repo: "{{ secrets_repo }}"
-          dest: "{{ secrets_repo_path }}"
-          version: "{{ secrets_branch | default('HEAD', true) }}"
 
     - name: Set dev-scripts config values
       lineinfile:

--- a/ansible/ocp_installer.yaml
+++ b/ansible/ocp_installer.yaml
@@ -1,0 +1,8 @@
+---
+- name: Include and execute OCP dev-scripts Ansible logic
+  import_playbook: ocp_dev_scripts.yaml
+  when: ocp_ai | bool == False
+
+- name: Include and execute OCP assisted installer Ansible logic
+  import_playbook: ocp_ai.yaml
+  when: ocp_ai | bool

--- a/ansible/ocp_installer.yaml
+++ b/ansible/ocp_installer.yaml
@@ -1,8 +1,8 @@
 ---
 - name: Include and execute OCP dev-scripts Ansible logic
   import_playbook: ocp_dev_scripts.yaml
-  when: ocp_ai | bool == False
+  when: not (ocp_ai|bool)
 
 - name: Include and execute OCP assisted installer Ansible logic
   import_playbook: ocp_ai.yaml
-  when: ocp_ai | bool
+  when: ocp_ai|bool

--- a/ansible/ocp_installer_destroy.yaml
+++ b/ansible/ocp_installer_destroy.yaml
@@ -1,0 +1,8 @@
+---
+- name: Destroy the dev-scripts OCP cluster
+  import_playbook: ocp_dev_scripts_destroy.yaml
+  when: ocp_ai | bool == False
+
+- name: Destroy the assisted installer OCP cluster
+  import_playbook: ocp_ai_destroy.yaml
+  when: ocp_ai | bool

--- a/ansible/ocp_installer_destroy.yaml
+++ b/ansible/ocp_installer_destroy.yaml
@@ -1,8 +1,8 @@
 ---
 - name: Destroy the dev-scripts OCP cluster
   import_playbook: ocp_dev_scripts_destroy.yaml
-  when: ocp_ai | bool == False
+  when: not (ocp_ai|bool)
 
 - name: Destroy the assisted installer OCP cluster
   import_playbook: ocp_ai_destroy.yaml
-  when: ocp_ai | bool
+  when: ocp_ai|bool

--- a/ansible/ocp_installer_prep.yaml
+++ b/ansible/ocp_installer_prep.yaml
@@ -1,0 +1,11 @@
+---
+- name: Include and execute OCP user creation logic
+  import_playbook: ocp_user.yaml
+
+- name: Include and execute OCP dev-scripts preparation Ansible logic
+  import_playbook: ocp_dev_scripts_prep.yaml
+  when: ocp_ai | bool == False
+
+- name: Include and execute OCP assisted installer preparation Ansible logic
+  import_playbook: ocp_ai_prep.yaml
+  when: ocp_ai | bool

--- a/ansible/ocp_installer_prep.yaml
+++ b/ansible/ocp_installer_prep.yaml
@@ -4,8 +4,8 @@
 
 - name: Include and execute OCP dev-scripts preparation Ansible logic
   import_playbook: ocp_dev_scripts_prep.yaml
-  when: ocp_ai | bool == False
+  when: not (ocp_ai|bool)
 
 - name: Include and execute OCP assisted installer preparation Ansible logic
   import_playbook: ocp_ai_prep.yaml
-  when: ocp_ai | bool
+  when: ocp_ai|bool

--- a/ansible/ocp_user.yaml
+++ b/ansible/ocp_user.yaml
@@ -1,0 +1,24 @@
+---
+- hosts: convergence_base
+  gather_facts: false
+  become: true
+
+  tasks:
+    - name: create ocp group
+      group:
+        name: ocp
+        state: present
+
+    - name: Create user to run installer dev scripts
+      user:
+        name: ocp
+        comment: ocp user
+        shell: /bin/bash
+        group: ocp
+        groups: wheel
+
+    - name: make sure /home/ocp is world readable
+      file:
+        path: /home/ocp
+        state: directory
+        mode: '0755'

--- a/ansible/ocp_vm_setup_extra_nics.yaml
+++ b/ansible/ocp_vm_setup_extra_nics.yaml
@@ -24,7 +24,7 @@
 
   - name: check if osp network already exists
     shell: >
-      virsh net-list | grep ospnetwork
+      virsh net-list --all | grep ospnetwork
     ignore_errors: true
     register: ospnetwork_exist
 
@@ -48,10 +48,12 @@
     - name: Define ospnetwork libvirt network
       command: "virsh net-define {{ working_dir }}/osp-network/ospnetwork.xml"
 
-    - name: Start the osp network
-      shell: |
-        virsh net-start --network ospnetwork
-        virsh net-autostart --network ospnetwork
+  - name: Start the osp network
+    shell: |
+      virsh net-start --network ospnetwork
+      virsh net-autostart --network ospnetwork
+    register: ospnetwork_start
+    failed_when: ospnetwork_start.stderr != "" and "network is already active" not in ospnetwork_start.stderr
 
   - name: get active worker nodes
     shell: >
@@ -73,10 +75,23 @@
     with_items: "{{ worker_ocp_inactive.stdout_lines[0].split(' ') }}"
     ignore_errors: true
 
-  - name: Attach the osp network to ACTIVE worker VM's
-    command: "virsh attach-interface {{ item }} bridge ospnetwork --mac {{ '00:14:cd:2b:c8:0%01x' | format(item[-1]|int) }} --model virtio --persistent --live"
+  - name: HACK to fix dev-scripts bug
+    shell: |
+      virsh destroy {{ item }}
     with_items: "{{ worker_ocp_active.stdout_lines[0].split(' ') }}"
+    when: ocp_ai|bool == False
+
+  - name: Attach the osp network to ACTIVE worker VM's
+    command: "virsh attach-interface {{ item }} bridge ospnetwork --mac {{ '00:14:cd:2b:c8:0%01x' | format(item[-1]|int) }} --model virtio --persistent --config"
+    with_items: "{{ worker_ocp_active.stdout_lines[0].split(' ') }}"
+
+  - name: HACK to fix dev-scripts bug
+    shell: |
+      virsh start {{ item }}
+    with_items: "{{ worker_ocp_active.stdout_lines[0].split(' ') }}"
+    when: ocp_ai|bool == False
 
   - name: Attach the osp network to INACTIVE worker VM's
     command: "virsh attach-interface {{ item }} bridge ospnetwork --mac {{ '00:14:cd:2b:c8:0%01x' | format(item[-1]|int) }} --model virtio --persistent"
     with_items: "{{ worker_ocp_inactive.stdout_lines[0].split(' ') }}"
+    when: worker_ocp_inactive.stdout_lines != 0

--- a/ansible/ocp_vm_setup_extra_nics.yaml
+++ b/ansible/ocp_vm_setup_extra_nics.yaml
@@ -79,7 +79,7 @@
     shell: |
       virsh destroy {{ item }}
     with_items: "{{ worker_ocp_active.stdout_lines[0].split(' ') }}"
-    when: ocp_ai|bool == False
+    when: not (ocp_ai|bool)
 
   - name: Attach the osp network to ACTIVE worker VM's
     command: "virsh attach-interface {{ item }} bridge ospnetwork --mac {{ '00:14:cd:2b:c8:0%01x' | format(item[-1]|int) }} --model virtio --persistent --config"
@@ -89,7 +89,7 @@
     shell: |
       virsh start {{ item }}
     with_items: "{{ worker_ocp_active.stdout_lines[0].split(' ') }}"
-    when: ocp_ai|bool == False
+    when: not (ocp_ai|bool)
 
   - name: Attach the osp network to INACTIVE worker VM's
     command: "virsh attach-interface {{ item }} bridge ospnetwork --mac {{ '00:14:cd:2b:c8:0%01x' | format(item[-1]|int) }} --model virtio --persistent"

--- a/ansible/pull-secret.yaml
+++ b/ansible/pull-secret.yaml
@@ -1,0 +1,39 @@
+---
+- name: Copy pull-secret file
+  when: secrets_repo is undefined
+  block:
+  - name: Set secrets repo path
+    set_fact:
+      secrets_repo_path: "{{ base_path }}"
+
+  - name: Copy pull-secret
+    copy:
+      dest: "{{ base_path }}/pull-secret"
+      src: files/pull-secret
+      mode: "0644"
+  rescue:
+  - name: Fail when pull-secrets is not found
+    fail:
+      msg: |
+        files/pull-secret is not present. You must obtain it from
+        https://cloud.redhat.com/openshift/install/pull-secret and copy it
+        there manually.
+
+- name: use secrets_repo
+  when: secrets_repo is defined
+  block:
+  - name: Set secrets_repo path
+    set_fact:
+      secrets_repo_path: "{{ base_path }}/{{ secrets_repo | urlsplit('hostname') }}/{{ (secrets_repo | urlsplit('path') | splitext)[0] }}"
+
+  - name: create base dir for secrets_repo repo
+    file:
+      path: "{{ secrets_repo_path }}"
+      state: directory
+      mode: "0755"
+
+  - name: Clone the repo specified in secrets_repo
+    git:
+      repo: "{{ secrets_repo }}"
+      dest: "{{ secrets_repo_path }}"
+      version: "{{ secrets_branch | default('HEAD', true) }}"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,3 +1,9 @@
-- name: chrony
-  src: https://github.com/openstack/ansible-role-chrony.git
-  version: 1.0.1
+---
+roles:
+  - name: chrony
+    src: https://github.com/openstack/ansible-role-chrony.git
+    version: 1.0.1
+
+collections:
+  - name: containers.podman
+  - name: community.general

--- a/ansible/roles/working_yaml_dir/tasks/main.yaml
+++ b/ansible/roles/working_yaml_dir/tasks/main.yaml
@@ -4,7 +4,8 @@
     "{{ name }}_yaml_dir": "{{ working_yamls_dir }}/{{ name }}"
     __yaml_dir: "{{ working_yamls_dir }}/{{ name }}"
 
-- debug:
+- name: Debug message to print working YAMLs location
+  debug:
     msg: "yamls will be written to {{ __yaml_dir }} locally"
 
 - name: Create yaml dir

--- a/ansible/templates/ai/cluster_mgnt_roles/50-master-scheduler.yml.j2
+++ b/ansible/templates/ai/cluster_mgnt_roles/50-master-scheduler.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+spec:
+{% if ocp_ai_masters_schedulable is undefined %}
+  mastersSchedulable: true
+{% else %}
+  mastersSchedulable: {{ ocp_ai_masters_schedulable }}
+{% endif %}
+  policy:
+    name: ""

--- a/ansible/templates/ai/cluster_mgnt_roles/60-ingress-controller.yml.j2
+++ b/ansible/templates/ai/cluster_mgnt_roles/60-ingress-controller.yml.j2
@@ -1,0 +1,11 @@
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  nodePlacement:
+    nodeSelector:
+      matchLabels:
+        node-role.kubernetes.io/master: ""
+  replicas: {{ ocp_ai_ingress_replicas | default(3, true) }}

--- a/ansible/templates/ai/cluster_mgnt_roles/inventory.ospd.j2
+++ b/ansible/templates/ai/cluster_mgnt_roles/inventory.ospd.j2
@@ -1,0 +1,104 @@
+[all:vars]
+
+###############################################################################
+# Required configuration variables for Assisted Install Installations         #
+###############################################################################
+
+# Name of the cluster, i.e. openshift
+cluster_name="{{ ocp_cluster_name }}"
+
+# Base DNS domain
+base_dns_domain="{{ ocp_domain_name | default('test.metalkube.org', true) }}"
+
+# Available subnets *
+machine_network_cidr="{{ ocp_ai_bm_bridge_cidr }}"
+
+# Allocate virtual IPs via DHCP server
+vip_dhcp_allocation=False
+
+# API virtual IP
+api_vip="{{ ocp_ai_bm_cidr_prefix }}.3"
+
+# Ingress virtual IP
+ingress_vip="{{ ocp_ai_bm_cidr_prefix }}.4"
+
+# Cluster network CIDR
+cluster_network_cidr="10.128.0.0/14"
+
+# Cluster network host prefix
+cluster_network_host_prefix=23
+
+# Service network CIDR
+service_network_cidr="172.30.0.0/16"
+
+ntp_server="clock.redhat.com"
+
+#Host SSH Public Key for troubleshooting after installation
+# Use the same host discovery SSH key
+ssh_public_key="{{ lookup('file', '/root/.ssh/id_rsa.pub') }}"
+
+# Load pull-secret file
+{% if secrets_repo is undefined %}
+pull_secret={{ lookup('file', base_path + '/pull-secret') }}
+{% else %}
+pull_secret={{ lookup('file', secrets_repo_path + '/pull-secret') }}
+{% endif %}
+
+# Load cluster file, this is generated automatically
+cluster_id="{{ '{{' }} lookup('file', './cluster.txt') {{ '}}' }}"
+
+# Version of the openshift-installer, undefined or empty results in the playbook failing.
+openshift_version="{{ ocp_version }}"
+
+# Discovery ISO
+discovery_iso_name="discovery_image_{{ ocp_cluster_name }}.iso"
+# HTTP server where the ISO is stored
+discovery_iso_server="http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_http_store_port | default('8080', true) }}"
+
+# Parameters for a Restricted Network installation
+use_mirror= False
+mirror_certificate="NA"
+mirror_registry=NA:5000
+
+[services]
+assisted_installer host={{ ocp_ai_bm_ip }} port={{ ocp_ai_service_port | default('8090', true) }}
+http_store host={{ ocp_ai_bm_ip }} port={{ ocp_ai_http_store_port | default('8080', true) }}
+
+[bastions]
+bastion ansible_ssh_user=root ansible_ssh_host={{ ocp_ai_bm_ip }}
+
+# 3 masters nodes are mandatory, workers nodes are optional
+# each node must be identify with an unique name and the following paratmers
+# role, mac, ip, bmc_address, bmc_user, bmc_password are mandatory parameters
+# vendor parameter is mandatory, options include: Dell, HPE, SuperMicro, Lenovo, KVM
+# ip, mask, gateway, dns are mandatory parameters for static IP, othewise use ip=dhcp
+
+# Master nodes
+[masters]
+{% for i in range(0, ocp_num_masters) %}
+{{ ocp_cluster_name }}-master-{{ i }} bmc_address={{ ocp_ai_bm_ip }}:{{ ocp_ai_sushy_port | default('8082', true) }} mac={{ ocp_ai_bm_bridge_master_mac_prefix }}{{ i }} ip={{ ocp_ai_bm_cidr_prefix }}.1{{ i }}
+{% endfor %}
+
+[masters:vars]
+role=master
+vendor=KVM
+bmc_user=USERID
+bmc_password=PASSW0RD
+mask=24
+gateway={{ ocp_ai_bm_ip }}
+dns={{ ocp_ai_bm_ip }}
+
+# Worker nodes
+[workers]
+{% for i in range(0, ocp_num_workers) %}
+{{ ocp_cluster_name }}-worker-{{ i }} bmc_address={{ ocp_ai_bm_ip }}:{{ ocp_ai_sushy_port | default('8082', true) }} mac={{ ocp_ai_bm_bridge_worker_mac_prefix }}{{ i }} ip={{ ocp_ai_bm_cidr_prefix }}.2{{ i }}
+{% endfor %}
+
+[workers:vars]
+role=worker 
+vendor=KVM
+bmc_user=USERID
+bmc_password=PASSW0RD
+mask=24
+gateway={{ ocp_ai_bm_ip }}
+dns={{ ocp_ai_bm_ip }}

--- a/ansible/templates/ai/cluster_mgnt_roles/inventory.ospd.j2
+++ b/ansible/templates/ai/cluster_mgnt_roles/inventory.ospd.j2
@@ -67,6 +67,9 @@ http_store host={{ ocp_ai_bm_ip }} port={{ ocp_ai_http_store_port | default('808
 [bastions]
 bastion ansible_ssh_user=root ansible_ssh_host={{ ocp_ai_bm_ip }}
 
+[bastions:vars]
+ansible_connection=local
+
 # 3 masters nodes are mandatory, workers nodes are optional
 # each node must be identify with an unique name and the following paratmers
 # role, mac, ip, bmc_address, bmc_user, bmc_password are mandatory parameters

--- a/ansible/templates/ai/cluster_mgnt_roles/kubeconfig.j2
+++ b/ansible/templates/ai/cluster_mgnt_roles/kubeconfig.j2
@@ -1,0 +1,1 @@
+{{ ai_kubeconfig }}

--- a/ansible/templates/ai/cluster_mgnt_roles/run_playbook.sh.j2
+++ b/ansible/templates/ai/cluster_mgnt_roles/run_playbook.sh.j2
@@ -1,0 +1,5 @@
+#!/bin/bash
+exec 3>&1 4>&2
+trap 'exec 2>&4 1>&3' 0 1 2 3
+exec 1>{{ base_path }}/ai.log 2>&1
+ansible-playbook -i inventory.ospd deploy_cluster.yml

--- a/ansible/templates/ai/dnsmasq/dnsmasq.conf.j2
+++ b/ansible/templates/ai/dnsmasq/dnsmasq.conf.j2
@@ -1,0 +1,65 @@
+# Don't use /etc/resolv.conf
+no-resolv
+
+# Don't use /etc/hosts
+no-hosts
+
+# Recursive DNS
+server={{ ocp_ai_external_dns }}
+
+# Set local domain
+domain={{ ocp_ai_full_cluster_name }}
+
+# Disable DHCP for external interface
+no-dhcp-interface={{ ocp_ai_ext_intf.stdout }}
+# Enable DHCP for baremetal bridge
+interface={{ ocp_cluster_name }}bm
+# include cni-podman0 interface that connects to assisted-installer container for DNS requests to succeed
+interface=cni-podman0
+bind-interfaces
+
+#### DHCP (dnsmasq --help dhcp)
+dhcp-range={{ ocp_ai_bm_bridge_dhcp_range }},24h
+dhcp-option=option:netmask,255.255.255.0
+dhcp-option=option:router,{{ ocp_ai_bm_ip }}
+dhcp-option=option:dns-server,{{ ocp_ai_bm_ip }}
+dhcp-option=option:ntp-server,{{ ocp_ai_bm_ip }}
+
+
+# Provisioning node
+address=/provisioning.{{ ocp_ai_full_cluster_name }}/{{ ocp_ai_bm_ip }}
+ptr-record=1.{{ ocp_ai_bm_cidr_rev_suffix }},provisioning.{{ ocp_ai_full_cluster_name }}
+
+# Cluster ntp-server
+address=/ntp-server.{{ ocp_ai_full_cluster_name }}/{{ ocp_ai_bm_ip }}
+ptr-record=1.{{ ocp_ai_bm_cidr_rev_suffix }},ntp-server.{{ ocp_ai_full_cluster_name }}
+
+# External API endpoint (External VIP)
+address=/api.{{ ocp_ai_full_cluster_name }}/{{ ocp_ai_bm_cidr_prefix }}.3
+ptr-record=3.{{ ocp_ai_bm_cidr_rev_suffix }},api.{{ ocp_ai_full_cluster_name }}
+
+# Ingress VIP 
+address=/.apps.{{ ocp_ai_full_cluster_name }}/{{ ocp_ai_bm_cidr_prefix }}.4
+#ptr-record=4.{{ ocp_ai_bm_cidr_rev_suffix }},*apps.{{ ocp_ai_full_cluster_name }}
+
+# Internal API endpoint (Internal VIP)
+address=/api-int.{{ ocp_ai_full_cluster_name }}/{{ ocp_ai_bm_cidr_prefix }}.3
+ptr-record=3.{{ ocp_ai_bm_cidr_rev_suffix }},api-int.{{ ocp_ai_full_cluster_name }}
+
+{% for i in range(0, ocp_num_masters) %}
+# Master-{{ i }}
+dhcp-host={{ ocp_ai_bm_bridge_master_mac_prefix }}{{ i }},{{ ocp_ai_bm_cidr_prefix }}.1{{ i }},master-{{ i }}.{{ ocp_ai_full_cluster_name }}
+address=/master-{{ i }}.{{ ocp_ai_full_cluster_name }}/{{ ocp_ai_bm_cidr_prefix }}.1{{ i }}
+ptr-record=1{{ i }}.{{ ocp_ai_bm_cidr_rev_suffix }},master-{{ i }}.{{ ocp_ai_full_cluster_name }}
+{% endfor %}
+
+{% for i in range(0, ocp_num_workers + ocp_num_extra_workers) %}
+# Worker-{{ i }}
+dhcp-host={{ ocp_ai_bm_bridge_worker_mac_prefix }}{{ i }},{{ ocp_ai_bm_cidr_prefix }}.2{{ i }},worker-{{ i }}.{{ ocp_ai_full_cluster_name }}
+address=/worker-{{ i }}.{{ ocp_ai_full_cluster_name }}/{{ ocp_ai_bm_cidr_prefix }}.2{{ i }}
+ptr-record=2{{ i }}.{{ ocp_ai_bm_cidr_rev_suffix }},worker-{{ i }}.{{ ocp_ai_full_cluster_name }}
+{% endfor %}
+
+#
+# END OF FILE
+#

--- a/ansible/templates/ai/dnsmasq/nm_dnsmasq.conf.j2
+++ b/ansible/templates/ai/dnsmasq/nm_dnsmasq.conf.j2
@@ -1,0 +1,2 @@
+[main]
+dns = none

--- a/ansible/templates/ai/dnsmasq/resolv.conf.j2
+++ b/ansible/templates/ai/dnsmasq/resolv.conf.j2
@@ -1,0 +1,1 @@
+nameserver {{ ocp_ai_bm_ip }}

--- a/ansible/templates/ai/libvirt/storage-pool.xml.j2
+++ b/ansible/templates/ai/libvirt/storage-pool.xml.j2
@@ -1,0 +1,14 @@
+<pool type='dir'>
+  <name>default</name>
+  <source>
+  </source>
+  <target>
+    <path>/var/lib/libvirt/images</path>
+    <permissions>
+      <mode>0711</mode>
+      <owner>0</owner>
+      <group>0</group>
+      <label>system_u:object_r:virt_image_t:s0</label>
+    </permissions>
+  </target>
+</pool>

--- a/ansible/templates/ai/metal3/extra_workers_bmhs.yml.j2
+++ b/ansible/templates/ai/metal3/extra_workers_bmhs.yml.j2
@@ -1,0 +1,30 @@
+{% for i in range(ocp_num_workers, ocp_num_extra_workers+ocp_num_workers) %}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openshift-worker-{{ i }}-bmc-secret
+  namespace: openshift-machine-api
+type: Opaque
+data:
+  username: VVNFUklE
+  password: UEFTU1cwUkQ=
+
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: openshift-worker-{{ i }}
+  namespace: openshift-machine-api
+spec:
+  online: false
+  bootMACAddress: {{ ocp_ai_prov_bridge_worker_mac_prefix }}{{ i }}
+  bmc:
+    address: redfish+http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_sushy_port | default('8082', true) }}/redfish/v1/Systems/{{ extra_worker_uuids.results[i].stdout }}
+    credentialsName: openshift-worker-{{ i }}-bmc-secret
+  hardwareProfile: unknown
+  bootMode: legacy
+  rootDeviceHints:
+    deviceName: /dev/vda
+
+{% endfor %}

--- a/ansible/templates/ai/metal3/extra_workers_bmhs.yml.j2
+++ b/ansible/templates/ai/metal3/extra_workers_bmhs.yml.j2
@@ -25,6 +25,6 @@ spec:
   hardwareProfile: unknown
   bootMode: legacy
   rootDeviceHints:
-    deviceName: /dev/vda
+    deviceName: /dev/sda
 
 {% endfor %}

--- a/ansible/templates/ai/metal3/provisioning.yml.j2
+++ b/ansible/templates/ai/metal3/provisioning.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: metal3.io/v1alpha1
+kind: Provisioning
+metadata:
+  finalizers:
+  - provisioning.metal3.io
+  name: provisioning-configuration
+spec:
+  provisioningDHCPRange: {{ ocp_ai_pr_bridge_dhcp_range }}
+  provisioningIP: {{ ((ocp_ai_pr_bridge_cidr.split('.'))[0:3])|join('.') }}.3
+  provisioningInterface: enp2s0
+  provisioningNetwork: Managed
+  provisioningNetworkCIDR: {{ ocp_ai_pr_bridge_cidr }}
+  

--- a/ansible/templates/ai/sushy-tools/sushy-emulator.conf.j2
+++ b/ansible/templates/ai/sushy-tools/sushy-emulator.conf.j2
@@ -1,0 +1,151 @@
+#/etc/sushy-emulator.conf
+# sushy emulator configuration file build on top of Flask application
+# configuration infrastructure: http://flask.pocoo.org/docs/config/
+
+# Listen on all local IP interfaces
+SUSHY_EMULATOR_LISTEN_IP = u'0.0.0.0'
+
+# Bind to TCP port 8080
+SUSHY_EMULATOR_LISTEN_PORT = {{ ocp_ai_sushy_port | default('8082', true) }}
+
+# Serve this SSL certificate to the clients
+SUSHY_EMULATOR_SSL_CERT = None
+
+# If SSL certificate is being served, this is its RSA private key
+SUSHY_EMULATOR_SSL_KEY = None
+
+# The OpenStack cloud ID to use. This option enables OpenStack driver.
+SUSHY_EMULATOR_OS_CLOUD = None
+
+# The libvirt URI to use. This option enables libvirt driver.
+SUSHY_EMULATOR_LIBVIRT_URI = u'qemu:///system'
+
+# The map of firmware loaders dependant on the boot mode and
+# system architecture
+SUSHY_EMULATOR_BOOT_LOADER_MAP = {
+    u'UEFI': {
+        u'x86_64': u'/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd',
+        u'aarch64': u'/usr/share/AAVMF/AAVMF_CODE.fd'
+    },
+    u'Legacy': {
+        u'x86_64': None,
+        u'aarch64': None
+    }
+}
+
+# This map contains statically configured Redfish Chassis linked
+# up with the Systems and Managers enclosed into this Chassis.
+#
+# The first chassis in the list will contain all other resources.
+#
+# If this map is not present in the configuration, a single default
+# Chassis is configured automatically to enclose all available Systems
+# and Managers.
+SUSHY_EMULATOR_CHASSIS = [
+    {
+        u'Id': u'Chassis',
+        u'Name': u'Chassis',
+        u'UUID': u'48295861-2522-3561-6729-621118518810'
+    }
+]
+
+# This map contains statically configured Redfish IndicatorLED
+# resource state ('Lit', 'Off', 'Blinking') keyed by UUIDs of
+# System and Chassis resources.
+#
+# If this map is not present in the configuration, each
+# System and Chassis will have their IndicatorLED `Lit` by default.
+#
+# Redfish client can change IndicatorLED state. The new state
+# is volatile, i.e. it's maintained in process memory.
+SUSHY_EMULATOR_INDICATOR_LEDS = {
+#    u'48295861-2522-3561-6729-621118518810': u'Blinking'
+}
+
+# This map contains statically configured virtual media resources.
+# These devices ('Cd', 'Floppy', 'USBStick') will be exposed by the
+# Manager(s) and possibly used by the System(s) if system emulation
+# backend supports boot image configuration.
+#
+# If this map is not present in the configuration, the following configuration
+# is used:
+SUSHY_EMULATOR_VMEDIA_DEVICES = {
+    u'Cd': {
+        u'Name': 'Virtual CD',
+        u'MediaTypes': [
+            u'CD',
+            u'DVD'
+        ]
+    }
+}
+
+# This map contains statically configured Redfish Storage resource linked
+# up with the Systems resource, keyed by the UUIDs of the Systems.
+SUSHY_EMULATOR_STORAGE = {
+    "da69abcc-dae0-4913-9a7b-d344043097c0": [
+        {
+            "Id": "1",
+            "Name": "Local Storage Controller",
+            "StorageControllers": [
+                {
+                    "MemberId": "0",
+                    "Name": "Contoso Integrated RAID",
+                    "SpeedGbps": 12
+                }
+            ],
+            "Drives": [
+                "32ADF365C6C1B7BD"
+            ]
+        }
+    ]
+}
+
+# This map contains statically configured Redfish Drives resource. The Drive
+# objects are keyed in a composite fashion using a tuple of the form
+# (System_UUID, Storage_ID) referring to the UUID of the System and Id of the
+# Storage resource, respectively, to which the drive belongs.
+SUSHY_EMULATOR_DRIVES = {
+    ("da69abcc-dae0-4913-9a7b-d344043097c0", "1"): [
+        {
+            "Id": "32ADF365C6C1B7BD",
+            "Name": "Drive Sample",
+            "CapacityBytes": 899527000000,
+            "Protocol": "SAS"
+        }
+    ]
+}
+
+# This map contains dynamically configured Redfish Volume resource backed
+# by the libvirt virtualization backend of the dynamic Redfish emulator.
+# The Volume objects are keyed in a composite fashion using a tuple of the
+# form (System_UUID, Storage_ID) referring to the UUID of the System and ID
+# of the Storage resource, respectively, to which the Volume belongs.
+#
+# Only the volumes specified in the map or created via a POST request are
+# allowed to be emulated upon by the emulator. Volumes other than these can
+# neither be listed nor deleted.
+#
+# The Volumes from map missing in the libvirt backend will be created
+# dynamically in the pool name specified (provided the pool exists in the
+# backend). If the pool name is not specified, the volume will be created
+# automatically in pool named 'default'.
+SUSHY_EMULATOR_VOLUMES = {
+    ('da69abcc-dae0-4913-9a7b-d344043097c0', '1'): [
+        {
+            "libvirtPoolName": "sushyPool",
+            "libvirtVolName": "testVol",
+            "Id": "1",
+            "Name": "Sample Volume 1",
+            "VolumeType": "Mirrored",
+            "CapacityBytes": 23748
+        },
+        {
+            "libvirtPoolName": "sushyPool",
+            "libvirtVolName": "testVol1",
+            "Id": "2",
+            "Name": "Sample Volume 2",
+            "VolumeType": "StripedWithParity",
+            "CapacityBytes": 48395
+        }
+    ]
+}

--- a/ansible/templates/ai/sushy-tools/sushy-tools.service.j2
+++ b/ansible/templates/ai/sushy-tools/sushy-tools.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Sushy Tools (Redfish Emulator for Libvirt)
+After=network.target syslog.target
+
+[Service]
+Type=simple
+TimeoutStartSec=5m
+#User=<your-user>
+WorkingDirectory=/opt/sushy-tools
+ExecStart=/usr/local/bin/sushy-emulator --config /opt/sushy-tools/sushy-emulator.conf
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
+++ b/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
@@ -11,7 +11,11 @@ spec:
   # How many nodes to provision
   replicas: {{ osp_compute_count }}
   # The image to install on the provisioned nodes
+{% if ocp_ai|bool == False %}
   baseImageUrl: http://172.22.0.1/images/{{ osp_controller_base_image_url | basename }}
+{% else %}
+  baseImageUrl: http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_http_store_port | default('8080', true) }}/{{ osp_controller_base_image_url | basename }}
+{% endif %}
   provisionServerName: openstack
   # The secret containing the SSH pub key to place on the provisioned nodes
   deploymentSSHSecret: osp-controlplane-ssh-keys

--- a/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
+++ b/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
@@ -11,7 +11,7 @@ spec:
   # How many nodes to provision
   replicas: {{ osp_compute_count }}
   # The image to install on the provisioned nodes
-{% if ocp_ai|bool == False %}
+{% if not (ocp_ai|bool) %}
   baseImageUrl: http://172.22.0.1/images/{{ osp_controller_base_image_url | basename }}
 {% else %}
   baseImageUrl: http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_http_store_port | default('8080', true) }}/{{ osp_controller_base_image_url | basename }}

--- a/ansible/templates/osp/compute/openstackprovisionserver.yaml.j2
+++ b/ansible/templates/osp/compute/openstackprovisionserver.yaml.j2
@@ -5,4 +5,8 @@ metadata:
   namespace: openstack
 spec:
   port: 8080
+{% if ocp_ai|bool == False %}
   baseImageUrl: http://172.22.0.1/images/{{ osp_controller_base_image_url | basename }}
+{% else %}
+  baseImageUrl: http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_http_store_port | default('8080', true) }}/{{ osp_controller_base_image_url | basename }}
+{% endif %}

--- a/ansible/templates/osp/compute/openstackprovisionserver.yaml.j2
+++ b/ansible/templates/osp/compute/openstackprovisionserver.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: openstack
 spec:
   port: 8080
-{% if ocp_ai|bool == False %}
+{% if not (ocp_ai|bool) %}
   baseImageUrl: http://172.22.0.1/images/{{ osp_controller_base_image_url | basename }}
 {% else %}
   baseImageUrl: http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_http_store_port | default('8080', true) }}/{{ osp_controller_base_image_url | basename }}

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -8,6 +8,15 @@ ocp_version: 4.7
 ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.7.4-x86_64
 ocp_release_type: ga
 
+# If set to true:
+# - Assisted installer is used to install OCP instead of dev-scripts
+# - Thus, dev-scripts related variables are ignored, and ...
+# - ocp_release_image and ocp_release_type are ignored, and ocp_version must be 4.7 (for now)
+# - Other OCP AI variables are stored in vars/ocp_ai.yaml to reduce clutter in this file
+# NOTE: This variable should be set to true in local-defaults.yaml as opposed to changing it here,
+#       otherwise our playbooks seem to be flaky with executing the AI logic
+#ocp_ai: false 
+
 # private repo to read required secret files from
 # The playbooks expect secret files which can be placed in a private repo
 # Right now these are:
@@ -38,6 +47,7 @@ ocp_worker_disk: 50
 
 # OCP cluster name
 ocp_cluster_name: ostest
+#ocp_domain_name: defaults to test.metalkube.org
 
 # Released version of the opm package (can be set to 'latest')
 opm_version: v1.12.5

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -1,0 +1,27 @@
+---
+ocp_ai_external_dns: 10.11.5.19
+
+# ocp_ai_service_repo: defaults to "https://github.com/sonofspike/assisted-service-onprem.git"
+# ocp_ai_service_branch: defaults to "a55b218e3176ed920200c1283256337db94ae4b6"
+# ocp_ai_ansible_repo: defaults to "https://github.com/sonofspike/cluster_mgnt_roles.git"
+# ocp_ai_ansible_branch: defaults to "ccb34826a671f6c3435869303b6abb538638252b"
+
+ocp_ai_bm_bridge_master_mac_prefix: 3c:fd:fe:78:ab:0
+ocp_ai_bm_bridge_worker_mac_prefix: 3c:fd:fe:78:ab:1
+ocp_ai_prov_bridge_master_mac_prefix: 3c:fd:fe:78:cd:0
+ocp_ai_prov_bridge_worker_mac_prefix: 3c:fd:fe:78:cd:1
+
+ocp_ai_bm_bridge_cidr: 192.168.111.0/24 # NOTE: Must currently end in /24
+ocp_ai_bm_bridge_dhcp_range: 192.168.111.6,192.168.111.100 # NOTE: Must leave .2, .3 and .4 outside the range
+ocp_ai_pr_bridge_cidr: 172.22.0.0/24 # NOTE: Must currently end in /24
+ocp_ai_pr_bridge_dhcp_range: 172.22.0.10,172.22.0.254
+ocp_ai_bm_ip: "{{ (ocp_ai_bm_bridge_cidr.split('.')[0:3]|join('.')) }}.1"
+ocp_ai_pr_ip: "{{ (ocp_ai_pr_bridge_cidr.split('.')[0:3]|join('.')) }}.1"
+
+# ocp_ai_sushy_port: defaults to "8082"
+
+# ocp_ai_service_store_dir: defaults to "/opt/assisted-service"
+# ocp_ai_service_port: defaults to "8090"
+
+# ocp_ai_http_store_dir: defaults to "/opt/http_store/data"
+# ocp_ai_http_store_port: defaults to "8080"


### PR DESCRIPTION
Behemoth patch that enables our dev-tools to deploy an OCP cluster via the new-ish assisted installer.  Current restrictions on usage:

1. Provisioning host must be RHEL 8.3
2. Only version 4.7 of OCP is supported
3. Netmasks for CIDRs must be `/24`
4. IPV6 not supported

Basic usage: just set `ocp_ai: true` in your `local-defaults.yaml`