### PR TITLE
Enable additional tempest features

### DIFF
--- a/ansible/templates/tempest/tempest_script.sh.j2
+++ b/ansible/templates/tempest/tempest_script.sh.j2
@@ -35,9 +35,22 @@ $TEMPESTCONF \
   --debug \
   --create \
   --network-id ${PUB_NETWORK_ID} \
+{% if tempest_disable_feature_dict is defined and tempest_disable_feature_dict|length %}
+  --remove \
+{% for component, features in tempest_disable_feature_dict.items() %}
+{% for feature, setting in features.items() %}
+  {{ component }}.{{ feature }} {{ setting }} \
+{% endfor %}
+{% endfor %}
+{% endif %}
+{% if tempest_enable_feature_dict is defined and tempest_enable_feature_dict|length %}
+{% for component, features in tempest_enable_feature_dict.items() %}
+{% for feature, setting in features.items() %}
+  {{ component }}.{{ feature }} {{ setting }} \
+{% endfor %}
+{% endfor %}
+{% endif %}
   object-storage.reseller_admin ResellerAdmin
-
-crudini --set /var/lib/tempest/tempest_workspace/etc/tempest.conf compute-feature-enabled vnc_console true
 
 tempest cleanup --init-saved-state
 

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -98,6 +98,20 @@ tempest_timeout: 3600
 # run smoketest
 tempest_smoketest: false
 
+# enable specific tempest features
+tempest_enable_feature_dict:
+  compute-feature-enabled:
+    vnc_console: true
+    live_migration: true
+    block_migration_for_live_migration: true
+    volume_backed_live_migration: true
+    console_output: true
+
+# disable specific tempest features
+#tempest_disable_feature_dict:
+#  compute-feature-enabled:
+#    vnc_console: false
+
 # specify tempest tests to run
 tempest_test_dict:
   regex: '(?!.*\[.*\bslow\b.*\])(^tempest\.(api|scenario))'
@@ -137,7 +151,7 @@ osp_container_tag: 16.2_20210707.1
 osp_ceph_image: ceph-4.2-rhel-8
 
 # number of OCP worker nodes should be OSP compute hosts
-osp_compute_count: 1
+osp_compute_count: 2
 # if false nfs is used for glance
 osp_compute_hci: false
 # number of OSD disks per compute node


### PR DESCRIPTION
This allows to enable/disable tempest features using
tempest_enable_feature_dict and tempest_disable_feature_dict.

It also:
* enables the following compute-feature-enabled features
in our default vars file: vnc_console, live_migration,
block_migration_for_live_migration, volume_backed_live_migration
and console_output
* deployes 2 OSP compute nodes per default that live migration
tests can be done.