### PR TITLE
Add required HW reqs for SNO for AI

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -510,7 +510,7 @@
       ansible.builtin.lineinfile:
         path: "{{ base_path }}/assisted-service-onprem/onprem-environment"
         regexp: '^HW_VALIDATOR_REQUIREMENTS='
-        line: 'HW_VALIDATOR_REQUIREMENTS=[{"version":"default","master":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":30,"installation_disk_speed_threshold_ms":10},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":30,"installation_disk_speed_threshold_ms":10}}]'
+        line: 'HW_VALIDATOR_REQUIREMENTS=[{"version":"default","master":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":30,"installation_disk_speed_threshold_ms":10},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":30,"installation_disk_speed_threshold_ms":10},"sno":{"cpu_cores":8,"ram_mib":32768,"disk_size_gb":30,"installation_disk_speed_threshold_ms":10}}]'
 
     - name: Start assisted installer service container
       shell: |


### PR DESCRIPTION
Upstream AI service code changed such that it requires a hardware requirements entry for `sno` (even if you're not using single-node mode)