### PR TITLE
Allow AI to work for RHEL 8.4

### DIFF
--- a/ansible/templates/ai/sushy-tools/sushy-emulator.conf.j2
+++ b/ansible/templates/ai/sushy-tools/sushy-emulator.conf.j2
@@ -24,7 +24,11 @@ SUSHY_EMULATOR_LIBVIRT_URI = u'qemu:///system'
 # system architecture
 SUSHY_EMULATOR_BOOT_LOADER_MAP = {
     u'UEFI': {
+{% if ansible_distribution_version|float <= 8.3 %}
         u'x86_64': u'/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd',
+{% else %}
+        u'x86_64': u'/usr/share/OVMF/OVMF_CODE.secboot.fd',
+{% endif %}
         u'aarch64': u'/usr/share/AAVMF/AAVMF_CODE.fd'
     },
     u'Legacy': {


### PR DESCRIPTION
Something is different in RHEL 8.4 vs 8.3 (and earlier), such that `sushy-tools` configuration needs to point to a different bootloader for `x86_64` UEFI