### PR TITLE
Remove Ceph OSD Journal Size

### DIFF
--- a/ansible/templates/osp/tripleo_deploy/storage-backend.yaml.j2
+++ b/ansible/templates/osp/tripleo_deploy/storage-backend.yaml.j2
@@ -29,7 +29,6 @@ parameter_defaults:
 {% endfor %}
     osd_scenario: lvm
     osd_objectstore: bluestore
-    journal_size: 512
   CephAnsibleExtraConfig:
     is_hci: true
   CephConfigOverrides:


### PR DESCRIPTION
The journal_size parameter applies to Filestore but the template
deploys with Bluestore so remove the unnecessary paramter.

Signed-off-by: John Fulton <fulton@redhat.com>