### PR TITLE
Make sure git_ssh_key has EOL

### DIFF
--- a/ansible/git.yaml
+++ b/ansible/git.yaml
@@ -80,8 +80,9 @@
       register: git_ssh_key
 
     - name: copy git .ssh key to working_dir
+      #command: "echo {{ git_ssh_key.stdout }} > {{ working_dir }}/git_id_rsa"
       copy:
-        content: "{{ git_ssh_key.stdout }}"
+        content: "{{ git_ssh_key.stdout }}{{ '\n' }}"
         dest: "{{ working_dir }}/git_id_rsa"
         mode: 0644
 


### PR DESCRIPTION
the copy ansible module will not add EOL to the last line when
adding git_ssh_key.stdout as the content to the git_ssh_key file.
This makes sure we add a EOL to at the end