### PR TITLE
Fix CNV install

### DIFF
--- a/ansible/ocp_cnv.yaml
+++ b/ansible/ocp_cnv.yaml
@@ -12,6 +12,11 @@
   - debug:
       msg: "yamls will be written to {{ yaml_dir }} locally"
 
+  - name: Clean yaml dir
+    file:
+      state: absent
+      path: "{{ yaml_dir }}"
+
   - name: Create local yamldir
     file:
       path: "{{ yaml_dir }}"
@@ -28,14 +33,6 @@
     - operatorgroup.yaml
     - subscription.yaml
     - deploy_operator.yaml
-
-  - name: Create namespace, operatorgroup, subscription and machine config pool
-    shell: |
-      set -e
-      oc apply -f "{{ yaml_dir }}"
-    environment:
-      PATH: "{{ oc_env_path }}"
-      KUBECONFIG: "{{ kubeconfig }}"
 
   - name: Create namespace, operatorgroup and subscription
     shell: |


### PR DESCRIPTION
It turns out that the CNV-install error we've been hitting was due to two things:

1. We did not clean the YAML working dir for CNV files.  So during a redeploy, `deploy_operator.yaml` would still be there, and...
2. We were applying the entire CNV working dir, causing us to try to deploy a `HyperConverged` CR before the CRD existed

Now we clean the working dir and only atomically apply the individual files, avoiding the problem