### PR TITLE
Clean AI podman images

### DIFF
--- a/ansible/ocp_ai_destroy.yaml
+++ b/ansible/ocp_ai_destroy.yaml
@@ -119,9 +119,13 @@
       path: "{{ osp_controller_base_image_url_path }}"
       state: absent
 
-  - name: Delete dicovery images
+  - name: Delete discovery images
     file:
       path:
       state: absent
     with_fileglob:
     - "/var/lib/libvirt/images/discovery_image_ostest*.img"
+
+  - name: Delete AI podman images
+    shell: |
+      for i in $(podman images | grep -E '(assisted-service|ocp-metal-ui)' | awk {'print $3'}); do podman rmi $i; done


### PR DESCRIPTION
Removes AI container images during `make destroy_ocp` to ensure the next run always has the latest images