### PR TITLE
Add retry for image reg availability

### DIFF
--- a/ansible/ocp_image_registry.yaml
+++ b/ansible/ocp_image_registry.yaml
@@ -77,3 +77,7 @@
     environment:
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"
+    register: image_registry_available
+    until: image_registry_available is not failed
+    retries: "{{ (default_timeout / 5)|int }}"
+    delay: 5


### PR DESCRIPTION
Sometimes the check for image registry availability fails temporarily right after the deployment has finished.  Let's add a retry to give the `wait` condition a few chances to succeed.