### PR TITLE
Add default AI HW validation JSON

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -492,6 +492,12 @@
         replace: 'OPENSHIFT_VERSIONS={"4.6":{"display_name":"4.6.16","release_version":"4.6.16","release_image":"quay.io/openshift-release-dev/ocp-release:4.6.16-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso","rhcos_rootfs":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img","rhcos_version":"46.82.202012051820-0","support_level":"production"},"4.7":{"display_name":"4.7.9","release_version":"4.7.9","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.9-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso","rhcos_rootfs":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img","rhcos_version":"47.83.202103251640-0","support_level":"production","default":true}}'
         # We can add this later into the JSON above when we support 4.8: ',"4.8":{"display_name":"4.8.0-fc.3","release_version":"4.8.0-fc.3","release_image":"quay.io/openshift-release-dev/ocp-release:4.8.0-fc.3-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.8.0-fc.3/rhcos-4.8.0-fc.3-x86_64-live.x86_64.iso","rhcos_rootfs":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.8.0-fc.3/rhcos-live-rootfs.x86_64.img","rhcos_version":"48.84.202105062123-0","support_level":"beta"}'
 
+    - name: Set assisted installer service default hardware requirements
+      ansible.builtin.lineinfile:
+        path: "{{ base_path }}/assisted-service-onprem/onprem-environment"
+        regexp: '^HW_VALIDATOR_REQUIREMENTS='
+        line: 'HW_VALIDATOR_REQUIREMENTS=[{"version":"default","master":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":30,"installation_disk_speed_threshold_ms":10},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":30,"installation_disk_speed_threshold_ms":10}}]'
+
     - name: Start assisted installer service container
       shell: |
         ./stop-assisted-service.sh;


### PR DESCRIPTION
Another upstream AI change was recently made that requires a `HW_VALIDATOR_REQUIREMENTS` env var to be set in the AI service container.  For now we'll inject until they respin the associated `stable`-tag AI image that includes it by default.