### PR TITLE
cleanup discovery images on ocp destroy

### DIFF
--- a/ansible/ocp_ai_destroy.yaml
+++ b/ansible/ocp_ai_destroy.yaml
@@ -118,3 +118,10 @@
     file:
       path: "{{ osp_controller_base_image_url_path }}"
       state: absent
+
+  - name: Delete dicovery images
+    file:
+      path:
+      state: absent
+    with_fileglob:
+    - "/var/lib/libvirt/images/discovery_image_ostest*.img"


### PR DESCRIPTION
ci system was running out of disk space because of this