### PR TITLE
Temp workaround for SoS and AI conflict

### DIFF
--- a/ansible/ocp_ai.yaml
+++ b/ansible/ocp_ai.yaml
@@ -90,7 +90,7 @@
       dest: "/tmp/openshift-client-linux.tar.gz"
       mode: '0755'
       timeout: 30
-      when: ocp_version < 4.8
+    when: ocp_version < 4.8
 
   # FIXME: remove when 4.8 is hosted in the format above
   - name: Get the ocp client tar gunzip file 4.8
@@ -99,7 +99,7 @@
       dest: "/tmp/openshift-client-linux.tar.gz"
       mode: '0755'
       timeout: 30
-      when: ocp_version == 4.8
+    when: ocp_version == 4.8
 
   - name: "Untar the openshift-client-linux.tar.gz"
     unarchive:

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -481,7 +481,7 @@
         repo: "{{ ocp_ai_service_repo | default('https://github.com/sonofspike/assisted-service-onprem.git', true) }}"
         dest: "{{ base_path }}/assisted-service-onprem"
         force: yes
-        version: "{{ ocp_ai_service_branch | default('a55b218e3176ed920200c1283256337db94ae4b6', true) }}"
+        version: "{{ ocp_ai_service_branch | default('feb00ba10823ab04ec489a05ce8eb543ec688fda', true) }}"
 
     - name: Create assisted installer service storage directory
       file:
@@ -564,6 +564,16 @@
         dest: "{{ base_path }}/cluster_mgnt_roles"
         force: true
         version: "{{ ocp_ai_ansible_branch | default('9051f7da86fa90f9b60c1b09414dabeaf7d58fb7', true) }}"
+
+    # HACK: Remove old, bad logic from SoS so that it works with latest AI service (we never needed it anyhow)
+    # Once this logic is fixed upstream in SoS, we can remove this task
+    - name: Remove problematic SoS create-cluster logic
+      replace:
+        path: "{{ base_path }}/cluster_mgnt_roles/create_cluster/tasks/main.yml"
+        after: '##### TO REMOVE ####'
+        before: '#TODO: Apply manifests before cluster installation'
+        regexp: '^(.+)$'
+        replace: '# \1'
 
     - name: Add schedulable-master manifest
       block:

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -8,7 +8,7 @@ ocp_ai_external_dns:
   - 10.5.30.160
 
 # ocp_ai_service_repo: defaults to "https://github.com/sonofspike/assisted-service-onprem.git"
-# ocp_ai_service_branch: defaults to "a55b218e3176ed920200c1283256337db94ae4b6"
+# ocp_ai_service_branch: defaults to "feb00ba10823ab04ec489a05ce8eb543ec688fda"
 # ocp_ai_ansible_repo: defaults to "https://github.com/sonofspike/cluster_mgnt_roles.git"
 # ocp_ai_ansible_branch: defaults to "9051f7da86fa90f9b60c1b09414dabeaf7d58fb7"
 


### PR DESCRIPTION
Temporary workaround for AI deployments that removes Son of Spike logic that is incompatible with the latest version of the `assisted-service`.  We did not need the problematic SoS functionality anyhow.