### PR TITLE
Drop director_operator_version (use csv_version instead)

### DIFF
--- a/ansible/templates/osp-director-operator/catalogsource.yaml.j2
+++ b/ansible/templates/osp-director-operator/catalogsource.yaml.j2
@@ -5,4 +5,4 @@ metadata:
   namespace: {{ namespace }}
 spec:
   sourceType: grpc
-  image: {{ director_operator_image }}-index:{{ director_operator_version }}
+  image: {{ director_operator_image }}-index:{{ csv_version }}

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -83,7 +83,7 @@ watch_namespace: openstack,openshift-machine-api,openshift-sriov-network-operato
 
 # osp-director-operator image and tag to use
 director_operator_image: quay.io/openstack-k8s-operators/osp-director-operator
-director_operator_version: 0.0.1
+# CSV version is used for both the CSV version and container image tag
 csv_version: 0.0.1
 
 #ocp_network_type: OVNKubernetes


### PR DESCRIPTION
As far as I know we always set the tag name to match the CSV version
in our development environments.