### PR TITLE
AI and IPI use same image server URLs

### DIFF
--- a/ansible/datavolume.yaml
+++ b/ansible/datavolume.yaml
@@ -14,7 +14,7 @@
 
   - name: Set path to RHEL base image for assisted installer
     set_fact:
-      osp_controller_base_image_url_path: "{{ ocp_ai_http_store_dir | default('/opt/http_store/data', true) }}/{{ osp_controller_base_image_url | basename }}"
+      osp_controller_base_image_url_path: "/opt/http_store/data/images/{{ osp_controller_base_image_url | basename }}"
     when: ocp_ai|bool
 
   # NOTE: we copy this to the Ironic images directory to reuse it for

--- a/ansible/ocp_ai.yaml
+++ b/ansible/ocp_ai.yaml
@@ -16,7 +16,7 @@
     become_user: ocp
     block:
     - name: Delete existing AI cluster (if any)
-      command: "aicli -U http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_service_port | default('8090', true) }} delete cluster {{ ocp_cluster_name }}"
+      command: "aicli -U http://192.168.111.1:{{ ocp_ai_service_port | default('8090', true) }} delete cluster {{ ocp_cluster_name }}"
       environment:
         PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin
       register: delete_ai_cluster
@@ -32,9 +32,9 @@
         msg: |
           Executing the assisted installer playbook. You can tail the logs at {{ base_path }}/ai.log on
           the host for progress.  Furthermore, you can view the assisted installer console by entering the
-          URL http://{{ ocp_ai_bm_ip }}:8888/clusters/.  If you do not have direct access to that IP from
+          URL http://192.168.111.1:8888/clusters/.  If you do not have direct access to that IP from
           your browser, you can use a tool like "sshuttle" to provide connectivity like so:
-          sshuttle --dns -r <user>@<cluster host> {{ ocp_ai_bm_bridge_cidr }}.  You would then hit this
+          sshuttle --dns -r <user>@<cluster host> 192.168.111.0/24.  You would then hit this
           URL in your browser: http://<cluster host>:8888/clusters/
 
     - name: Run the assisted installer playbook
@@ -47,8 +47,8 @@
 
     - name: Download assisted installer cluster kubeconfig and kubeadmin password
       shell: |
-        aicli -U http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_service_port | default('8090', true) }} download kubeconfig {{ ocp_cluster_name }}
-        aicli -U http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_service_port | default('8090', true) }} download kubeadmin-password {{ ocp_cluster_name }}
+        aicli -U http://192.168.111.1:{{ ocp_ai_service_port | default('8090', true) }} download kubeconfig {{ ocp_cluster_name }}
+        aicli -U http://192.168.111.1:{{ ocp_ai_service_port | default('8090', true) }} download kubeadmin-password {{ ocp_cluster_name }}
       args:
         chdir: "{{ base_path }}/cluster_mgnt_roles"
       environment:

--- a/ansible/ocp_ai_destroy.yaml
+++ b/ansible/ocp_ai_destroy.yaml
@@ -112,7 +112,7 @@
 
   - name: Set path to RHEL base image for assisted installer
     set_fact:
-      osp_controller_base_image_url_path: "{{ ocp_ai_http_store_dir | default('/opt/http_store/data', true) }}/{{ osp_controller_base_image_url | basename }}"
+      osp_controller_base_image_url_path: "/opt/http_store/data/images/{{ osp_controller_base_image_url | basename }}"
 
   - name: Delete {{ osp_controller_base_image_url_path }}
     file:

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -24,6 +24,7 @@
       extra_args: "--user"
       executable: /usr/bin/pip-3
 
+
   ### ADDITIONAL SET-FACTS
 
   - name: Set fact for full cluster name
@@ -33,15 +34,11 @@
   # TODO: Add support for ipv6 for this and the following set_facts
   - name: Set fact for BM CIDR prefix
     set_fact:
-      ocp_ai_bm_cidr_prefix: "{{ ((ocp_ai_bm_bridge_cidr.split('.'))[0:3])|join('.') }}"
+      ocp_ai_bm_cidr_prefix: "192.168.111"
 
   - name: Set fact for reverse BM CIDR suffix
     set_fact:
-      ocp_ai_bm_cidr_rev_suffix: "{{ ((ocp_ai_bm_bridge_cidr.split('.'))[:-1]|join('.')|ipaddr('revdns'))[2:-1] }}"
-
-  - name: Set fact for provisioning CIDR prefix
-    set_fact:
-        ocp_ai_pr_cidr_prefix: "{{ ((ocp_ai_bm_bridge_cidr.split('.'))[0:3])|join('.') }}"
+      ocp_ai_bm_cidr_rev_suffix: "111.168.192"
 
 
   ### BRIDGES
@@ -96,7 +93,7 @@
           autoconnect: yes
           stp: off
           # TODO: Support any netmask?
-          ip4: "{{ ocp_ai_bm_ip }}/24"
+          ip4: "192.168.111.1/24"
           state: present
 
       - name: Create provisioning bridge
@@ -107,7 +104,7 @@
           autoconnect: yes
           stp: off
           # TODO: Support any netmask?
-          ip4: "{{ ocp_ai_pr_ip }}/24"
+          ip4: "172.22.0.1/24"
           state: present
 
       - name: Reload bridges
@@ -147,7 +144,7 @@
         immediate: yes
       with_items:
         - 8000
-        - "{{ ocp_ai_http_store_port | default(8081, true) }}"
+        - 80
         - "{{ ocp_ai_sushy_port | default(8082, true) }}"
         - "{{ ocp_ai_service_port | default(8090, true) }}"
         - 8888
@@ -206,7 +203,7 @@
     block:
     - name: Create HTTP server storage directory
       file:
-        path: "{{ ocp_ai_http_store_dir | default('/opt/http_store/data', true) }}"
+        path: /opt/http_store/data/images
         state: directory
         mode: '0777'
 
@@ -217,9 +214,9 @@
         state: started
         restart: yes
         ports:
-          - "{{ ocp_ai_http_store_port | default(8081, true) }}:8080"
+          - "80:8080"
         volumes:
-          - "{{ ocp_ai_http_store_dir | default('/opt/http_store/data', true) }}:/var/www/html:z"
+          - "/opt/http_store/data:/var/www/html:z"
 
 
   ### DNSMASQ
@@ -508,7 +505,7 @@
       replace:
         path: "{{ base_path }}/assisted-service-onprem/onprem-environment"
         regexp: 'SERVICE_BASE_URL=.*'
-        replace: 'SERVICE_BASE_URL=http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_service_port | default("8090", true) }}'
+        replace: 'SERVICE_BASE_URL=http://192.168.111.1:{{ ocp_ai_service_port | default("8090", true) }}'
 
     - name: Set assisted installer service OCP release image
       replace:
@@ -534,7 +531,7 @@
 
     - name: Wait until the assisted installer service is fully available
       shell: |
-        aicli -U http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_service_port | default('8090', true) }} list cluster
+        aicli -U http://192.168.111.1:{{ ocp_ai_service_port | default('8090', true) }} list cluster
       register: assisted_service_ready
       until: '"Dns Domain" in assisted_service_ready.stdout'
       retries: 60

--- a/ansible/templates/ai/cluster_mgnt_roles/inventory.ospd.j2
+++ b/ansible/templates/ai/cluster_mgnt_roles/inventory.ospd.j2
@@ -11,7 +11,7 @@ cluster_name="{{ ocp_cluster_name }}"
 base_dns_domain="{{ ocp_domain_name | default('test.metalkube.org', true) }}"
 
 # Available subnets *
-machine_network_cidr="{{ ocp_ai_bm_bridge_cidr }}"
+machine_network_cidr="192.168.111.0/24"
 
 # Allocate virtual IPs via DHCP server
 vip_dhcp_allocation=False
@@ -53,7 +53,7 @@ openshift_version="{{ ocp_version }}"
 # Discovery ISO
 discovery_iso_name="discovery_image_{{ ocp_cluster_name }}.iso"
 # HTTP server where the ISO is stored
-discovery_iso_server="http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_http_store_port | default('8081', true) }}"
+discovery_iso_server="http://192.168.111.1/images"
 
 # Parameters for a Restricted Network installation
 use_mirror= False
@@ -61,11 +61,11 @@ mirror_certificate="NA"
 mirror_registry=NA:5000
 
 [services]
-assisted_installer host={{ ocp_ai_bm_ip }} port={{ ocp_ai_service_port | default('8090', true) }}
-http_store host={{ ocp_ai_bm_ip }} port={{ ocp_ai_http_store_port | default('8081', true) }}
+assisted_installer host=192.168.111.1 port={{ ocp_ai_service_port | default('8090', true) }}
+http_store host=192.168.111.1 port=80
 
 [bastions]
-bastion ansible_ssh_user=root ansible_ssh_host={{ ocp_ai_bm_ip }}
+bastion ansible_ssh_user=root ansible_ssh_host=192.168.111.1
 
 [bastions:vars]
 ansible_connection=local
@@ -79,7 +79,7 @@ ansible_connection=local
 # Master nodes
 [masters]
 {% for i in range(0, ocp_num_masters) %}
-{{ ocp_cluster_name }}-master-{{ i }} bmc_address={{ ocp_ai_bm_ip }}:{{ ocp_ai_sushy_port | default('8082', true) }} mac={{ ocp_ai_bm_bridge_master_mac_prefix }}{{ i }} ip={{ ocp_ai_bm_cidr_prefix }}.1{{ i }}
+{{ ocp_cluster_name }}-master-{{ i }} bmc_address=192.168.111.1:{{ ocp_ai_sushy_port | default('8082', true) }} mac={{ ocp_ai_bm_bridge_master_mac_prefix }}{{ i }} ip={{ ocp_ai_bm_cidr_prefix }}.1{{ i }}
 {% endfor %}
 
 [masters:vars]
@@ -88,13 +88,13 @@ vendor=KVM
 bmc_user=USERID
 bmc_password=PASSW0RD
 mask=24
-gateway={{ ocp_ai_bm_ip }}
-dns={{ ocp_ai_bm_ip }}
+gateway=192.168.111.1
+dns=192.168.111.1
 
 # Worker nodes
 [workers]
 {% for i in range(0, ocp_num_workers) %}
-{{ ocp_cluster_name }}-worker-{{ i }} bmc_address={{ ocp_ai_bm_ip }}:{{ ocp_ai_sushy_port | default('8082', true) }} mac={{ ocp_ai_bm_bridge_worker_mac_prefix }}{{ i }} ip={{ ocp_ai_bm_cidr_prefix }}.2{{ i }}
+{{ ocp_cluster_name }}-worker-{{ i }} bmc_address=192.168.111.1:{{ ocp_ai_sushy_port | default('8082', true) }} mac={{ ocp_ai_bm_bridge_worker_mac_prefix }}{{ i }} ip={{ ocp_ai_bm_cidr_prefix }}.2{{ i }}
 {% endfor %}
 
 [workers:vars]
@@ -103,5 +103,5 @@ vendor=KVM
 bmc_user=USERID
 bmc_password=PASSW0RD
 mask=24
-gateway={{ ocp_ai_bm_ip }}
-dns={{ ocp_ai_bm_ip }}
+gateway=192.168.111.1
+dns=192.168.111.1

--- a/ansible/templates/ai/cluster_mgnt_roles/run_playbook.sh.j2
+++ b/ansible/templates/ai/cluster_mgnt_roles/run_playbook.sh.j2
@@ -2,4 +2,4 @@
 exec 3>&1 4>&2
 trap 'exec 2>&4 1>&3' 0 1 2 3
 exec 1>{{ base_path }}/ai.log 2>&1
-ansible-playbook -i inventory.ospd deploy_cluster.yml
+ansible-playbook -i inventory.ospd deploy_cluster.yml -e DOWNLOAD_DEST_PATH=/opt/http_store/data/images

--- a/ansible/templates/ai/dnsmasq/dnsmasq.conf.j2
+++ b/ansible/templates/ai/dnsmasq/dnsmasq.conf.j2
@@ -21,19 +21,19 @@ interface=cni-podman0
 bind-interfaces
 
 #### DHCP (dnsmasq --help dhcp)
-dhcp-range={{ ocp_ai_bm_bridge_dhcp_range }},24h
+dhcp-range=192.168.111.6,192.168.111.100,24h
 dhcp-option=option:netmask,255.255.255.0
-dhcp-option=option:router,{{ ocp_ai_bm_ip }}
-dhcp-option=option:dns-server,{{ ocp_ai_bm_ip }}
-dhcp-option=option:ntp-server,{{ ocp_ai_bm_ip }}
+dhcp-option=option:router,192.168.111.1
+dhcp-option=option:dns-server,192.168.111.1
+dhcp-option=option:ntp-server,192.168.111.1
 
 
 # Provisioning node
-address=/provisioning.{{ ocp_ai_full_cluster_name }}/{{ ocp_ai_bm_ip }}
+address=/provisioning.{{ ocp_ai_full_cluster_name }}/192.168.111.1
 ptr-record=1.{{ ocp_ai_bm_cidr_rev_suffix }},provisioning.{{ ocp_ai_full_cluster_name }}
 
 # Cluster ntp-server
-address=/ntp-server.{{ ocp_ai_full_cluster_name }}/{{ ocp_ai_bm_ip }}
+address=/ntp-server.{{ ocp_ai_full_cluster_name }}/192.168.111.1
 ptr-record=1.{{ ocp_ai_bm_cidr_rev_suffix }},ntp-server.{{ ocp_ai_full_cluster_name }}
 
 # External API endpoint (External VIP)

--- a/ansible/templates/ai/dnsmasq/resolv.conf.j2
+++ b/ansible/templates/ai/dnsmasq/resolv.conf.j2
@@ -1,1 +1,1 @@
-nameserver {{ ocp_ai_bm_ip }}
+nameserver 192.168.111.1

--- a/ansible/templates/ai/metal3/extra_workers_bmhs.yml.j2
+++ b/ansible/templates/ai/metal3/extra_workers_bmhs.yml.j2
@@ -20,7 +20,7 @@ spec:
   online: false
   bootMACAddress: {{ ocp_ai_prov_bridge_worker_mac_prefix }}{{ i }}
   bmc:
-    address: redfish+http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_sushy_port | default('8082', true) }}/redfish/v1/Systems/{{ extra_worker_uuids.results[i].stdout }}
+    address: redfish+http://192.168.111.1:{{ ocp_ai_sushy_port | default('8082', true) }}/redfish/v1/Systems/{{ extra_worker_uuids.results[i].stdout }}
     credentialsName: openshift-worker-{{ i }}-bmc-secret
   hardwareProfile: unknown
   bootMode: legacy

--- a/ansible/templates/ai/metal3/provisioning.yml.j2
+++ b/ansible/templates/ai/metal3/provisioning.yml.j2
@@ -5,9 +5,9 @@ metadata:
   - provisioning.metal3.io
   name: provisioning-configuration
 spec:
-  provisioningDHCPRange: {{ ocp_ai_pr_bridge_dhcp_range }}
-  provisioningIP: {{ ((ocp_ai_pr_bridge_cidr.split('.'))[0:3])|join('.') }}.3
+  provisioningDHCPRange: 172.22.0.10,172.22.0.254
+  provisioningIP: 172.22.0.3
   provisioningInterface: enp2s0
   provisioningNetwork: Managed
-  provisioningNetworkCIDR: {{ ocp_ai_pr_bridge_cidr }}
+  provisioningNetworkCIDR: 172.22.0.0/24
   

--- a/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
+++ b/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
@@ -11,11 +11,7 @@ spec:
   # How many nodes to provision
   count: {{ osp_compute_count }}
   # The image to install on the provisioned nodes
-{% if not (ocp_ai|bool) %}
-  baseImageUrl: http://172.22.0.1/images/{{ osp_controller_base_image_url | basename }}
-{% else %}
-  baseImageUrl: http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_http_store_port | default('8081', true) }}/{{ osp_controller_base_image_url | basename }}
-{% endif %}
+  baseImageUrl: http://192.168.111.1/images/{{ osp_controller_base_image_url | basename }}
   provisionServerName: openstack
   # The secret containing the SSH pub key to place on the provisioned nodes
   deploymentSSHSecret: osp-controlplane-ssh-keys

--- a/ansible/templates/osp/compute/openstackprovisionserver.yaml.j2
+++ b/ansible/templates/osp/compute/openstackprovisionserver.yaml.j2
@@ -5,8 +5,4 @@ metadata:
   namespace: openstack
 spec:
   port: 8080
-{% if not (ocp_ai|bool) %}
-  baseImageUrl: http://172.22.0.1/images/{{ osp_controller_base_image_url | basename }}
-{% else %}
-  baseImageUrl: http://{{ ocp_ai_bm_ip }}:{{ ocp_ai_http_store_port | default('8081', true) }}/{{ osp_controller_base_image_url | basename }}
-{% endif %}
+  baseImageUrl: http://192.168.111.1/images/{{ osp_controller_base_image_url | basename }}

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -17,19 +17,9 @@ ocp_ai_bm_bridge_worker_mac_prefix: 3c:fd:fe:78:ab:1
 ocp_ai_prov_bridge_master_mac_prefix: 3c:fd:fe:78:cd:0
 ocp_ai_prov_bridge_worker_mac_prefix: 3c:fd:fe:78:cd:1
 
-ocp_ai_bm_bridge_cidr: 192.168.111.0/24 # NOTE: Must currently end in /24
-ocp_ai_bm_bridge_dhcp_range: 192.168.111.6,192.168.111.100 # NOTE: Must leave .2, .3 and .4 outside the range
-ocp_ai_pr_bridge_cidr: 172.22.0.0/24 # NOTE: Must currently end in /24
-ocp_ai_pr_bridge_dhcp_range: 172.22.0.10,172.22.0.254
-ocp_ai_bm_ip: "{{ (ocp_ai_bm_bridge_cidr.split('.')[0:3]|join('.')) }}.1"
-ocp_ai_pr_ip: "{{ (ocp_ai_pr_bridge_cidr.split('.')[0:3]|join('.')) }}.1"
-
 # ocp_ai_sushy_port: defaults to "8082"
 
 # ocp_ai_service_store_dir: defaults to "/opt/assisted-service"
 # ocp_ai_service_port: defaults to "8090"
-
-# ocp_ai_http_store_dir: defaults to "/opt/http_store/data"
-# ocp_ai_http_store_port: defaults to "8081"
 
 ocp_ai_libvirt_storage_dir: /var/lib/libvirt/images


### PR DESCRIPTION
Consolidates AI and IPI deployments to use the same URL structure for RHEL image locations.  In doing so, AI no longer supports customizable provisioning and baremetal network CIDRs, and instead uses the same forced defaults of the IPI dev-scripts approach.