### PR TITLE
Allow OCP user to write to AI http_store

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -201,7 +201,7 @@
       file:
         path: "{{ ocp_ai_http_store_dir | default('/opt/http_store/data', true) }}"
         state: directory
-        mode: '0755'
+        mode: '0777'
 
     - name: Start httpd container
       containers.podman.podman_container:


### PR DESCRIPTION
Now that we download the RHEL image as `ocp` user, we need to open up the perms on the AI httpd image store