### PR TITLE
support multiple external dns server

### DIFF
--- a/ansible/datavolume.yaml
+++ b/ansible/datavolume.yaml
@@ -33,6 +33,7 @@
       owner: ocp
       group: ocp
       mode: '0644'
+      timeout: 30
 
   - name: does the datavolume already exist
     ignore_errors: true

--- a/ansible/download_tools.yaml
+++ b/ansible/download_tools.yaml
@@ -26,12 +26,14 @@
       url: https://github.com/operator-framework/operator-registry/releases/{{ opm_url_suffix }}/linux-amd64-opm
       dest: "{{ lookup('env', 'HOME') }}/bin/opm"
       mode: '0755'
+      timeout: 30
 
   - name: Download operator-sdk
     get_url:
       url: https://github.com/operator-framework/operator-sdk/releases/download/{{ sdk_version }}/operator-sdk_linux_amd64
       dest: "{{ lookup('env', 'HOME') }}/bin/operator-sdk"
       mode: '0755'
+      timeout: 30
 
   - name: Download and extract kustomize
     unarchive:
@@ -44,6 +46,7 @@
       url: https://github.com/kudobuilder/kuttl/releases/download/v{{ kuttl_version }}/kubectl-kuttl_{{ kuttl_version }}_linux_x86_64
       dest: "{{ lookup('env', 'HOME') }}/bin/kubectl-kuttl"
       mode: '0755'
+      timeout: 30
 
   - name: Install packages
     package:

--- a/ansible/ocp_ai.yaml
+++ b/ansible/ocp_ai.yaml
@@ -87,6 +87,7 @@
       url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-{{ ocp_version }}/openshift-client-linux.tar.gz"
       dest: "/tmp/openshift-client-linux.tar.gz"
       mode: '0755'
+      timeout: 30
 
   - name: "Untar the openshift-client-linux.tar.gz"
     unarchive:

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -209,6 +209,7 @@
         dest: "{{ ocp_ai_http_store_dir | default('/opt/http_store/data', true) }}/{{ osp_controller_base_image_url | basename }}"
         mode: '0644'
         setype: httpd_sys_content_t
+        timeout: 30
 
     - name: Start httpd container
       containers.podman.podman_container:

--- a/ansible/templates/ai/dnsmasq/dnsmasq.conf.j2
+++ b/ansible/templates/ai/dnsmasq/dnsmasq.conf.j2
@@ -5,7 +5,9 @@ no-resolv
 no-hosts
 
 # Recursive DNS
-server={{ ocp_ai_external_dns }}
+{% for dns_server in ocp_ai_external_dns %}
+server={{ dns_server }}
+{% endfor %}
 
 # Set local domain
 domain={{ ocp_ai_full_cluster_name }}

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -1,5 +1,9 @@
 ---
-ocp_ai_external_dns: 10.11.5.19
+ocp_ai_external_dns:
+  - 10.11.5.19
+  - 10.38.5.26
+  - 10.10.160.2
+  - 10.5.30.160
 
 # ocp_ai_service_repo: defaults to "https://github.com/sonofspike/assisted-service-onprem.git"
 # ocp_ai_service_branch: defaults to "a55b218e3176ed920200c1283256337db94ae4b6"


### PR DESCRIPTION
Also increase the get_url timeout since it can take longer than
10s for the dns resolution to switch to the next server when the
targeted one is down.