### PR TITLE
Add k8s api route to controller VMs

### DIFF
--- a/ansible/files/osp/16.2/net-config-multi-nic-controller.yaml
+++ b/ansible/files/osp/16.2/net-config-multi-nic-controller.yaml
@@ -170,6 +170,14 @@ resources:
             $network_config:
               network_config:
               - type: interface
+                name: nic1
+                use_dhcp: false
+                addresses:
+                - ip_netmask: 10.0.2.2/24
+                routes:
+                - ip_netmask: 172.30.0.1/32
+                  next_hop: 10.0.2.1
+              - type: interface
                 name: nic2
                 mtu:
                   get_param: ControlPlaneMtu


### PR DESCRIPTION
Adds nic1 (pod network) to the controller nic template with a
route to 172.30.0.1/32 via 10.0.2.1 . In the end the nic templates
for VMs should get rendered by the osp-director-operator.