### PR TITLE
Add option to select mirror for guest image and rcm tools

### DIFF
--- a/ansible/datavolume.yaml
+++ b/ansible/datavolume.yaml
@@ -9,18 +9,18 @@
 
   - name: Set path to RHEL base image for dev-scripts
     set_fact:
-      osp_controller_base_image_url_path: "{{ base_path }}/ironic/html/images/{{ osp.controller.base_image_url | basename }}"
+      osp_controller_base_image_url_path: "{{ base_path }}/ironic/html/images/{{ osp.controller.image_url_path | basename }}"
     when: not (ocp_ai|bool)
 
   - name: Set path to RHEL base image for assisted installer
     set_fact:
-      osp_controller_base_image_url_path: "/opt/http_store/data/images/{{ osp.controller.base_image_url | basename }}"
+      osp_controller_base_image_url_path: "/opt/http_store/data/images/{{ osp.controller.image_url_path | basename }}"
     when: ocp_ai|bool
 
   # NOTE: we copy this to the Ironic images directory to reuse it for
   # the provision server (openstackbaremetalsets). This avoids downloading
   # the same image twice.
-  - name: Check if {{ osp.controller.base_image_url | basename }} already exist
+  - name: Check if {{ osp.controller.image_url_path | basename }} already exist
     stat:
       path: "{{ osp_controller_base_image_url_path }}"
     register: stat_result
@@ -30,9 +30,18 @@
     become_user: ocp
     when: not stat_result.stat.exists
     block:
-      - name: Download RHEL guest image {{ osp.controller.base_image_url }}
+      - name: Select fastest guest base image mirror
+        shell: |
+          printf "{{ osp.controller.base_image_url_mirrors | join('\n') }}" | xargs -I {} echo "curl -r 0-102400 -s -w %{speed_download} -o /dev/null {}/ls-lR.gz; echo ' '{}" | sh | sort -g -r |head -1| awk '{ print $2 }'
+        register: download_site
+
+      - name: Set the guest image mirror
+        set_fact:
+          base_image_url: "{{ download_site.stdout }}"
+
+      - name: Download RHEL guest image {{ osp.controller.image_url_path | basename }}
         get_url:
-          url: "{{ osp.controller.base_image_url }}"
+          url: "{{ base_image_url }}/{{ osp.controller.image_url_path }}"
           dest: "{{ osp_controller_base_image_url_path }}"
           owner: ocp
           group: ocp

--- a/ansible/osp_register_overcloud_nodes.yaml
+++ b/ansible/osp_register_overcloud_nodes.yaml
@@ -82,6 +82,15 @@
             rhel_subscription_activation_key: <activation key>
             rhel_subscription_org_id: "xxxxxxx"
 
+  - name: Select fastest rcm-guest mirror
+    shell: |
+      printf "{{ osp.controller.base_image_url_mirrors | join('\n') }}" | xargs -I {} echo "curl -r 0-102400 -s -w %{speed_download} -o /dev/null {}/ls-lR.gz; echo ' '{}" | sh | sort -g -r |head -1| awk '{ print $2 }'
+    register: download_site
+
+  - name: Set the rcm-guest mirror
+    set_fact:
+      base_image_url: "{{ download_site.stdout }}"
+
   - name: Render templates to yaml dir
     template:
       src: "osp/{{ item }}.j2"

--- a/ansible/templates/osp/rhsm.yaml.j2
+++ b/ansible/templates/osp/rhsm.yaml.j2
@@ -15,7 +15,7 @@
 {% else %}
   - name: install rhos-release
     dnf:
-      name: http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm
+      name: "{{ base_image_url }}/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm"
       state: present
       disable_gpg_check: true
   - name: run rhos-release

--- a/ansible/vars/16.2.yaml
+++ b/ansible/vars/16.2.yaml
@@ -8,8 +8,7 @@ osp:
     cores: 6
     memory: 20
     disk_size: 40
-    # use http://download.devel.redhat.com to get the local mirror depending on where the server is
-    base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/8.4/1168/images/rhel-guest-image-8.4-1168.x86_64.qcow2
+    image_url_path: brewroot/packages/rhel-guest-image/8.4/1168/images/rhel-guest-image-8.4-1168.x86_64.qcow2
     storage_class: host-nfs-storageclass
   # OSP compute OCP worker settings
   compute:

--- a/ansible/vars/17.0.yaml
+++ b/ansible/vars/17.0.yaml
@@ -10,8 +10,7 @@ osp:
     cores: 6
     memory: 20
     disk_size: 40
-    # use http://download.devel.redhat.com to get the local mirror depending on where the server is
-    base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/8.4/1168/images/rhel-guest-image-8.4-1168.x86_64.qcow2
+    image_url_path: brewroot/packages/rhel-guest-image/8.4/1168/images/rhel-guest-image-8.4-1168.x86_64.qcow2
     storage_class: host-nfs-storageclass
   # OSP compute OCP worker settings
   compute:

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -174,8 +174,10 @@ osp:
     cores: 6
     memory: 20
     disk_size: 40
-    # use http://download.devel.redhat.com to get the local mirror depending on where the server is
-    base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/8.4/1168/images/rhel-guest-image-8.4-1168.x86_64.qcow2
+    base_image_url_mirrors:
+      - "http://download.devel.redhat.com"
+      - "http://download.eng.brq.redhat.com"
+    image_url_path: brewroot/packages/rhel-guest-image/8.4/1168/images/rhel-guest-image-8.4-1168.x86_64.qcow2
     storage_class: host-nfs-storageclass
   # OSP compute OCP worker settings
   compute:


### PR DESCRIPTION
In the event download.devel is down we need to be able to
pick other mirrors, so the CI is not failing.