### PR TITLE
Auto-inject upstream AI service onprem OCP versions var

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -494,13 +494,19 @@
         regexp: 'SERVICE_BASE_URL=.*'
         replace: 'SERVICE_BASE_URL=http://192.168.111.1:{{ ocp_ai_service_port | default("8090", true) }}'
 
+    - name: Create dict of upstream AI onprem variables
+      set_fact:
+        ocp_ai_onprem_env_dict: "{{ ocp_ai_onprem_env_dict|default({}) | combine( {item.split('=')[0]: item.split('=')[1]} ) }}"
+      with_items:
+        - "{{ ocp_ai_onprem_env }}"
+
     - name: Set assisted installer service OCP release image
       replace:
         path: "{{ base_path }}/assisted-service-onprem/onprem-environment"
         # regexp: '"display_name":"4.7.2","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.2-x86_64"'
         # replace: '"display_name":"4.7","release_image":"{{ ocp_release_image }}"'
         regexp: 'OPENSHIFT_VERSIONS=.*'
-        replace: 'OPENSHIFT_VERSIONS={"4.6":{"display_name":"4.6.16","release_version":"4.6.16","release_image":"quay.io/openshift-release-dev/ocp-release:4.6.16-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso","rhcos_rootfs":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img","rhcos_version":"46.82.202012051820-0","support_level":"production"},"4.7":{"display_name":"4.7.9","release_version":"4.7.9","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.9-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso","rhcos_rootfs":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img","rhcos_version":"47.83.202103251640-0","support_level":"production","default":true},"4.8":{"display_name":"4.8.2","release_version":"4.8.2","release_image":"quay.io/openshift-release-dev/ocp-release:4.8.12-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.2/rhcos-live.x86_64.iso","rhcos_rootfs":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.2/rhcos-live-rootfs.x86_64.img","rhcos_version":"48.84.202107202156-0","support_level":"beta"}}'
+        replace: 'OPENSHIFT_VERSIONS={{ ocp_ai_onprem_env_dict["OPENSHIFT_VERSIONS"] }}'
 
         # NOTE: obtain rhcos image version from here: https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/releasestream/4-stable/release/4.8.2 or https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/builds.json
 

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -1,5 +1,6 @@
 ---
 ocp_ai_discovery_iso: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{{ ocp_version }}/latest/rhcos-live.x86_64.iso"
+ocp_ai_onprem_env: "{{ lookup('url', 'https://raw.githubusercontent.com/openshift/assisted-service/master/onprem-environment', wantlist=True) }}"
 
 # this address needs to be reachable from IPMI/iDRAC if BM worker is used 
 ocp_ai_discovery_iso_server: 192.168.111.1


### PR DESCRIPTION
Get the latest verified upstream `OPENSHIFT_VERSIONS` onprem AI service var and inject it into our onprem AI service during OCP cluster deployment