### PR TITLE
Move httpd port to 8081

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -125,7 +125,7 @@
       when: ocp_ai_ext_intf.stdout == ""
 
     - name: Add BM bridge to libvirt zone
-      command: firewall-cmd --zone libvirt --change-interface ostestbm --permanent
+      command: "firewall-cmd --zone libvirt --change-interface {{ ocp_cluster_name }}bm --permanent"
 
     - name: Add TCP firewall rules for BM bridge
       firewalld:
@@ -136,13 +136,13 @@
         immediate: yes
       with_items:
         - 8000
-        - 8080
-        - 8082
-        - 8090
+        - "{{ ocp_ai_http_store_port | default(8081, true) }}"
+        - "{{ ocp_ai_sushy_port | default(8082, true) }}"
+        - "{{ ocp_ai_service_port | default(8090, true) }}"
         - 8888
 
     - name: Add provisioning bridge to libvirt zone
-      command: firewall-cmd --zone libvirt --change-interface ostestpr --permanent
+      command: "firewall-cmd --zone libvirt --change-interface {{ ocp_cluster_name }}pr --permanent"
 
     - name: Add TCP firewall rules for provisioning bridge
       firewalld:
@@ -217,7 +217,7 @@
         image: registry.centos.org/centos/httpd-24-centos7:latest
         state: started
         ports:
-          - "8080:8080"
+          - "{{ ocp_ai_http_store_port | default(8081, true) }}:8080"
         volumes:
           - "{{ ocp_ai_http_store_dir | default('/opt/http_store/data', true) }}:/var/www/html:z"
 

--- a/ansible/templates/ai/cluster_mgnt_roles/inventory.ospd.j2
+++ b/ansible/templates/ai/cluster_mgnt_roles/inventory.ospd.j2
@@ -53,7 +53,7 @@ openshift_version="{{ ocp_version }}"
 # Discovery ISO
 discovery_iso_name="discovery_image_{{ ocp_cluster_name }}.iso"
 # HTTP server where the ISO is stored
-discovery_iso_server="http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_http_store_port | default('8080', true) }}"
+discovery_iso_server="http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_http_store_port | default('8081', true) }}"
 
 # Parameters for a Restricted Network installation
 use_mirror= False
@@ -62,7 +62,7 @@ mirror_registry=NA:5000
 
 [services]
 assisted_installer host={{ ocp_ai_bm_ip }} port={{ ocp_ai_service_port | default('8090', true) }}
-http_store host={{ ocp_ai_bm_ip }} port={{ ocp_ai_http_store_port | default('8080', true) }}
+http_store host={{ ocp_ai_bm_ip }} port={{ ocp_ai_http_store_port | default('8081', true) }}
 
 [bastions]
 bastion ansible_ssh_user=root ansible_ssh_host={{ ocp_ai_bm_ip }}

--- a/ansible/templates/ai/sushy-tools/sushy-emulator.conf.j2
+++ b/ansible/templates/ai/sushy-tools/sushy-emulator.conf.j2
@@ -5,7 +5,7 @@
 # Listen on all local IP interfaces
 SUSHY_EMULATOR_LISTEN_IP = u'0.0.0.0'
 
-# Bind to TCP port 8080
+# Bind to TCP port {{ ocp_ai_sushy_port | default('8082', true) }}
 SUSHY_EMULATOR_LISTEN_PORT = {{ ocp_ai_sushy_port | default('8082', true) }}
 
 # Serve this SSL certificate to the clients

--- a/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
+++ b/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
@@ -14,7 +14,7 @@ spec:
 {% if not (ocp_ai|bool) %}
   baseImageUrl: http://172.22.0.1/images/{{ osp_controller_base_image_url | basename }}
 {% else %}
-  baseImageUrl: http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_http_store_port | default('8080', true) }}/{{ osp_controller_base_image_url | basename }}
+  baseImageUrl: http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_http_store_port | default('8081', true) }}/{{ osp_controller_base_image_url | basename }}
 {% endif %}
   provisionServerName: openstack
   # The secret containing the SSH pub key to place on the provisioned nodes

--- a/ansible/templates/osp/compute/openstackprovisionserver.yaml.j2
+++ b/ansible/templates/osp/compute/openstackprovisionserver.yaml.j2
@@ -8,5 +8,5 @@ spec:
 {% if not (ocp_ai|bool) %}
   baseImageUrl: http://172.22.0.1/images/{{ osp_controller_base_image_url | basename }}
 {% else %}
-  baseImageUrl: http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_http_store_port | default('8080', true) }}/{{ osp_controller_base_image_url | basename }}
+  baseImageUrl: http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_http_store_port | default('8081', true) }}/{{ osp_controller_base_image_url | basename }}
 {% endif %}

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -30,4 +30,4 @@ ocp_ai_pr_ip: "{{ (ocp_ai_pr_bridge_cidr.split('.')[0:3]|join('.')) }}.1"
 # ocp_ai_service_port: defaults to "8090"
 
 # ocp_ai_http_store_dir: defaults to "/opt/http_store/data"
-# ocp_ai_http_store_port: defaults to "8080"
+# ocp_ai_http_store_port: defaults to "8081"


### PR DESCRIPTION
Moves default `httpd` port for AI to 8081 instead of 8080 to avoid conflicts when running operator locally