### PR TITLE
Align network deployment parameters

### DIFF
--- a/ansible/templates/osp/tripleo_heat_envs/16.2/flat/network-environment.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/16.2/flat/network-environment.yaml.j2
@@ -6,8 +6,3 @@ parameter_defaults:
   EC2MetadataIp: 192.168.25.1
   ControlPlaneDefaultRoute: 192.168.25.1
   NeutronPublicInterface: eth1
-  NtpServer:
-    - clock.redhat.com
-    - clock2.redhat.com
-  DnsServers:
-    - 192.168.25.1

--- a/ansible/templates/osp/tripleo_heat_envs/16.2/network-environment.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/16.2/network-environment.yaml.j2
@@ -23,11 +23,6 @@ parameter_defaults:
   ControlPlaneSubnetCidr: '24'
   NeutronGlobalPhysnetMtu: 1350
   NeutronPublicInterface: nic3
-  NtpServer:
-    - clock.redhat.com
-    - clock2.redhat.com
-  DnsServers:
-    - 192.168.25.1
   NeutronBridgeMappings: datacentre:br-ex,tenant:br-isolated
   NeutronExternalNetworkBridge: br-ex
   NeutronNetworkType: geneve

--- a/ansible/templates/osp/tripleo_heat_envs/17.0/network-environment.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/17.0/network-environment.yaml.j2
@@ -1,11 +1,6 @@
 parameter_defaults:
   PublicVirtualFixedIPs: [{ "ip_address": "10.0.0.5" }]
   NeutronPublicInterface: nic3
-  NtpServer:
-    - clock.redhat.com
-    - clock2.redhat.com
-  DnsServers:
-    - 192.168.25.1
   NeutronBridgeMappings: datacentre:br-ex,tenant:br-isolated
   NeutronExternalNetworkBridge: br-ex
   NeutronNetworkType: geneve

--- a/ansible/templates/osp/tripleo_heat_envs/17.0/network-environment.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/17.0/network-environment.yaml.j2
@@ -1,27 +1,5 @@
 parameter_defaults:
-  ExternalNetCidr: 10.0.0.0/24
-  ExternalAllocationPools: [{"start": "10.0.0.10", "end": "10.0.0.50"}]
-  ExternalInterfaceDefaultRoute: 10.0.0.1
   PublicVirtualFixedIPs: [{ "ip_address": "10.0.0.5" }]
-  InternalApiNetCidr: 172.17.0.0/24
-  InternalApiAllocationPools: [{"start": "172.17.0.10", "end": "172.17.0.250"}]
-  # Note: in OSP17 the subnet vlan id from DeployedNetworkEnvironment has precedence
-  # InternalApiNetworkVlanID: 20
-  StorageNetCidr: 172.18.0.0/24
-  StorageAllocationPools: [{"start": "172.18.0.10", "end": "172.18.0.250"}]
-  # Note: in OSP17 the subnet vlan id from DeployedNetworkEnvironment has precedence
-  # StorageNetworkVlanID: 30
-  StorageMgmtNetCidr: 172.19.0.0/24
-  StorageMgmtAllocationPools: [{"start": "172.19.0.10", "end": "172.19.0.250"}]
-  # Note: in OSP17 the subnet vlan id from DeployedNetworkEnvironment has precedence
-  # StorageMgmtNetworkVlanID: 40
-  TenantNetCidr: 172.20.0.0/24
-  TenantAllocationPools: [{"start": "172.20.0.10", "end": "172.20.0.250"}]
-  # Note: in OSP17 the subnet vlan id from DeployedNetworkEnvironment has precedence
-  # TenantNetworkVlanID: 50
-  ControlPlaneDefaultRoute: 192.168.25.1
-  ControlPlaneSubnetCidr: '24'
-  NeutronGlobalPhysnetMtu: 1350
   NeutronPublicInterface: nic3
   NtpServer:
     - clock.redhat.com

--- a/ansible/templates/osp/tripleo_heat_envs/17.0/network-environment.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/17.0/network-environment.yaml.j2
@@ -1,5 +1,6 @@
 parameter_defaults:
   PublicVirtualFixedIPs: [{ "ip_address": "10.0.0.5" }]
+  NeutronGlobalPhysnetMtu: 1350
   NeutronPublicInterface: nic3
   NeutronBridgeMappings: datacentre:br-ex,tenant:br-isolated
   NeutronExternalNetworkBridge: br-ex

--- a/ansible/templates/osp/tripleo_heat_envs/17.0/overcloud-networks-deployed.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/17.0/overcloud-networks-deployed.yaml.j2
@@ -4,7 +4,7 @@ parameter_defaults:
     net_attributes_map:
       external:
         network:
-          dns_domain: external.localdomain.
+          dns_domain: external.{{ ocp_cluster_name }}.
           mtu: 1350
           name: external
           tags:
@@ -23,7 +23,7 @@ parameter_defaults:
             - tripleo_vlan_id=1
       internal_api:
         network:
-          dns_domain: internalapi.localdomain.
+          dns_domain: internalapi.{{ ocp_cluster_name }}.
           mtu: 1350
           name: internal_api
           tags:
@@ -42,7 +42,7 @@ parameter_defaults:
             - tripleo_vlan_id=20
       storage:
         network:
-          dns_domain: storage.localdomain.
+          dns_domain: storage.{{ ocp_cluster_name }}.
           mtu: 1350
           name: storage
           tags:
@@ -61,7 +61,7 @@ parameter_defaults:
             - tripleo_vlan_id=30
       storage_mgmt:
         network:
-          dns_domain: storagemgmt.localdomain.
+          dns_domain: storagemgmt.{{ ocp_cluster_name }}.
           mtu: 1350
           name: storage_mgmt
           tags:
@@ -80,7 +80,7 @@ parameter_defaults:
             - tripleo_vlan_id=30
       tenant:
         network:
-          dns_domain: tenant.localdomain.
+          dns_domain: tenant.{{ ocp_cluster_name }}.
           mtu: 1350
           name: tenant
           tags:
@@ -117,7 +117,7 @@ parameter_defaults:
   # The value for this parameter is automatically populated in the plan environment by tripleoclient.
   CtlplaneNetworkAttributes:
     network:
-      dns_domain: ctlplane.localdomain.
+      dns_domain: ctlplane.{{ ocp_cluster_name }}.
       mtu: 1500
       name: ctlplane
       tags:

--- a/ansible/templates/osp/tripleo_heat_envs/common/network-common.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/common/network-common.yaml.j2
@@ -1,0 +1,6 @@
+parameter_defaults:
+  NtpServer:
+    - clock.redhat.com
+    - clock2.redhat.com
+  DnsServers:
+    - 192.168.25.1


### PR DESCRIPTION
- with network v2 and deployed networks, some parameters [1] are deprecates no longer used
- NtpServer and DnsServer can be in a common environment file

[1] https://review.opendev.org/c/openstack/tripleo-specs/+/752437/7/specs/victoria/triplo-network-data-v2.rst#1