### PR TITLE
Update our ConfigMap cleanups

### DIFF
--- a/ansible/openstack_cleanup.yaml
+++ b/ansible/openstack_cleanup.yaml
@@ -18,7 +18,7 @@
       - "oc delete -n openstack openstackplaybookgenerator --all"
       - "oc delete -n openstack openstackephemeralheat --all"
       - "oc delete -n openstack openstackclient --all"
-      - "oc delete -n openstack cm tripleo-deploy-config tripleo-deploy-config-custom tripleo-tarball-config --ignore-not-found=true"
+      - "oc delete -n openstack cm tripleo-deploy-config heat-env-config tripleo-tarball-config --ignore-not-found=true"
 
   - name: delete playbooks git repo dir
     become: true


### PR DESCRIPTION
The name of tripleo-deploy-config-custom is now heat-env-config.

Also, includes the tripleo-passwords CM in the cleanup.