### PR TITLE
Update to use current latest 16.2 tripleoclient image

### DIFF
--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -109,7 +109,7 @@ nfs_export_dir: /home/nfs
 default_timeout: 240
 
 # openstackclient container image
-openstackclient_image: quay.io/openstack-k8s-operators/tripleo-deploy:16.2_20210309.1
+openstackclient_image: quay.io/openstack-k8s-operators/rhosp16-openstack-tripleoclient:16.2_20210521.1
 
 # OSP controller VM sizing
 osp_controller_count: 1
@@ -121,7 +121,7 @@ osp_controller_base_image_url: http://download.devel.redhat.com/brewroot/package
 osp_controller_storage_class: host-nfs-storageclass
 # Interface connected to osp network, will be configured as linux-bridge using nmstate
 osp_interface: enp7s0
-osp_container_tag: 16.2_20210420.1
+osp_container_tag: 16.2_20210521.1
 osp_ceph_image: ceph-4.2-rhel-8
 
 # number of OCP worker nodes should be OSP compute hosts


### PR DESCRIPTION
The latest image now contain the ceph-ansible packages. For now
added the image to our quay.io repo to not have to add internal
registry ssl certs.

Depends-On: https://github.com/openstack-k8s-operators/osp-director-operator/pull/255