### PR TITLE
Initialize a --bare git repo

### DIFF
--- a/ansible/git.yaml
+++ b/ansible/git.yaml
@@ -59,7 +59,7 @@
   - name: git init playbooks.git
     # noqa 303
     shell: |
-       git init .
+       git init --bare .
     args:
       chdir: /home/git/playbooks.git
       creates: /home/git/playbooks.git/.git


### PR DESCRIPTION
This repository is meant to be used remotely only. This should
resolve some subtle issues that could occur when pushing/pulling
to the non-bare repo otherwise.