### PR TITLE
Use latest SoS cluster_mgnt_roles

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -565,7 +565,7 @@
         repo: "{{ ocp_ai_ansible_repo | default('https://github.com/sonofspike/cluster_mgnt_roles.git', true) }}"
         dest: "{{ base_path }}/cluster_mgnt_roles"
         force: true
-        version: "{{ ocp_ai_ansible_branch | default('ccb34826a671f6c3435869303b6abb538638252b', true) }}"
+        version: "{{ ocp_ai_ansible_branch | default('9051f7da86fa90f9b60c1b09414dabeaf7d58fb7', true) }}"
 
     - name: Add schedulable-master manifest
       block:

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -10,7 +10,7 @@ ocp_ai_external_dns:
 # ocp_ai_service_repo: defaults to "https://github.com/sonofspike/assisted-service-onprem.git"
 # ocp_ai_service_branch: defaults to "a55b218e3176ed920200c1283256337db94ae4b6"
 # ocp_ai_ansible_repo: defaults to "https://github.com/sonofspike/cluster_mgnt_roles.git"
-# ocp_ai_ansible_branch: defaults to "ccb34826a671f6c3435869303b6abb538638252b"
+# ocp_ai_ansible_branch: defaults to "9051f7da86fa90f9b60c1b09414dabeaf7d58fb7"
 
 ocp_ai_bm_bridge_master_mac_prefix: 3c:fd:fe:78:ab:0
 ocp_ai_bm_bridge_worker_mac_prefix: 3c:fd:fe:78:ab:1


### PR DESCRIPTION
Moving us to latest Son of Spike `cluster_mgnt_roles` to get the past few months' fixes.  Tested twice in my environment.