### PR TITLE
Use FQDNs

### DIFF
--- a/ansible/templates/osp/ctlplane/osp-director_openstackcontrolplane.yaml.j2
+++ b/ansible/templates/osp/ctlplane/osp-director_openstackcontrolplane.yaml.j2
@@ -12,6 +12,7 @@ spec:
         - internalapi
   openStackClientStorageClass: {{ osp.controller.storage_class }}
   passwordSecret: userpassword
+  domainName: {{ ocp_cluster_name }}.{{ ocp_domain_name }}
   virtualMachineRoles:
     controller:
       roleName: Controller

--- a/ansible/templates/osp/tripleo_heat_envs/common/cloud-names.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/common/cloud-names.yaml.j2
@@ -1,7 +1,7 @@
 parameter_defaults:
-  CloudDomain: {{ ocp_cluster_name }}
-  CloudName: overcloud.{{ ocp_cluster_name }}
-  CloudNameInternal: overcloud.internalapi.{{ ocp_cluster_name }}
-  CloudNameStorage: overcloud.storage.{{ ocp_cluster_name }}
-  CloudNameStorageManagement: overcloud.storagemgmt.{{ ocp_cluster_name }}
-  CloudNameCtlplane: overcloud.ctlplane.{{ ocp_cluster_name }}
+  CloudDomain: {{ ocp_cluster_name }}.{{ ocp_domain_name }}
+  CloudName: overcloud.{{ ocp_cluster_name }}.{{ ocp_domain_name }}
+  CloudNameInternal: overcloud.internalapi.{{ ocp_cluster_name }}.{{ ocp_domain_name }}
+  CloudNameStorage: overcloud.storage.{{ ocp_cluster_name }}.{{ ocp_domain_name }}
+  CloudNameStorageManagement: overcloud.storagemgmt.{{ ocp_cluster_name }}.{{ ocp_domain_name }}
+  CloudNameCtlplane: overcloud.ctlplane.{{ ocp_cluster_name }}.{{ ocp_domain_name }}

--- a/ansible/templates/osp/tripleo_heat_envs/features/common/nvf/custom_nfv.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/features/common/nvf/custom_nfv.yaml.j2
@@ -1,10 +1,10 @@
 parameter_defaults:
-  CloudDomain: {{ ocp_cluster_name }}
-  CloudName: overcloud.{{ ocp_cluster_name }}
-  CloudNameInternal: overcloud.internalapi.{{ ocp_cluster_name }}
-  CloudNameStorage: overcloud.storage.{{ ocp_cluster_name }}
-  CloudNameStorageManagement: overcloud.storagemgmt.{{ ocp_cluster_name }}
-  CloudNameCtlplane: overcloud.ctlplane.{{ ocp_cluster_name }}
+  CloudDomain: {{ ocp_cluster_name }}.{{ ocp_domain_name }}
+  CloudName: overcloud.{{ ocp_cluster_name }}.{{ ocp_domain_name }}
+  CloudNameInternal: overcloud.internalapi.{{ ocp_cluster_name }}.{{ ocp_domain_name }}
+  CloudNameStorage: overcloud.storage.{{ ocp_cluster_name }}.{{ ocp_domain_name }}
+  CloudNameStorageManagement: overcloud.storagemgmt.{{ ocp_cluster_name }}.{{ ocp_domain_name }}
+  CloudNameCtlplane: overcloud.ctlplane.{{ ocp_cluster_name }}.{{ ocp_domain_name }}
   # Compute settings
   ComputeParameters:
     KernelArgs: "default_hugepagesz=1GB hugepagesz=1G hugepages=256"

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -62,7 +62,7 @@ ocp_num_bm_workers: 0
 
 # OCP cluster name
 ocp_cluster_name: ostest
-#ocp_domain_name: defaults to test.metalkube.org
+ocp_domain_name: test.metalkube.org
 
 # Released version of the opm package (can be set to 'latest')
 opm_version: v1.12.5


### PR DESCRIPTION
Set the domainName in the ControlPlane CRD and update the corresponding
CloudName/Domain t-h-t params.

Depends-On: openstack-k8s-operators/osp-director-operator#396