### PR TITLE
Director image cleanup task

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -105,6 +105,11 @@ openstack_cleanup: hosts local-defaults.yaml
 	-i hosts -e @local-defaults.yaml \
 	openstack_cleanup.yaml
 
+director_image_cleanup: hosts local-defaults.yaml
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-i hosts -e @local-defaults.yaml \
+	director_image_cleanup.yaml
+
 networks: hosts local-defaults.yaml
 	# NOTE: requires 'make olm'
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \

--- a/ansible/director_image_cleanup.yaml
+++ b/ansible/director_image_cleanup.yaml
@@ -1,0 +1,20 @@
+---
+- hosts: localhost
+  vars_files: vars/default.yaml
+  roles:
+  - oc_local
+
+  tasks:
+
+  #NOTE: this is a bit risky as it just greps for director. But I've not hit an issue yet.
+  - name: director image cleanup
+    ignore_errors: true
+    shell: >
+      {% raw %}
+      for worker in $(oc get nodes -o name); do
+        oc debug $worker -T -- chroot /host sh -c "podman images --format 'table {{ .ID }} {{ .Repository }}:{{ .Tag }}' | grep director | cut -f 1 -d ' ' | xargs -r podman rmi -f"
+      done
+      {% endraw %}
+    environment:
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"


### PR DESCRIPTION
Cleans the local image cache of the director images
on each OC node.