### PR TITLE
Use retries in wait tasks

### DIFF
--- a/ansible/ocp_ai_post_install.yaml
+++ b/ansible/ocp_ai_post_install.yaml
@@ -82,8 +82,10 @@
 
     - name: Wait for Metal3 pods to restart
       shell: |
-        oc wait pod --for condition=ready -n openshift-machine-api -l k8s-app=metal3 --timeout={{ default_timeout*2 }}s
+        oc wait pod --for condition=ready -n openshift-machine-api -l k8s-app=metal3 --timeout={{ default_timeout }}s
       environment:
         <<: *oc_env
+      retries: 5
+      delay: 5
 
     when: ocp_ai|bool

--- a/ansible/olm.yaml
+++ b/ansible/olm.yaml
@@ -70,3 +70,5 @@
       oc wait pod -l control-plane=controller-manager --for condition=ready -n "{{ namespace }}" --timeout={{ default_timeout }}s
     environment:
       <<: *oc_env
+    retries: 5
+    delay: 5


### PR DESCRIPTION
Sometimes wait condition fail like:

Error from server: etcdserver: request timed out

Lets use retries to rerun the wait.