### PR TITLE
Add openstack-16-for-rhel-8-x86_64-rpms repo

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -45,6 +45,7 @@ If `vars/rhel-subscription.yaml` is not specified, a subscription must have been
 ```
 advanced-virt-for-rhel-8-x86_64-rpms                    Advanced Virtualization for RHEL 8 x86_64 (RPMs)
 ansible-2-for-rhel-8-x86_64-rpms                        Red Hat Ansible Engine 2 for RHEL 8 x86_64 (RPMs)
+openstack-16-for-rhel-8-x86_64-rpms                     Red Hat OpenStack 16 for RHEL 8 x86_64 (RPMs)
 rhel-8-for-x86_64-appstream-rpms                        Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
 rhel-8-for-x86_64-baseos-rpms                           Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
 ```

--- a/ansible/host_prep.yaml
+++ b/ansible/host_prep.yaml
@@ -102,7 +102,7 @@
       when: manual_rhel_subscription is undefined
 
     - name: enable rhel-8-for-x86_64-appstream-rpms and advanced-virt-for-rhel-8-x86_64-rpms
-      command: subscription-manager repos --enable=rhel-8-for-x86_64-appstream-rpms --enable=advanced-virt-for-rhel-8-x86_64-rpms
+      command: subscription-manager repos --enable=rhel-8-for-x86_64-appstream-rpms --enable=advanced-virt-for-rhel-8-x86_64-rpms --enable=openstack-16-for-rhel-8-x86_64-rpms
 
     - name: validation and tweaks for assisted installer
       block:


### PR DESCRIPTION
dev-scripts deployment now require python3-passlib python3-bcrypt
which ar part of openstack-16-for-rhel-8-x86_64-rpms repo.