### PR TITLE
Extend tempest tests for current phase2 tests

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -47,6 +47,11 @@ post_install: hosts local-defaults.yaml
 	ocp_image_registry.yaml \
 	ocp_vm_setup_extra_nics.yaml
 
+nics: hosts local-defaults.yaml
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-i hosts -e @local-defaults.yaml \
+	ocp_vm_setup_extra_nics.yaml
+
 cnv_install: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
 	-i hosts -e @local-defaults.yaml \

--- a/ansible/files/externalnetwork.xml
+++ b/ansible/files/externalnetwork.xml
@@ -1,0 +1,12 @@
+<network>
+  <name>external</name>
+  <forward mode='nat'>
+    <nat>
+      <port start='1024' end='65535'/>
+    </nat>
+  </forward>
+  <bridge name='external' stp='on' delay='0'/>
+  <mac address='52:54:00:eb:1e:dd'/>
+  <ip address='10.0.0.1' netmask='255.255.255.0'>
+  </ip>
+</network>

--- a/ansible/files/osp/net_config/vlan/net-config-multi-nic-controller.yaml
+++ b/ansible/files/osp/net_config/vlan/net-config-multi-nic-controller.yaml
@@ -221,7 +221,7 @@ resources:
                   list_concat_unique:
                     - get_param: InternalApiInterfaceRoutes
               - type: ovs_bridge
-                name: br-tenant
+                name: br-isolated
                 mtu:
                   get_param: TenantMtu
                 dns_servers:

--- a/ansible/files/osp/net_config/vlan/net-config-two-nic-vlan-compute.yaml
+++ b/ansible/files/osp/net_config/vlan/net-config-two-nic-vlan-compute.yaml
@@ -54,28 +54,6 @@ parameters:
       Unless the default is changed, the parameter is automatically resolved
       from the subnet host_routes attribute.
     type: json
-  StorageMgmtIpSubnet:
-    default: ''
-    description: IP address/subnet on the storage_mgmt network
-    type: string
-  StorageMgmtNetworkVlanID:
-    default: 40
-    description: Vlan ID for the storage_mgmt network traffic.
-    type: number
-  StorageMgmtMtu:
-    default: 1500
-    description: The maximum transmission unit (MTU) size(in bytes) that is
-      guaranteed to pass through the data path of the segments in the
-      StorageMgmt network.
-    type: number
-  StorageMgmtInterfaceRoutes:
-    default: []
-    description: >
-      Routes for the storage_mgmt network traffic.
-      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
-      Unless the default is changed, the parameter is automatically resolved
-      from the subnet host_routes attribute.
-    type: json
   InternalApiIpSubnet:
     default: ''
     description: IP address/subnet on the internal_api network
@@ -120,6 +98,12 @@ parameters:
       Unless the default is changed, the parameter is automatically resolved
       from the subnet host_routes attribute.
     type: json
+  ExternalMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the
+      External network.
+    type: number
   DnsServers: # Override this via parameter_defaults
     default: []
     description: >
@@ -150,6 +134,7 @@ resources:
             - {get_param: StorageMtu}
             - {get_param: InternalApiMtu}
             - {get_param: TenantMtu}
+            - {get_param: ExternalMtu}
 
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -163,7 +148,7 @@ resources:
             $network_config:
               network_config:
               - type: ovs_bridge
-                name: bridge_name
+                name: br-isolated
                 mtu:
                   get_attr: [MinViableMtu, value]
                 use_dhcp: false
@@ -185,7 +170,7 @@ resources:
                           get_param: ControlPlaneDefaultRoute
                 members:
                 - type: interface
-                  name: nic3
+                  name: nic4
                   mtu:
                     get_attr: [MinViableMtu, value]
                   # force the MAC address of the bridge to this interface
@@ -201,17 +186,6 @@ resources:
                   routes:
                     list_concat_unique:
                       - get_param: StorageInterfaceRoutes
-                - type: vlan
-                  mtu:
-                    get_param: StorageMgmtMtu
-                  vlan_id:
-                    get_param: StorageMgmtNetworkVlanID
-                  addresses:
-                  - ip_netmask:
-                      get_param: StorageMgmtIpSubnet
-                  routes:
-                    list_concat_unique:
-                      - get_param: StorageMgmtInterfaceRoutes
                 - type: vlan
                   mtu:
                     get_param: InternalApiMtu
@@ -234,6 +208,20 @@ resources:
                   routes:
                     list_concat_unique:
                       - get_param: TenantInterfaceRoutes
+              - type: ovs_bridge
+                # This will default to br-ex, anything else requires specific
+                # brige mapping entries for it to be used.
+                name: bridge_name
+                mtu:
+                  get_param: ExternalMtu
+                use_dhcp: false
+                members:
+                - type: interface
+                  name: nic3
+                  mtu:
+                    get_param: ExternalMtu
+                  use_dhcp: false
+                  primary: true
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/ansible/files/osp/net_config/vlan/net-config-two-nic-vlan-computehci.yaml
+++ b/ansible/files/osp/net_config/vlan/net-config-two-nic-vlan-computehci.yaml
@@ -54,6 +54,28 @@ parameters:
       Unless the default is changed, the parameter is automatically resolved
       from the subnet host_routes attribute.
     type: json
+  StorageMgmtIpSubnet:
+    default: ''
+    description: IP address/subnet on the storage_mgmt network
+    type: string
+  StorageMgmtNetworkVlanID:
+    default: 40
+    description: Vlan ID for the storage_mgmt network traffic.
+    type: number
+  StorageMgmtMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the
+      StorageMgmt network.
+    type: number
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   InternalApiIpSubnet:
     default: ''
     description: IP address/subnet on the internal_api network
@@ -98,6 +120,12 @@ parameters:
       Unless the default is changed, the parameter is automatically resolved
       from the subnet host_routes attribute.
     type: json
+  ExternalMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the
+      External network.
+    type: number
   DnsServers: # Override this via parameter_defaults
     default: []
     description: >
@@ -126,8 +154,10 @@ resources:
           data:
             - {get_param: ControlPlaneMtu}
             - {get_param: StorageMtu}
+            - {get_param: StorageMgmtMtu}
             - {get_param: InternalApiMtu}
             - {get_param: TenantMtu}
+            - {get_param: ExternalMtu}
 
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -141,7 +171,7 @@ resources:
             $network_config:
               network_config:
               - type: ovs_bridge
-                name: bridge_name
+                name: br-isolated
                 mtu:
                   get_attr: [MinViableMtu, value]
                 use_dhcp: false
@@ -163,7 +193,7 @@ resources:
                           get_param: ControlPlaneDefaultRoute
                 members:
                 - type: interface
-                  name: nic3
+                  name: nic4
                   mtu:
                     get_attr: [MinViableMtu, value]
                   # force the MAC address of the bridge to this interface
@@ -179,6 +209,17 @@ resources:
                   routes:
                     list_concat_unique:
                       - get_param: StorageInterfaceRoutes
+                - type: vlan
+                  mtu:
+                    get_param: StorageMgmtMtu
+                  vlan_id:
+                    get_param: StorageMgmtNetworkVlanID
+                  addresses:
+                  - ip_netmask:
+                      get_param: StorageMgmtIpSubnet
+                  routes:
+                    list_concat_unique:
+                      - get_param: StorageMgmtInterfaceRoutes
                 - type: vlan
                   mtu:
                     get_param: InternalApiMtu
@@ -201,6 +242,20 @@ resources:
                   routes:
                     list_concat_unique:
                       - get_param: TenantInterfaceRoutes
+              - type: ovs_bridge
+                # This will default to br-ex, anything else requires specific
+                # brige mapping entries for it to be used.
+                name: bridge_name
+                mtu:
+                  get_param: ExternalMtu
+                use_dhcp: false
+                members:
+                - type: interface
+                  name: nic3
+                  mtu:
+                    get_param: ExternalMtu
+                  use_dhcp: false
+                  primary: true
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/ansible/libvirt_cleanup.yaml
+++ b/ansible/libvirt_cleanup.yaml
@@ -10,4 +10,17 @@
     shell: |
       virsh net-destroy ospnetwork
       virsh net-undefine ospnetwork
+      virsh net-destroy external
+      virsh net-undefine external
     ignore_errors: true
+
+  # only required now for cleanup existing envs without redeploy, could be removed soon
+  - name: make sure ibvirt network script is gone
+    file:
+      path: /etc/libvirt/hooks/network
+      state: absent
+
+  - name: Restart libvirt
+    service:
+       name: libvirtd
+       state: restarted

--- a/ansible/ocp_vm_setup_extra_nics.yaml
+++ b/ansible/ocp_vm_setup_extra_nics.yaml
@@ -12,12 +12,20 @@
     become: true
     become_user: root
     shell: >
-      virsh net-list --all | grep ospnetwork
+      virsh net-info ospnetwork
     ignore_errors: true
     register: ospnetwork_exist
 
-  - name: create osp network
-    when: ospnetwork_exist.rc == 1
+  - name: check if osp external network already exists
+    become: true
+    become_user: root
+    shell: >
+      virsh net-info external
+    ignore_errors: true
+    register: extnetwork_exist
+
+  - name: create osp networks
+    when: ospnetwork_exist.rc == 1 or extnetwork_exist.rc == 1
     block:
     - name: create osp network directory
       file:
@@ -32,39 +40,33 @@
         mode: 0644
       with_items:
         - files/ospnetwork.xml
+        - files/externalnetwork.xml
 
     - name: Define ospnetwork libvirt network
       become: true
       become_user: root
       command: "virsh net-define {{ working_dir }}/osp-network/ospnetwork.xml"
+      when: ospnetwork_exist.rc == 1
+
+    - name: Define external libvirt network
+      become: true
+      become_user: root
+      command: "virsh net-define {{ working_dir }}/osp-network/externalnetwork.xml"
+      when: extnetwork_exist.rc == 1
 
   - name: Setup OSP network
     become: true
     become_user: root
     block:
-    - name: create libvirt hooks directory
-      file:
-        path: /etc/libvirt/hooks
-        state: directory
-        mode: 0755
-
-    - name: copy libvirt network hook to /etc/libvirt/hooks/network
-      copy:
-        src:  files/qemu/network
-        dest: /etc/libvirt/hooks/network
-        mode: 0750
-
-    - name: Restart libvirt
-      service:
-         name: libvirtd
-         state: restarted
-
-    - name: Start the osp network
+    - name: Start the osp networks
       shell: |
-        virsh net-start --network ospnetwork
-        virsh net-autostart --network ospnetwork
-      register: ospnetwork_start
-      failed_when: ospnetwork_start.stderr != "" and "network is already active" not in ospnetwork_start.stderr
+        virsh net-start --network {{ item }}
+        virsh net-autostart --network {{ item }}
+      register: network_start
+      failed_when: network_start.stderr != "" and "network is already active" not in network_start.stderr
+      with_items:
+        - external
+        - ospnetwork
 
     - name: get active worker nodes, if they exist
       shell: >
@@ -94,35 +96,59 @@
       register: worker_ocp_inactive
 
     - name: Attach/detach network interfaces for INACTIVE workers
+      when: worker_ocp_inactive.stdout_lines|length > 0
       block:
-      - name: Detach osp network interface from INACTIVE worker VM's if this is a rerun of the playbook
-        command: "virsh detach-interface {{ item }} bridge --persistent"
-        with_items: "{{ worker_ocp_inactive.stdout_lines[0].split(' ') }}"
+      - name: Detach network interface from INACTIVE worker VM's if this is a rerun of the playbook
+        shell: |
+          ifmacs=$(virsh domiflist {{ item.0 }} | grep {{ item.1 }} | awk '{ print $5}')
+          for mac in $ifmacs; do
+            virsh detach-interface {{ item.0 }} bridge --mac $mac --persistent
+          done
+        with_nested:
+        - "{{ worker_ocp_inactive.stdout_lines[0].split(' ') }}"
+        - ['external', 'ospnetwork']
         ignore_errors: true
 
       - name: Attach the osp network to INACTIVE worker VM's
-        command: "virsh attach-interface {{ item }} bridge ospnetwork --model virtio --persistent"
-        with_items: "{{ worker_ocp_inactive.stdout_lines[0].split(' ') }}"
-      when: worker_ocp_inactive.stdout_lines|length > 0
+        command: "virsh attach-interface {{ item.0 }} bridge {{ item.1 }} --model virtio --persistent"
+        with_nested:
+        - "{{ worker_ocp_inactive.stdout_lines[0].split(' ') }}"
+        - ['external', 'ospnetwork']
 
     - name: Attach/detach network interfaces for ACTIVE workers
+      when: worker_ocp_active|length > 0
       block:
       - name: Detach osp network interface from ACTIVE worker VM's if this is a rerun of the playbook
-        command: "virsh detach-interface {{ item }} bridge --persistent --live"
-        with_items: "{{ worker_ocp_active[0].split(' ') }}"
+        shell: |
+          ifmacs=$(virsh domiflist {{ item.0 }} | grep {{ item.1 }} | awk '{ print $5}')
+          for mac in $ifmacs; do
+            virsh detach-interface {{ item.0 }} bridge --mac $mac --persistent --live
+          done
+        with_nested:
+        - "{{ worker_ocp_active[0].split(' ') }}"
+        - ['external',  'ospnetwork']
         ignore_errors: true
 
       - name: Attach the osp network to ACTIVE worker VM's
-        shell: |
-          # HACK to fix dev-scripts bug
-          virsh destroy {{ item }}
-          virsh attach-interface {{ item }} bridge ospnetwork --model virtio --persistent --config
-          virsh start {{ item }}
-        with_items: "{{ worker_ocp_active[0].split(' ') }}"
         when: not (ocp_ai|bool)
+        block:
+        # HACK to fix dev-scripts bug
+        - name: "destroy vm {{ item }}"
+          command: "virsh destroy {{ item }}"
+          with_items: "{{ worker_ocp_active[0].split(' ') }}"
+        - name: attach interfaces to vm
+          shell: |
+            virsh attach-interface {{ item.0 }} bridge {{ item.1 }} --model virtio --persistent --config
+          with_nested:
+          - "{{ worker_ocp_active[0].split(' ') }}"
+          - ['external', 'ospnetwork']
+        - name: "start vm {{ item }}"
+          command: "virsh start {{ item }}"
+          with_items: "{{ worker_ocp_active[0].split(' ') }}"
 
       - name: Attach the osp network to ACTIVE worker VM's
-        command: "virsh attach-interface {{ item }} bridge ospnetwork --model virtio --persistent --config"
-        with_items: "{{ worker_ocp_active[0].split(' ') }}"
+        command: "virsh attach-interface {{ item.0 }} bridge {{ item.1 }} --model virtio --persistent --config"
+        with_nested:
+        - "{{ worker_ocp_active[0].split(' ') }}"
+        - ['external', 'ospnetwork']
         when: ocp_ai|bool
-      when: worker_ocp_active|length > 0

--- a/ansible/ocp_vm_setup_extra_nics.yaml
+++ b/ansible/ocp_vm_setup_extra_nics.yaml
@@ -54,12 +54,11 @@
       command: "virsh net-define {{ working_dir }}/osp-network/externalnetwork.xml"
       when: extnetwork_exist.rc == 1
 
-  - name: Setup OSP network
-    become: true
-    become_user: root
-    block:
     - name: Start the osp networks
+      become: true
+      become_user: root
       shell: |
+        set -e
         virsh net-start --network {{ item }}
         virsh net-autostart --network {{ item }}
       register: network_start
@@ -68,6 +67,22 @@
         - external
         - ospnetwork
 
+  # on CI runs it has seen that the network interface was still down
+  # lets make sure the OSP network interfaces are up
+  - name: make sure the network interfaces are up
+    become: true
+    become_user: root
+    shell: |
+      set -e
+      ip link set {{ item }} up
+    with_items:
+        - external
+        - ospnetwork
+
+  - name: Attach OSP networks to OCP worker VMs
+    become: true
+    become_user: root
+    block:
     - name: get active worker nodes, if they exist
       shell: >
           echo $(virsh list --name | grep worker)

--- a/ansible/openstack_cleanup.yaml
+++ b/ansible/openstack_cleanup.yaml
@@ -18,6 +18,7 @@
       - "oc delete -n openstack openstackplaybookgenerator --all"
       - "oc delete -n openstack openstackephemeralheat --all"
       - "oc delete -n openstack openstackclient --all"
+      - "oc delete -n openstack cm tripleo-deploy-config tripleo-deploy-config-custom tripleo-tarball-config --ignore-not-found=true"
 
   - name: delete playbooks git repo dir
     file:

--- a/ansible/osp_tempest.yaml
+++ b/ansible/osp_tempest.yaml
@@ -123,11 +123,22 @@
         sed -n '/^Totals/,$p' {{ working_log_dir }}/tempest.log
       register: tempest_summary
 
-    - name:
+    - name: Get failed tempest tests
+      shell: |
+        #!/bin/bash
+        set -e
+        grep FAILED {{ working_log_dir }}/tempest.log || true
+      register: tempest_failed
+
+    - name: Tempest run summary
       debug:
         msg: "{{ tempest_summary.stdout.split('\n') }}"
+
+    - name: Tempest failed tests
+      debug:
+        msg: "{{ tempest_failed.stdout.split('\n') }}"
 
     - name: Fail playbook if tempest run failed or timed out
       fail:
         msg: Tempest run failed or timed out, check output {{ working_log_dir }}/tempest.log
-      when: tempest_run.rc == 1
+      when: tempest_run.rc == 1 or tempest_failed.stdout | length != 0

--- a/ansible/osp_tempest.yaml
+++ b/ansible/osp_tempest.yaml
@@ -50,7 +50,8 @@
     with_items:
     - tempest-deployer-input.conf
     - tempest_script.sh
-    - whitelist_file
+    - include_file
+    - exclude_file
 
   - name: create tempest osclient
     shell: |
@@ -102,7 +103,8 @@
       with_items:
       - tempest-deployer-input.conf
       - tempest_script.sh
-      - whitelist_file
+      - include_file
+      - exclude_file
 
     - name: Run tempest, the output gets logged at {{ working_log_dir }}/tempest.log
       shell: |

--- a/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
+++ b/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
@@ -24,6 +24,7 @@ spec:
   # Networks to associate with this host
   networks:
     - ctlplane
+    - external
     - internalapi
     - tenant
     - storage

--- a/ansible/templates/osp/networks/03-external.yaml.j2
+++ b/ansible/templates/osp/networks/03-external.yaml.j2
@@ -5,7 +5,6 @@ metadata:
 spec:
   cidr: 10.0.0.0/24
   gateway: 10.0.0.1
-  vlan: 10
   allocationStart: 10.0.0.4
   allocationEnd: 10.0.0.250
   attachConfiguration:
@@ -19,8 +18,8 @@ spec:
               stp:
                 enabled: false
             port:
-            - name: {{ osp_interface }}
-          description: Linux bridge with {{ osp_interface }} as a port
-          name: br-osp
+            - name: {{ osp_external }}
+          description: Linux bridge with {{ osp_external }} as a port
+          name: br-ex
           state: up
           type: linux-bridge

--- a/ansible/templates/osp/tripleo_heat_envs/vlan/network-environment.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/vlan/network-environment.yaml.j2
@@ -1,16 +1,17 @@
 resource_registry:
   OS::TripleO::Controller::Net::SoftwareConfig: net-config-multi-nic-controller.yaml
 {% if osp_compute_hci %}
-  OS::TripleO::ComputeHCI::Net::SoftwareConfig: net-config-single-vlan-computehci.yaml
+  OS::TripleO::ComputeHCI::Net::SoftwareConfig: net-config-two-nic-vlan-computehci.yaml
 {% else %}
-  OS::TripleO::Compute::Net::SoftwareConfig: net-config-single-vlan-compute.yaml
+  OS::TripleO::Compute::Net::SoftwareConfig: net-config-two-nic-vlan-compute.yaml
 {% endif %}
 
 
 parameter_defaults:
   EC2MetadataIp: 192.168.25.1
   ControlPlaneDefaultRoute: 192.168.25.1
-  NeutronPublicInterface: eth1
+  NeutronGlobalPhysnetMtu: 1350
+  NeutronPublicInterface: nic3
   NtpServer:
     - clock.redhat.com
     - clock2.redhat.com
@@ -22,7 +23,6 @@ parameter_defaults:
       start: 10.0.0.4
   ExternalInterfaceDefaultRoute: 10.0.0.1
   ExternalNetCidr: 10.0.0.0/24
-  ExternalNetworkVlanID: 10
   InternalApiAllocationPools:
   -   end: 172.16.2.250
       start: 172.16.2.4

--- a/ansible/templates/tempest/exclude_file.j2
+++ b/ansible/templates/tempest/exclude_file.j2
@@ -1,0 +1,3 @@
+{% for test in tempest_test_dict.excludelist %}
+{{ test }}
+{% endfor %}

--- a/ansible/templates/tempest/include_file.j2
+++ b/ansible/templates/tempest/include_file.j2
@@ -1,0 +1,3 @@
+{% for test in tempest_test_dict.includelist %}
+{{ test }}
+{% endfor %}

--- a/ansible/templates/tempest/tempest_script.sh.j2
+++ b/ansible/templates/tempest/tempest_script.sh.j2
@@ -3,12 +3,12 @@ set -e
 
 PUB_NETWORK_ID=$(openstack --os-cloud overcloud network list -f value -c ID --name public)
 if [ -z "$PUB_NETWORK_ID" ]; then
-  openstack --os-cloud overcloud network create public --external
-  openstack --os-cloud overcloud subnet create ext --subnet-range 192.168.25.96/28 --gateway 192.168.25.1 --no-dhcp --network public
+  openstack --os-cloud overcloud network create public --external  --provider-network-type flat --provider-physical-network datacentre
+  openstack --os-cloud overcloud subnet create pub_sub --subnet-range 10.0.0.0/24 --allocation-pool start=10.0.0.100,end=10.0.0.150 --gateway 10.0.0.1 --no-dhcp --network public
   openstack --os-cloud overcloud network create private --share
-  openstack --os-cloud overcloud subnet create priv --subnet-range 192.168.0.0/24 --network private
+  openstack --os-cloud overcloud subnet create priv_sub --subnet-range 192.168.0.0/24 --network private
   openstack --os-cloud overcloud router create priv_router
-  openstack --os-cloud overcloud router add subnet priv_router priv
+  openstack --os-cloud overcloud router add subnet priv_router priv_sub
   openstack --os-cloud overcloud router set priv_router --external-gateway public
   PUB_NETWORK_ID=$(openstack --os-cloud overcloud network list -f value -c ID --name public)
 fi
@@ -36,6 +36,8 @@ $TEMPESTCONF \
   --create \
   --network-id ${PUB_NETWORK_ID} \
   object-storage.reseller_admin ResellerAdmin
+
+crudini --set /var/lib/tempest/tempest_workspace/etc/tempest.conf compute-feature-enabled vnc_console true
 
 tempest cleanup --init-saved-state
 

--- a/ansible/templates/tempest/tempest_script.sh.j2
+++ b/ansible/templates/tempest/tempest_script.sh.j2
@@ -39,11 +39,13 @@ $TEMPESTCONF \
 
 tempest cleanup --init-saved-state
 
-if [ -f "/var/lib/tempest/whitelist_file" ]; then
-  tempest run --whitelist-file /var/lib/tempest/whitelist_file
-else
+{% if (tempest_smoketest|bool) %}
   # Run for example smoke tests
   tempest run --smoke
-fi
+{% else %}
+  tempest run --regex "{{ tempest_test_dict.regex }}" \
+    --include-list /var/lib/tempest/include_file \
+    --exclude-list /var/lib/tempest/exclude_file
+{% endif %}
 
 tempest cleanup

--- a/ansible/templates/tempest/whitelist_file.j2
+++ b/ansible/templates/tempest/whitelist_file.j2
@@ -1,3 +1,0 @@
-{% for test in tempest_whitelist %}
-{{ test }}
-{% endfor %}

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -122,13 +122,14 @@ openstackclient_image: quay.io/openstack-k8s-operators/rhosp16-openstack-tripleo
 # OSP controller VM sizing
 osp_controller_count: 1
 osp_controller_cores: 6
-osp_controller_memory: 12
+osp_controller_memory: 20
 osp_controller_disk_size: 40
 # use http://download.devel.redhat.com to get the local mirror depending on where the server is
 osp_controller_base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/8.4/1168/images/rhel-guest-image-8.4-1168.x86_64.qcow2
 osp_controller_storage_class: host-nfs-storageclass
-# Interface connected to osp network, will be configured as linux-bridge using nmstate
-osp_interface: enp7s0
+# Interfaces connected to the external and osp(ctlplane,internal_api,storage,storage_mgmt via vlan) network, will be configured as linux-bridge using nmstate
+osp_interface: enp8s0
+osp_external: enp7s0
 osp_container_tag: 16.2_20210630.1
 osp_ceph_image: ceph-4.2-rhel-8
 

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -95,10 +95,18 @@ tempest_image: quay.io/openstack-k8s-operators/rhosp16-openstack-tempest:16.2_20
 # tempest timeout in seconds
 tempest_timeout: 3600
 
-# tempest test whitelist, if [] smoke test runs
-#tempest_whitelist: []
-tempest_whitelist:
-  - 'tempest.api.compute.servers.test_create_server.ServersTestJSON.test_list_servers'
+# run smoketest
+tempest_smoketest: false
+
+# specify tempest tests to run
+tempest_test_dict:
+  regex: '(?!.*\[.*\bslow\b.*\])(^tempest\.(api|scenario))'
+  includelist: []
+  excludelist:
+      - "^tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_multi_create_auto_allocate"
+      - "^tempest.api.compute.admin.test_live_migration.LiveMigrationTest.test_live_block_migration_paused"
+      - "^tempest.api.compute.admin.test_live_migration.LiveAutoBlockMigrationV225Test.test_live_block_migration_paused"
+      - "^tempest.api.compute.admin.test_live_migration.LiveMigrationRemoteConsolesV26Test.test_live_block_migration_paused"
 
 local_working_dir: "~/{{ ocp_cluster_name }}-working"
 

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -102,11 +102,14 @@ tempest_smoketest: false
 tempest_test_dict:
   regex: '(?!.*\[.*\bslow\b.*\])(^tempest\.(api|scenario))'
   includelist: []
+  # per default with OVN there is no DHCPAgent, disable the tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON tests
   excludelist:
       - "^tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_multi_create_auto_allocate"
       - "^tempest.api.compute.admin.test_live_migration.LiveMigrationTest.test_live_block_migration_paused"
       - "^tempest.api.compute.admin.test_live_migration.LiveAutoBlockMigrationV225Test.test_live_block_migration_paused"
       - "^tempest.api.compute.admin.test_live_migration.LiveMigrationRemoteConsolesV26Test.test_live_block_migration_paused"
+      - "^tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON.test_add_remove_network_from_dhcp_agent"
+      - "^tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON.test_list_networks_hosted_by_one_dhcp"
 
 local_working_dir: "~/{{ ocp_cluster_name }}-working"
 


### PR DESCRIPTION
Adds tempest vars to control which tests to run.
tempest_smoketest run tempest with --smoke, default
to false.
If tempest_smoketest is false, information from tempest_test_dict
is used to run tempest with --regex, --include-list, and
--exclude-list

current test list from https://github.com/redhat-openstack/infrared/blob/master/plugins/tempest/vars/tests/full.yml

Depends-On: https://github.com/openstack-k8s-operators/osp-director-operator/pull/311