### PR TITLE
Make RedHat subscription tasks robust

### DIFF
--- a/ansible/host_prep.yaml
+++ b/ansible/host_prep.yaml
@@ -67,6 +67,9 @@
             rhel_subscription_org_id: "xxxxxxx"
 
     - name: unregister node
+      retries: 3
+      delay: 3
+      ignore_errors: yes
       redhat_subscription:
         state: absent
         activationkey: "{{ rhel_subscription_activation_key }}"
@@ -74,8 +77,11 @@
         pool: '^(Red Hat Enterprise Server for x86_64)$'
 
     - name: Register with activationkey and consume subscriptions matching Red Hat Enterprise Server
+      retries: 3
+      delay: 3
       redhat_subscription:
         state: present
+        force_register: yes
         activationkey: "{{ rhel_subscription_activation_key }}"
         org_id: "{{ rhel_subscription_org_id }}"
         pool: '^(Red Hat Enterprise Server for x86_64)$'


### PR DESCRIPTION
The RedHat subscription manager is failing randomly either on
the unsubscribe or subscribe tasks. Adding retries make it more
robust. Unsubscribe failing task can be ignored with the follow
change to allow registering system even if it was already
registered.