### PR TITLE
Fix AI install service

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -409,10 +409,9 @@
   - name: Install sushy-tools
     block:
     - name: Install sushy-tools via pip3
-      command: "pip3 install {{ item }}"
-      with_items:
-        - sushy-tools
-        - libvirt-python
+      pip:
+        name: ['sushy-tools', 'libvirt-python']
+        executable: /usr/bin/pip-3
 
     - name: Create sushy-tools conf directory
       file:
@@ -481,8 +480,11 @@
     - name: Set assisted installer service OCP release image
       replace:
         path: "{{ base_path }}/assisted-service-onprem/onprem-environment"
-        regexp: '"display_name":"4.7.2","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.2-x86_64"'
-        replace: '"display_name":"4.7","release_image":"{{ ocp_release_image }}"'
+        # regexp: '"display_name":"4.7.2","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.2-x86_64"'
+        # replace: '"display_name":"4.7","release_image":"{{ ocp_release_image }}"'
+        regexp: 'OPENSHIFT_VERSIONS=.*'
+        replace: 'OPENSHIFT_VERSIONS={"4.6":{"display_name":"4.6.16","release_version":"4.6.16","release_image":"quay.io/openshift-release-dev/ocp-release:4.6.16-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso","rhcos_rootfs":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img","rhcos_version":"46.82.202012051820-0","support_level":"production"},"4.7":{"display_name":"4.7.9","release_version":"4.7.9","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.9-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso","rhcos_rootfs":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img","rhcos_version":"47.83.202103251640-0","support_level":"production","default":true}}'
+        # We can add this later into the JSON above when we support 4.8: ',"4.8":{"display_name":"4.8.0-fc.3","release_version":"4.8.0-fc.3","release_image":"quay.io/openshift-release-dev/ocp-release:4.8.0-fc.3-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.8.0-fc.3/rhcos-4.8.0-fc.3-x86_64-live.x86_64.iso","rhcos_rootfs":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.8.0-fc.3/rhcos-live-rootfs.x86_64.img","rhcos_version":"48.84.202105062123-0","support_level":"beta"}'
 
     - name: Start assisted installer service container
       shell: |
@@ -496,7 +498,7 @@
         aicli -U http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_service_port | default('8090', true) }} list cluster
       register: assisted_service_ready
       until: '"Dns Domain" in assisted_service_ready.stdout'
-      retries: 48
+      retries: 60
       delay: 5
       environment:
         PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -13,7 +13,7 @@ ocp_release_type: ga
 # - Thus, dev-scripts related variables are ignored, and ...
 # - ocp_release_type is ignored
 # - ocp_version must be 4.7 (for now)
-# - ocp_release_image should point to a 4.7.X image
+# - ocp_release_image is ignored (for now)
 # - Other OCP AI variables are stored in vars/ocp_ai.yaml to reduce clutter in this file
 # NOTE: This variable should be set to true in local-defaults.yaml as opposed to changing it here,
 #       otherwise our playbooks seem to be flaky with executing the AI logic


### PR DESCRIPTION
Basic fix to get AI working again.  Disabling fine-grained version selection for AI for the moment, just to make sure the stock defaults from upstream work first.