### PR TITLE
Universal destroy_ocp

### DIFF
--- a/ansible/ocp_ai_destroy.yaml
+++ b/ansible/ocp_ai_destroy.yaml
@@ -84,6 +84,7 @@
       ./stop-assisted-service.sh
     args:
       chdir: "{{ base_path }}/assisted-service-onprem"
+    ignore_errors: true
 
 
   ### BRIDGES

--- a/ansible/ocp_installer_destroy.yaml
+++ b/ansible/ocp_installer_destroy.yaml
@@ -1,11 +1,9 @@
 ---
 - name: Destroy the dev-scripts OCP cluster
   import_playbook: ocp_dev_scripts_destroy.yaml
-  when: not (ocp_ai|bool)
 
 - name: Destroy the assisted installer OCP cluster
   import_playbook: ocp_ai_destroy.yaml
-  when: ocp_ai|bool
 
 - name: Cleanup libvirt resources
   import_playbook: libvirt_cleanup.yaml


### PR DESCRIPTION
CI improvement that allows `make destroy_ocp` to agnostically clean whatever previous OCP cluster might exist (regardless of whether IPI or AI)