### PR TITLE
Use biosdev nic names for osvmset and osbmset 

### DIFF
--- a/ansible/datavolume.yaml
+++ b/ansible/datavolume.yaml
@@ -27,13 +27,20 @@
 
   - name: Get RHEL guest base image
     when: not stat_result.stat.exists
-    get_url:
-      url: "{{ osp_controller_base_image_url }}"
-      dest: "{{ osp_controller_base_image_url_path }}"
-      owner: ocp
-      group: ocp
-      mode: '0644'
-      timeout: 30
+    block:
+    - name: Download RHEL guest image {{ osp_controller_base_image_url }}
+      get_url:
+        url: "{{ osp_controller_base_image_url }}"
+        dest: "{{ osp_controller_base_image_url_path }}"
+        owner: ocp
+        group: ocp
+        mode: '0644'
+        timeout: 30
+    - name: Remove net.ifnames=0 kernel param from {{ osp_controller_base_image_url_path }}
+      shell: |
+        #!/bin/bash
+        set -e
+        virt-customize -a "{{ osp_controller_base_image_url_path }}" --run-command 'sed -i -e "s/^\(kernelopts=.*\)net.ifnames=0 \(.*\)/\1\2/" /boot/grub2/grubenv'
 
   - name: does the datavolume already exist
     ignore_errors: true

--- a/ansible/host_prep.yaml
+++ b/ansible/host_prep.yaml
@@ -142,6 +142,9 @@
           - qemu-kvm
           - virt-install
 
+          # required to customize the guest-image to remove net.ifnames=0 kernel param
+          - libguestfs-tools-c
+
     - name: Enable helpful services
       service: name={{ item }} enabled=yes state=started
       with_items:

--- a/ansible/libvirt_cleanup.yaml
+++ b/ansible/libvirt_cleanup.yaml
@@ -10,3 +10,4 @@
     shell: |
       virsh net-destroy ospnetwork
       virsh net-undefine ospnetwork
+    ignore_errors: true

--- a/ansible/ocp_ai_destroy.yaml
+++ b/ansible/ocp_ai_destroy.yaml
@@ -106,3 +106,14 @@
       with_items:
         - bm
         - pr
+
+  ### remove osp_controller_base_image
+
+  - name: Set path to RHEL base image for assisted installer
+    set_fact:
+      osp_controller_base_image_url_path: "{{ ocp_ai_http_store_dir | default('/opt/http_store/data', true) }}/{{ osp_controller_base_image_url | basename }}"
+
+  - name: Delete {{ osp_controller_base_image_url_path }}
+    file:
+      path: "{{ osp_controller_base_image_url_path }}"
+      state: absent

--- a/ansible/ocp_dev_scripts_destroy.yaml
+++ b/ansible/ocp_dev_scripts_destroy.yaml
@@ -13,3 +13,14 @@
       make clean
     args:
       chdir: "{{ base_path }}/dev-scripts"
+
+  ### remove osp_controller_base_image
+
+  - name: Set path to RHEL base image for dev-scripts
+    set_fact:
+      osp_controller_base_image_url_path: "{{ base_path }}/ironic/html/images/{{ osp_controller_base_image_url | basename }}"
+
+  - name: Delete {{ osp_controller_base_image_url_path }}
+    file:
+      path: "{{ osp_controller_base_image_url_path }}"
+      state: absent

--- a/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
+++ b/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
@@ -20,7 +20,7 @@ spec:
   # The secret containing the SSH pub key to place on the provisioned nodes
   deploymentSSHSecret: osp-controlplane-ssh-keys
   # The interface on the nodes that will be assigned an IP from the mgmtCidr
-  ctlplaneInterface: eth2
+  ctlplaneInterface: enp8s0
   # Networks to associate with this host
   networks:
     - ctlplane


### PR DESCRIPTION
To prevent nic re-ordering nic biosdev names should be used for
overcloud nodes.

Depends-On: https://github.com/openstack-k8s-operators/osp-director-operator/pull/217