### PR TITLE
Use ansible module and proper pip-3 path

### DIFF
--- a/ansible/local_oc_client.yaml
+++ b/ansible/local_oc_client.yaml
@@ -13,13 +13,19 @@
     become: yes
 
   - name: Upgrade pip
-    shell: |
-      pip3 install --upgrade pip
+    pip:
+      name: pip>=21.1
+      executable: /usr/bin/pip-3
     become: yes
 
-  - name: Install openstack client
-    shell: |
-      pip3 install --user python-openstackclient osc-placement
+  - name: Upgrade pip
+    pip:
+      name:
+        - python-openstackclient
+        - osc-placement
+      extra_args: "--user"
+      executable: /usr/bin/pip-3
+    become: yes
 
   - name: Create environment file
     template:

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -14,9 +14,15 @@
   ### ASSISTED INSTALLER CLI BINARY
 
   - name: Install assisted installer CLI
-    shell: |
-      pip3 install aicli
-      pip3 install --user aicli
+    pip:
+      name: aicli
+      executable: /usr/bin/pip-3
+
+  - name: Install assisted installer CLI - user directory
+    pip:
+      name: aicli
+      extra_args: "--user"
+      executable: /usr/bin/pip-3
 
   ### ADDITIONAL SET-FACTS
 


### PR DESCRIPTION
On RHEL pip3 is located in the /usr/local/bin directory which
is not in the standard $PATH for the CI invoked jobs.
Using full path to the pip-3 CLI together with pip ansible module
should allow to pass on most systems.