### PR TITLE
Enable fencing only on 17.0 and add apiversion parameter

### DIFF
--- a/ansible/templates/osp/tripleo_fencing_overrides.yaml.j2
+++ b/ansible/templates/osp/tripleo_fencing_overrides.yaml.j2
@@ -40,12 +40,6 @@
       regexp: '^sys.path.append\("@FENCEAGENTSLIBDIR@"\)'
       line: 'sys.path.append("/usr/share/fence")'
 
-  - name: Replace Kubevirt API version in Kubevirt fencing agent code
-    lineinfile:
-      path: "/usr/sbin/fence_kubevirt"
-      regexp: "^API_VERSION='kubevirt.io/v1'"
-      line: "API_VERSION='kubevirt.io/v1alpha3'"
-
   - name: Copy kubeconfig from openstackclient
     copy:
       src: "/home/cloud-admin/kubeconfig"
@@ -59,6 +53,9 @@
       set -x
       if ! curl https://review.opendev.org/changes/openstack%2Fpuppet-pacemaker~806924/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -R -s -f --dry-run -d /usr/share/openstack-puppet/modules/pacemaker -p1; then
         curl https://review.opendev.org/changes/openstack%2Fpuppet-pacemaker~806924/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -d /usr/share/openstack-puppet/modules/pacemaker -b -z .orig -p1
+      fi
+      if ! curl https://review.opendev.org/changes/openstack%2Fpuppet-pacemaker~807299/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -R -s -f --dry-run -d /usr/share/openstack-puppet/modules/pacemaker -p1; then
+        curl https://review.opendev.org/changes/openstack%2Fpuppet-pacemaker~807299/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -d /usr/share/openstack-puppet/modules/pacemaker -b -z .orig -p1
       fi
       if ! curl https://review.opendev.org/changes/openstack%2Fpuppet-tripleo~806926/revisions/2/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -R -s -f --dry-run -d /usr/share/openstack-puppet/modules/tripleo -p1; then
         curl https://review.opendev.org/changes/openstack%2Fpuppet-tripleo~806926/revisions/2/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -d /usr/share/openstack-puppet/modules/tripleo -b -z .orig -p1

--- a/ansible/templates/osp/tripleo_heat_envs/17.0/fencing.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/17.0/fencing.yaml.j2
@@ -11,6 +11,7 @@ parameter_defaults:
         host_mac: {{ ctrl_vm_macs.stdout_lines[loop.index-1] }}
         params:
           plug: {{ vm_name }}
+          apiversion: kubevirt.io/v1alpha3
           namespace: openstack
           ssl_insecure: true
           power_timeout: 30


### PR DESCRIPTION
only enable fence_kubevirt in 17.0 environments, also add
apiserver support which got added to the fencing agent via:

https://github.com/ClusterLabs/fence-agents/pull/433