### PR TITLE
3-master-only OCP cluster deploy for AI

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -80,8 +80,24 @@ Create `local-defaults.yaml` file with settings like so:
 
 ```
 ocp_ai: true
-ocp_version: 4.7
 ```
+
+##### 3-master-worker-combo nodes install via AI
+
+We support the ability to deploy a cluster without dedicated workers -- instead using the master nodes as both
+masters and workers -- through our assisted installer integration.  To do so, set the following variables in
+your `local-defaults.yaml`:
+
+```
+ocp_ai: true
+ocp_num_workers: 0
+ocp_master_memory: 40000
+ocp_master_vcpu: 12
+ocp_master_disk: 50
+```
+
+Note that `ocp_num_extra_workers` still defaults to 2 in `vars/default.yaml`, meaning 2 extra VMs will be created
+for use as OSP compute nodes.  You may obviously change this if needed.
 
 #### Install all steps using the Makefile
 

--- a/ansible/install_computes.yaml
+++ b/ansible/install_computes.yaml
@@ -73,7 +73,7 @@
     environment:
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"
-    when: ocp_ai|bool
+    when: ocp_ai|bool and ocp_num_extra_workers > 0
 
   - name: Render templates to yaml dir
     template:

--- a/ansible/ocp_ai_post_install.yaml
+++ b/ansible/ocp_ai_post_install.yaml
@@ -13,32 +13,35 @@
 
     ### UN-SCHEDULABLE MASTERS
 
-    - name: Set directory for storing schedule/ingress yaml files
-      set_fact:
-        ai_sched_ingress_yaml_dir: "{{ working_yamls_dir }}/ai_schedule_ingress"
+    - name: Unschedule masters for AI
+      block:
+      - name: Set directory for storing schedule/ingress yaml files
+        set_fact:
+          ai_sched_ingress_yaml_dir: "{{ working_yamls_dir }}/ai_schedule_ingress"
 
-    - name: Set facts to disable schedulable masters
-      set_fact:
-        ocp_ai_masters_schedulable: false
+      - name: Set facts to disable schedulable masters
+        set_fact:
+          ocp_ai_masters_schedulable: false
 
-    - name: Create local yaml dir for schedule/ingress CRs
-      file:
-        path: "{{ ai_sched_ingress_yaml_dir }}"
-        state: directory
-        mode: '0755'
+      - name: Create local yaml dir for schedule/ingress CRs
+        file:
+          path: "{{ ai_sched_ingress_yaml_dir }}"
+          state: directory
+          mode: '0755'
 
-    - name: Create schedule CR
-      template:
-        src: ai/cluster_mgnt_roles/50-master-scheduler.yml.j2
-        dest: "{{ ai_sched_ingress_yaml_dir }}/50-master-scheduler.yml"
-        mode: '0664'
+      - name: Create schedule CR
+        template:
+          src: ai/cluster_mgnt_roles/50-master-scheduler.yml.j2
+          dest: "{{ ai_sched_ingress_yaml_dir }}/50-master-scheduler.yml"
+          mode: '0664'
 
-    - name: Make masters unschedulable
-      shell: |
-        oc apply -f {{ ai_sched_ingress_yaml_dir }}/50-master-scheduler.yml
-      environment: &oc_env
-        PATH: "{{ oc_env_path }}"
-        KUBECONFIG: "{{ base_path }}/cluster_mgnt_roles/kubeconfig.{{ ocp_cluster_name }}"
+      - name: Make masters unschedulable
+        shell: |
+          oc apply -f {{ ai_sched_ingress_yaml_dir }}/50-master-scheduler.yml
+        environment: &oc_env
+          PATH: "{{ oc_env_path }}"
+          KUBECONFIG: "{{ base_path }}/cluster_mgnt_roles/kubeconfig.{{ ocp_cluster_name }}"
+      when: ocp_num_workers > 0
 
 
     ### PROVISIONING NETWORK
@@ -80,3 +83,4 @@
       until: result.rc == 0
 
     when: ocp_ai|bool
+

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -315,43 +315,45 @@
 
     - name: Create AI OCP VM XML definitions
       shell: |
-        for i in {1..{{ ocp_num_masters }}}; do
+        for i in {0..{{ ocp_num_masters-1 }}}; do
             virt-install \
             --virt-type=kvm \
-            --name "{{ ocp_cluster_name }}-master-$((i-1))" \
+            --name "{{ ocp_cluster_name }}-master-$i" \
             --memory {{ ocp_master_memory }} \
             --vcpus={{ ocp_master_vcpu }} \
             --os-variant=rhel8.2 \
             --os-type linux \
-            --network=bridge:{{ ocp_cluster_name }}bm,mac="{{ ocp_ai_bm_bridge_master_mac_prefix }}$((i-1))" \
-            --network=bridge:{{ ocp_cluster_name }}pr,mac="{{ ocp_ai_prov_bridge_master_mac_prefix }}$((i-1))" \
+            --network=bridge:{{ ocp_cluster_name }}bm,mac="{{ ocp_ai_bm_bridge_master_mac_prefix }}$i" \
+            --network=bridge:{{ ocp_cluster_name }}pr,mac="{{ ocp_ai_prov_bridge_master_mac_prefix }}$i" \
             --controller type=scsi,model=virtio-scsi \
-            --disk path=/var/lib/libvirt/images/{{ ocp_cluster_name }}-master-$((i-1)).qcow2,size={{ ocp_master_disk }},bus=scsi,format=qcow2 \
+            --disk path=/var/lib/libvirt/images/{{ ocp_cluster_name }}-master-$i.qcow2,size={{ ocp_master_disk }},bus=scsi,format=qcow2 \
             --graphics vnc \
             --noautoconsole --wait=-1 \
             --boot uefi \
             --events on_reboot=restart \
-            --print-xml > /tmp/{{ ocp_cluster_name }}-master-$((i-1)).xml
+            --print-xml > /tmp/{{ ocp_cluster_name }}-master-$i.xml
         done
 
-        for i in {1..{{ ocp_num_workers + ocp_num_extra_workers }}}; do
-            virt-install \
-            --virt-type=kvm \
-            --name "{{ ocp_cluster_name }}-worker-$((i-1))" \
-            --memory {{ ocp_worker_memory }} \
-            --vcpus={{ ocp_worker_vcpu }} \
-            --os-variant=rhel8.2 \
-            --os-type linux \
-            --network=bridge:{{ ocp_cluster_name }}bm,mac="{{ ocp_ai_bm_bridge_worker_mac_prefix }}$((i-1))" \
-            --network=bridge:{{ ocp_cluster_name }}pr,mac="{{ ocp_ai_prov_bridge_worker_mac_prefix }}$((i-1))" \
-            --controller type=scsi,model=virtio-scsi \
-            --disk path=/var/lib/libvirt/images/{{ ocp_cluster_name }}-worker-$((i-1)).qcow2,size={{ ocp_worker_disk }},bus=scsi,format=qcow2 \
-            --graphics vnc \
-            --noautoconsole --wait=-1 \
-            --boot uefi \
-            --events on_reboot=restart \
-            --print-xml > /tmp/{{ ocp_cluster_name }}-worker-$((i-1)).xml
-        done
+        if [[ "{{ ocp_num_workers }}" -gt "0" ]] || [[ "{{ ocp_num_extra_workers }}" -gt "0" ]]; then
+          for i in {0..{{ ocp_num_workers + ocp_num_extra_workers-1 }}}; do
+              virt-install \
+              --virt-type=kvm \
+              --name "{{ ocp_cluster_name }}-worker-$i" \
+              --memory {{ ocp_worker_memory }} \
+              --vcpus={{ ocp_worker_vcpu }} \
+              --os-variant=rhel8.2 \
+              --os-type linux \
+              --network=bridge:{{ ocp_cluster_name }}bm,mac="{{ ocp_ai_bm_bridge_worker_mac_prefix }}$i" \
+              --network=bridge:{{ ocp_cluster_name }}pr,mac="{{ ocp_ai_prov_bridge_worker_mac_prefix }}$i" \
+              --controller type=scsi,model=virtio-scsi \
+              --disk path=/var/lib/libvirt/images/{{ ocp_cluster_name }}-worker-$i.qcow2,size={{ ocp_worker_disk }},bus=scsi,format=qcow2 \
+              --graphics vnc \
+              --noautoconsole --wait=-1 \
+              --boot uefi \
+              --events on_reboot=restart \
+              --print-xml > /tmp/{{ ocp_cluster_name }}-worker-$i.xml
+          done
+        fi
 
     - name: Create VMs
       shell: |
@@ -359,9 +361,11 @@
           virsh define --file /tmp/{{ ocp_cluster_name }}-master-$((i-1)).xml
         done
 
-        for i in {1..{{ ocp_num_workers + ocp_num_extra_workers }}}; do
-          virsh define --file /tmp/{{ ocp_cluster_name }}-worker-$((i-1)).xml
-        done
+        if [[ "{{ ocp_num_workers }}" -gt "0" ]] || [[ "{{ ocp_num_extra_workers }}" -gt "0" ]]; then
+          for i in {1..{{ ocp_num_workers + ocp_num_extra_workers }}}; do
+            virsh define --file /tmp/{{ ocp_cluster_name }}-worker-$((i-1)).xml
+          done
+        fi
 
     - name: Create rng device XML file
       template:
@@ -376,8 +380,9 @@
 
     - name: Remove random number generator devices from worker VM XMLs
       shell: |
-        virsh detach-device {{ ocp_cluster_name }}-worker-{{ item }} /tmp/{{ ocp_cluster_name }}_rng_device.xml --config
-      with_sequence: start=0 end={{ ocp_num_workers+ocp_num_extra_workers-1 }}
+        virsh detach-device {{ ocp_cluster_name }}-worker-{{ (item|int)-1 }} /tmp/{{ ocp_cluster_name }}_rng_device.xml --config
+      with_sequence: start=0 end={{ ocp_num_workers+ocp_num_extra_workers }}
+      when: (item|int-1) >= 0
 
     - name: Get worker domain names
       shell: "virsh list --all | grep {{ ocp_cluster_name }}-worker- | awk {'print $2'}"
@@ -418,6 +423,7 @@
         mode: '0664'
 
     delegate_to: localhost
+    when: ocp_num_extra_workers > 0
 
 
   ### SUSHY-TOOLS

--- a/ansible/ocp_vm_setup_extra_nics.yaml
+++ b/ansible/ocp_vm_setup_extra_nics.yaml
@@ -61,41 +61,63 @@
       register: ospnetwork_start
       failed_when: ospnetwork_start.stderr != "" and "network is already active" not in ospnetwork_start.stderr
 
-    - name: get active worker nodes
+    - name: get active worker nodes, if they exist
       shell: >
           echo $(virsh list --name | grep worker)
-      register: worker_ocp_active
+      register: worker_ocp_active_dedicated
+      when: ocp_num_workers > 0
+
+    - name: get active master nodes and count them as workers, if this cluster has no dedicated workers
+      shell: >
+          echo $(virsh list --name | grep master)
+      register: worker_ocp_active_masters
+      when: ocp_num_workers < 1
+
+    - name: set active worker nodes fact, if dedicated workers exist
+      set_fact:
+        worker_ocp_active: "{{ worker_ocp_active_dedicated.stdout_lines }}"
+      when: "'stdout_lines' in worker_ocp_active_dedicated and worker_ocp_active_dedicated.stdout_lines|length > 0"
+
+    - name: set active worker nodes fact, if no dedicated workers exist
+      set_fact:
+        worker_ocp_active: "{{ worker_ocp_active_masters.stdout_lines }}"
+      when: "'stdout_lines' in worker_ocp_active_masters and worker_ocp_active_masters.stdout_lines|length > 0"
 
     - name: get inactive worker nodes
       shell: >
           echo $(virsh list --inactive --name | grep worker)
       register: worker_ocp_inactive
 
-    - name: Detach osp network interface from ACTIVE worker VM's if this is a rerun of the playbook
-      command: "virsh detach-interface {{ item }} bridge --mac {{ '00:14:cd:2b:c8:0%01x' | format(item[-1]|int) }} --persistent --live"
-      with_items: "{{ worker_ocp_active.stdout_lines[0].split(' ') }}"
-      ignore_errors: true
+    - name: Attach/detach network interfaces for INACTIVE workers
+      block:
+      - name: Detach osp network interface from INACTIVE worker VM's if this is a rerun of the playbook
+        command: "virsh detach-interface {{ item }} bridge --persistent"
+        with_items: "{{ worker_ocp_inactive.stdout_lines[0].split(' ') }}"
+        ignore_errors: true
 
-    - name: Detach osp network interface from INACTIVE worker VM's if this is a rerun of the playbook
-      command: "virsh detach-interface {{ item }} bridge --mac {{ '00:14:cd:2b:c8:0%01x' | format(item[-1]|int) }} --persistent"
-      with_items: "{{ worker_ocp_inactive.stdout_lines[0].split(' ') }}"
-      ignore_errors: true
+      - name: Attach the osp network to INACTIVE worker VM's
+        command: "virsh attach-interface {{ item }} bridge ospnetwork --model virtio --persistent"
+        with_items: "{{ worker_ocp_inactive.stdout_lines[0].split(' ') }}"
+      when: worker_ocp_inactive.stdout_lines|length > 0
 
-    - name: Attach the osp network to ACTIVE worker VM's
-      shell: |
-        # HACK to fix dev-scripts bug
-        virsh destroy {{ item }}
-        virsh attach-interface {{ item }} bridge ospnetwork --mac {{ '00:14:cd:2b:c8:0%01x' | format(item[-1]|int) }} --model virtio --persistent --config
-        virsh start {{ item }}
-      with_items: "{{ worker_ocp_active.stdout_lines[0].split(' ') }}"
-      when: not (ocp_ai|bool)
+    - name: Attach/detach network interfaces for ACTIVE workers
+      block:
+      - name: Detach osp network interface from ACTIVE worker VM's if this is a rerun of the playbook
+        command: "virsh detach-interface {{ item }} bridge --persistent --live"
+        with_items: "{{ worker_ocp_active[0].split(' ') }}"
+        ignore_errors: true
 
-    - name: Attach the osp network to ACTIVE worker VM's
-      command: "virsh attach-interface {{ item }} bridge ospnetwork --mac {{ '00:14:cd:2b:c8:0%01x' | format(item[-1]|int) }} --model virtio --persistent --config"
-      with_items: "{{ worker_ocp_active.stdout_lines[0].split(' ') }}"
-      when: ocp_ai|bool
+      - name: Attach the osp network to ACTIVE worker VM's
+        shell: |
+          # HACK to fix dev-scripts bug
+          virsh destroy {{ item }}
+          virsh attach-interface {{ item }} bridge ospnetwork --model virtio --persistent --config
+          virsh start {{ item }}
+        with_items: "{{ worker_ocp_active[0].split(' ') }}"
+        when: not (ocp_ai|bool)
 
-    - name: Attach the osp network to INACTIVE worker VM's
-      command: "virsh attach-interface {{ item }} bridge ospnetwork --mac {{ '00:14:cd:2b:c8:0%01x' | format(item[-1]|int) }} --model virtio --persistent"
-      with_items: "{{ worker_ocp_inactive.stdout_lines[0].split(' ') }}"
-      when: worker_ocp_inactive.stdout_lines != 0
+      - name: Attach the osp network to ACTIVE worker VM's
+        command: "virsh attach-interface {{ item }} bridge ospnetwork --model virtio --persistent --config"
+        with_items: "{{ worker_ocp_active[0].split(' ') }}"
+        when: ocp_ai|bool
+      when: worker_ocp_active|length > 0


### PR DESCRIPTION
This PR enables us to deploy OCP clusters with 3 master/workers (and no dedicated workers).  To do so, use these variables in your `local-defaults.yaml`:

```
ocp_ai: true
ocp_num_workers: 0
ocp_master_memory: 40000
ocp_master_vcpu: 12
ocp_master_disk: 50
```

This functionality is only supported for AI and is not tested against dev-scripts.  The `ocp_num_extra_workers` can be whatever you like (we currently default it to 2).  Spec vars are increased for the masters to account for the increased pod load they will host.