### PR TITLE
Retry Install OpenShift Virtualization Operator if fails

### DIFF
--- a/ansible/ocp_cnv.yaml
+++ b/ansible/ocp_cnv.yaml
@@ -67,6 +67,10 @@
     environment:
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"
+    retries: 5
+    delay: 30
+    register: result
+    until: result.rc == 0
 
   - name: wait for OpenShift Virtualization Operator to be installed
     shell: |


### PR DESCRIPTION
It happens that the task fails randomly with the error
"no endpoints available for service "hco-webhook-service"

Retry does fix the above issue most of the times.