### PR TITLE
Workaround to avoid latest AI image auth issues

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -495,6 +495,13 @@
         regexp: 'OAS_HOSTDIR=.*'
         replace: 'OAS_HOSTDIR={{ ocp_ai_service_store_dir | default("/opt/assisted-service", true) }}'
 
+    # FIXME: Remove once AI team fixes the issue mentioned here
+    - name: Use older version of assisted-service image to avoid auth bug from 8/12/2021
+      replace:
+        path: "{{ base_path }}/assisted-service-onprem/start-assisted-service.sh"
+        regexp: 'OAS_IMAGE=.*'
+        replace: 'OAS_IMAGE=quay.io/ocpmetal/assisted-service:stable.10.08.2021-22.10'
+
     - name: Set assisted installer service discovery ISO location
       replace:
         path: "{{ base_path }}/assisted-service-onprem/start-assisted-service.sh"


### PR DESCRIPTION
A change was introduced to the `assisted-service` AI image on 8/12/2021 that broken authentication for on-prem clusters.  This is a temporary workaround that will make us use an image from 8/10/2021 to avoid the bug.