### PR TITLE
Register SSH public key before using in JINJA script

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -510,6 +510,14 @@
 
   ### ASSISTED INSTALLER EXECUTION PLAYBOOKS
 
+  # Work-around as invoking lookup plugin inside inventory.ospd.j2 template
+  # fails. This is because ansible user is different then id_rsa.pub one.
+  - name: Register SSH public key
+    become: true
+    become_user: root
+    command: "cat /root/.ssh/id_rsa.pub"
+    register: ssh_root_pub_key
+
   - name: Download and configure assisted installer playbooks
     become: true
     become_user: ocp
@@ -567,3 +575,5 @@
           src: ai/cluster_mgnt_roles/inventory.ospd.j2
           dest: "{{ base_path }}/cluster_mgnt_roles/inventory.ospd"
           mode: '0664'
+      vars:
+          ssh_pub_key: "{{ ssh_root_pub_key.stdout }}"

--- a/ansible/templates/ai/cluster_mgnt_roles/inventory.ospd.j2
+++ b/ansible/templates/ai/cluster_mgnt_roles/inventory.ospd.j2
@@ -35,7 +35,7 @@ ntp_server="clock.redhat.com"
 
 #Host SSH Public Key for troubleshooting after installation
 # Use the same host discovery SSH key
-ssh_public_key="{{ lookup('file', '/root/.ssh/id_rsa.pub') }}"
+ssh_public_key="{{ ssh_pub_key }}"
 
 # Load pull-secret file
 {% if secrets_repo is undefined %}


### PR DESCRIPTION
Use of lookup plugin inside JINJA template as different user fails
with error that file was not found. As a work-around we register
this file in previous task and pass it to JINJA as variable instead.

This allows to get SSH public key as any user that is specified in the
Ansible task.