### PR TITLE
Run openstack_cleanup on destroy_ocp

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -179,6 +179,7 @@ nfs_cleanup: hosts
 	 rm \$$temp"
 
 destroy_ocp: hosts local-defaults.yaml
+	$(MAKE) openstack_cleanup
 	ANSIBLE_FORCE_COLOR=true ansible-playbook -i hosts -e @local-defaults.yaml \
 	ocp_installer_destroy.yaml
 	$(MAKE) nfs_cleanup


### PR DESCRIPTION
When CI runs and only performs destroy_ocp there are left overs
of the previous playbook rendering. Run openstack_cleanup as
part of destroy_ocp to first gracefully cleanup OSP before
destroying the OCP cluster.