### PR TITLE
Kuttl tests to be invoked using Makefile

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -28,6 +28,7 @@ local-deps:
 download_tools: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
 	-v -i hosts -e @vars/${OSP_RELEASE}.yaml \
+	-e @vars/kuttl_tests.yaml \
 	-e @local-defaults.yaml \
 	download_tools.yaml
 
@@ -207,6 +208,14 @@ osp_tempest: hosts local-defaults.yaml
 	-e @vars/${OSP_RELEASE}.yaml \
 	-e @local-defaults.yaml \
 	osp_tempest.yaml
+
+kuttl_tests: hosts local-defaults.yaml
+	$(MAKE) download_tools
+	ANSIBLE_FORCE_COLOR=true ansible-playbook -i hosts \
+	-e @vars/${OSP_RELEASE}.yaml \
+	-e @vars/kuttl_tests.yaml \
+	-e @local-defaults.yaml \
+	osp_kuttl.yaml
 
 olm: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \

--- a/ansible/osp_kuttl.yaml
+++ b/ansible/osp_kuttl.yaml
@@ -1,0 +1,116 @@
+---
+- hosts: localhost
+  vars_files: vars/default.yaml
+  roles:
+  - oc_local
+
+  tasks:
+  - name: Set osp-director-operator directory facts
+    set_fact:
+      kuttl_working_dir: "{{ working_dir }}/kuttl"
+      osp_director_working_path: "{{ working_dir }}/kuttl/osp-director-operator"
+
+  - name: Set osp-director-operator local path if exists in env variable
+    set_fact:
+      osp_director_local_path: "{{ lookup('env','OSP_DIRECTOR_GIT_DIR') }}"
+    when: lookup('env','OSP_DIRECTOR_GIT_DIR')|length != 0
+
+  - debug:
+      msg:
+      - "Kuttl working directory available locally {{ kuttl_working_dir }}"
+      - "OSP Director Operator repo at {{ osp_director_working_path }}"
+
+  - debug:
+      msg:
+      - "Local OSP Director Operator repo at {{ osp_director_local_path }}"
+    when: (osp_director_local_path is defined and (osp_director_local_path|string|length != 0))
+
+  - name: Clean directories
+    file:
+      state: absent
+      path: "{{ item }}/"
+    with_items:
+    - "{{ kuttl_working_dir }}"
+    - "{{ osp_director_working_path }}"
+
+  - name: Create kuttl directories
+    file:
+      path: "{{ kuttl_working_dir }}"
+      state: directory
+      mode: '0755'
+
+  - name: Synchronize OSP director operator repository to working dir
+    ansible.posix.synchronize:
+      mode: push
+      src: "{{ osp_director_local_path }}"
+      dest: "{{ osp_director_working_path }}"
+      delete: yes
+    when: (osp_director_local_path is defined and (osp_director_local_path|string|length != 0))
+
+  - block:
+    - name: Clone OSP director operator repository from defaults
+      ansible.builtin.git:
+        repo: "{{ osp_director_operator_git }}"
+        dest: "{{ osp_director_working_path }}"
+        version: "{{ osp_director_operator_branch }}"
+      when: (osp_director_operator_pr|string|length == 0)
+
+    - name: Clone OSP director operator repository from defaults with PR
+      ansible.builtin.git:
+        refspec: "+refs/pull/{{ osp_director_operator_pr }}/head:refs/remotes/origin/pr/{{ osp_director_operator_pr }}"
+        version: "pr/{{ osp_director_operator_pr }}"
+        repo: "{{ osp_director_operator_git }}"
+        dest: "{{ osp_director_working_path }}"
+      when: (osp_director_operator_pr|string|length != 0)
+    when: (osp_director_local_path is not defined or (osp_director_local_path|string|length == 0))
+
+  - name: Remove OSP Director Operator CRs
+    command: "{{ item }}"
+    ignore_errors: true
+    environment: &oc_env
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
+    with_items:
+      - "oc delete -n {{ namespace }} openstackbaremetalset --all"
+      - "oc delete -n {{ namespace }} openstackcontrolplane --all"
+      - "oc delete -n {{ namespace }} openstackvmset --all"
+      - "oc delete -n {{ namespace }} openstacknet --all"
+
+  - name: Execute kubectl-kuttl tests
+    shell: |
+      #!/bin/bash
+      set -e
+      pushd {{ osp_director_working_path }}
+      kubectl-kuttl test > {{ working_log_dir }}/kuttl_tests.log 2>&1
+      popd
+    register: kuttl_result
+    environment:
+      <<: *oc_env
+
+  - name: Get failed tests
+    shell: |
+      #!/bin/bash
+      set -e
+      grep \\-\\-\\-\ FAIL {{ working_log_dir }}/kuttl_tests.log || true
+    register: kuttl_failed
+
+  - name: Get test summary
+    shell: |
+      #!/bin/bash
+      set -e
+      sed -E -e '/^.*--- FAIL:.*|^.*--- PASS:.*/!d' {{ working_log_dir }}/kuttl_tests.log
+    register: kuttl_summary
+
+  - name: kuttl run summary
+    debug:
+      msg: "{{ kuttl_summary.stdout.split('\n') }}"
+
+  - name: kuttl failed tests
+    debug:
+      msg: "{{ kuttl_failed.stdout.split('\n') }}"
+
+  - name: Fail playbook if kuttl run failed
+    ignore_errors: true
+    fail:
+      msg: kuttl test run failed, check output {{ working_log_dir }}/kuttl_tests.log
+    when: kuttl_result.rc == 1

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -5,5 +5,6 @@ roles:
     version: 1.0.1
 
 collections:
+  - name: ansible.posix
   - name: containers.podman
   - name: community.general

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -73,9 +73,6 @@ sdk_version: v1.5.0
 # kustomize version to use (must be specific version)
 kustomize_version: v4.0.1
 
-# kuttl version to use (must be specific version)
-kuttl_version: 0.9.0
-
 # SRIOV network operator version (usually should correspond to X.X release)
 sriov_version: "{{ ocp_version }}"
 

--- a/ansible/vars/kuttl_tests.yaml
+++ b/ansible/vars/kuttl_tests.yaml
@@ -1,0 +1,14 @@
+---
+# Variables required to run kuttl tests
+
+# The OSP Director Operator git repository contain kuttl tests itself,
+# so one need to be available locally. If not one is cloned from upstream
+# github.
+osp_director_operator_git: "https://github.com/openstack-k8s-operators/osp-director-operator"
+osp_director_operator_branch: "master"
+
+# Number - if specified PR is fetched
+osp_director_operator_pr: ""
+
+# kuttl version to use (must be specific version)
+kuttl_version: 0.9.0


### PR DESCRIPTION
KUTTL tests are written in the osp-director-operator git
repository. In order to invoke them we need to check out
that repository and execute those from it.

The repository in the CI is checked by the other parts,
so one can define path to the repository using env variable
or point directly to the upstream version and PR number
in the variable file.