### PR TITLE
Use ocp_version and ocp_minor_version

### DIFF
--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -5,7 +5,8 @@ base_path: /home/ocp
 
 # To set a specific release to install.
 ocp_version: 4.7
-ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.7.9-x86_64
+ocp_minor_version: 9
+ocp_release_image: "quay.io/openshift-release-dev/ocp-release:{{ ocp_version }}.{{ ocp_minor_version }}-x86_64"
 ocp_release_type: ga
 
 # If set to true:
@@ -76,10 +77,10 @@ kustomize_version: v4.0.1
 kuttl_version: 0.9.0
 
 # SRIOV network operator version (usually should correspond to X.X release)
-sriov_version: 4.7
+sriov_version: "{{ ocp_version }}"
 
 # Performance addon operator version (usually should correspond to X.X release)
-perf_version: 4.7
+perf_version: "{{ ocp_version }}"
 
 # CNV addon operator version (usually should correspond to X.X release)
 cnv_hyperconverged_operator_version: 2.6.2

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -1,5 +1,5 @@
 ---
-ocp_ai_discovery_iso: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.0/rhcos-live.x86_64.iso
+ocp_ai_discovery_iso: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{{ ocp_version }}/latest/rhcos-live.x86_64.iso"
 
 # this address needs to be reachable from IPMI/iDRAC if BM worker is used 
 ocp_ai_discovery_iso_server: 192.168.111.1


### PR DESCRIPTION
Use of ocp_version and ocp_minor_version allows CI to easily
use different ocp releases without putting too much logic in
the CI job definition. Also use latest rhcos-live image from the
particular release.