### PR TITLE
Default to OCP 4.7 while NMState broken in 4.8

### DIFF
--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -4,8 +4,8 @@ base_path: /home/ocp
 #dev_scripts_branch: defaults to "HEAD"
 
 # To set a specific release to install.
-ocp_version: 4.8
-ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.8.2-x86_64
+ocp_version: 4.7
+ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.7.9-x86_64
 ocp_release_type: ga
 
 # If set to true:
@@ -76,10 +76,10 @@ kustomize_version: v4.0.1
 kuttl_version: 0.9.0
 
 # SRIOV network operator version (usually should correspond to X.X release)
-sriov_version: 4.8
+sriov_version: 4.7
 
 # Performance addon operator version (usually should correspond to X.X release)
-perf_version: 4.8
+perf_version: 4.7
 
 # CNV addon operator version (usually should correspond to X.X release)
 cnv_hyperconverged_operator_version: 2.6.2

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -1,5 +1,5 @@
 ---
-ocp_ai_discovery_iso: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.2/rhcos-live.x86_64.iso
+ocp_ai_discovery_iso: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.0/rhcos-live.x86_64.iso
 
 # this address needs to be reachable from IPMI/iDRAC if BM worker is used 
 ocp_ai_discovery_iso_server: 192.168.111.1


### PR DESCRIPTION
4.8 NMState is currently broken, which in turn prevents us from setting up NNCPs.  Without NNCPs, the controllers do not have proper connectivity, so overcloud deployments always fail.  Default to OCP 4.7 to avoid this for now.