### PR TITLE
Align OSP intf names for IPI and AI

### DIFF
--- a/ansible/install_networks.yaml
+++ b/ansible/install_networks.yaml
@@ -23,11 +23,6 @@
       state: directory
       mode: '0755'
 
-  - name: Override osp_interface for assisted installer deployments
-    set_fact:
-      osp_interface: enp8s0
-    when: ocp_ai|bool
-
   - name: Render templates to yaml dir
     template:
       src: "osp/networks/{{ item }}.j2"

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -359,6 +359,22 @@
           virsh define --file /tmp/{{ ocp_cluster_name }}-worker-$((i-1)).xml
         done
 
+    - name: Create rng device XML file
+      template:
+          src: ai/libvirt/rng_device.xml.j2
+          dest: "/tmp/{{ ocp_cluster_name }}_rng_device.xml"
+          mode: '0664'
+
+    - name: Remove random number generator devices from master VM XMLs
+      shell: |
+        virsh detach-device {{ ocp_cluster_name }}-master-{{ item }} /tmp/{{ ocp_cluster_name }}_rng_device.xml --config
+      with_sequence: start=0 end={{ ocp_num_masters-1 }}
+
+    - name: Remove random number generator devices from worker VM XMLs
+      shell: |
+        virsh detach-device {{ ocp_cluster_name }}-worker-{{ item }} /tmp/{{ ocp_cluster_name }}_rng_device.xml --config
+      with_sequence: start=0 end={{ ocp_num_workers+ocp_num_extra_workers-1 }}
+
     - name: Get worker domain names
       shell: "virsh list --all | grep {{ ocp_cluster_name }}-worker- | awk {'print $2'}"
       register: worker_list

--- a/ansible/templates/ai/libvirt/rng_device.xml.j2
+++ b/ansible/templates/ai/libvirt/rng_device.xml.j2
@@ -1,0 +1,3 @@
+<rng model='virtio'>
+  <backend model='random'>/dev/urandom</backend>
+</rng>

--- a/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
+++ b/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
@@ -20,7 +20,7 @@ spec:
   # The secret containing the SSH pub key to place on the provisioned nodes
   deploymentSSHSecret: osp-controlplane-ssh-keys
   # The interface on the nodes that will be assigned an IP from the mgmtCidr
-  ctlplaneInterface: enp8s0
+  ctlplaneInterface: {{ osp_interface }}
   # Networks to associate with this host
   networks:
     - ctlplane

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -120,7 +120,7 @@ osp_controller_disk_size: 40
 osp_controller_base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/8.4/825/images/rhel-guest-image-8.4-825.x86_64.qcow2
 osp_controller_storage_class: host-nfs-storageclass
 # Interface connected to osp network, will be configured as linux-bridge using nmstate
-osp_interface: enp6s0
+osp_interface: enp7s0
 osp_container_tag: 16.2_20210420.1
 osp_ceph_image: ceph-4.2-rhel-8
 


### PR DESCRIPTION
Changes AI VMs so that they have `enp7s0` for the OSP network interface, just like dev-scripts VMs now do