### PR TITLE
Fix corrupt grubenv when customizing guest image

### DIFF
--- a/ansible/datavolume.yaml
+++ b/ansible/datavolume.yaml
@@ -44,8 +44,8 @@
           #!/bin/bash
           set -e
           virt-customize -a "{{ osp_controller_base_image_url_path }}" \
-            --run-command 'sed -i -e "s/^\(kernelopts=.*\)net.ifnames=0 \(.*\)/\1\2/" /boot/grub2/grubenv' \
-            --run-command 'sed -i -e "s/^\(GRUB_CMDLINE_LINUX=.*\)net.ifnames=0 \(.*\)/\1\2/" /etc/default/grub'
+            --run-command 'sed -i -e "s/^\(GRUB_CMDLINE_LINUX=.*\)net.ifnames=0 \(.*\)/\1\2/" /etc/default/grub' \
+            --run-command 'grub2-mkconfig -o /etc/grub2.cfg'
 
   - name: does the datavolume already exist
     ignore_errors: true


### PR DESCRIPTION
Use grub2-mkconfig to update the kernel args in the grub environment
instead of sed. The env is binary and grub reports that it's corrupt
when trying to set a boot marker.