### PR TITLE
OSPK8-386 Support composable roles config via vars file

### DIFF
--- a/ansible/datavolume.yaml
+++ b/ansible/datavolume.yaml
@@ -12,20 +12,20 @@
 
   - name: Set path to RHEL base image for dev-scripts
     set_fact:
-      osp_controller_base_image_url_path: "{{ base_path }}/ironic/html/images/{{ osp.controller.base_image_url | basename }}"
+      osp_base_image_url_path: "{{ base_path }}/ironic/html/images/{{ osp.base_image_url | basename }}"
     when: not (ocp_ai|bool)
 
   - name: Set path to RHEL base image for assisted installer
     set_fact:
-      osp_controller_base_image_url_path: "/opt/http_store/data/images/{{ osp.controller.base_image_url | basename }}"
+      osp_base_image_url_path: "/opt/http_store/data/images/{{ osp.base_image_url | basename }}"
     when: ocp_ai|bool
 
   # NOTE: we copy this to the Ironic images directory to reuse it for
   # the provision server (openstackbaremetalsets). This avoids downloading
   # the same image twice.
-  - name: Check if {{ osp.controller.base_image_url | basename }} already exist
+  - name: Check if {{ osp.base_image_url | basename }} already exist
     stat:
-      path: "{{ osp_controller_base_image_url_path }}"
+      path: "{{ osp_base_image_url_path }}"
     register: stat_result
 
   # Note: the CentOS image right now has some ifcfg configs, lets make sure they are deleted
@@ -34,63 +34,27 @@
     become_user: ocp
     when: not stat_result.stat.exists
     block:
-      - name: Download RHEL/CentOS guest image {{ osp.controller.base_image_url }}
+      - name: Download RHEL/CentOS guest image {{ osp.base_image_url }}
         get_url:
-          url: "{{ osp.controller.base_image_url }}"
-          dest: "{{ osp_controller_base_image_url_path }}"
+          url: "{{ osp.base_image_url }}"
+          dest: "{{ osp_base_image_url_path }}"
           owner: ocp
           group: ocp
           mode: '0644'
           timeout: 30
 
-      - name: Remove net.ifnames=0 kernel param from {{ osp_controller_base_image_url_path }}
+      - name: Remove net.ifnames=0 kernel param from {{ osp_base_image_url_path }}
         shell: |
           #!/bin/bash
           set -e
-          virt-customize -a "{{ osp_controller_base_image_url_path }}" \
+          virt-customize -a "{{ osp_base_image_url_path }}" \
             --run-command 'sed -i -e "s/^\(GRUB_CMDLINE_LINUX=.*\)net.ifnames=0 \(.*\)/\1\2/" /etc/default/grub' \
             --run-command 'grub2-mkconfig -o /etc/grub2.cfg' \
             --run-command 'rm -f /etc/sysconfig/network-scripts/ifcfg-ens* /etc/sysconfig/network-scripts/ifcfg-eth*'
 
-  # Make sure we delete the datavolume e.g. when switch from rhel image to centos image
-  # This won't solve the problem when the both images exist and we switch back.
-  - name: delete datavolume if image got downloaded
-    when: not stat_result.stat.exists
-    shell: >
-      oc delete datavolume --ignore-not-found=true openstack-base-img -n {{ namespace }}
-    environment: &oc_env
-      PATH: "{{ oc_env_path }}"
-      KUBECONFIG: "{{ kubeconfig }}"
-
-  - name: does the datavolume already exist
-    ignore_errors: true
-    shell: >
-      oc get datavolume openstack-base-img -n {{ namespace }}
-    environment:
-      <<: *oc_env
-    register: datavolume_switch
-
-  - name: Deploy the datavolume
-    when: datavolume_switch.rc == 1
-    environment:
-      <<: *oc_env
-    block:
-      - name: Upload OSP Controller base image
-        shell: |
-          virtctl image-upload dv openstack-base-img -n {{ namespace }} --size={{ osp.controller.disk_size }}G --image-path={{ osp_controller_base_image_url_path }} --insecure
-    rescue:
-      - name: Remove datavolume from failed OSP Controller upload
-        command: oc delete datavolume openstack-base-img -n {{ namespace }}
-        ignore_errors: yes
-
-      - name: Re-Upload OSP Controller base image
-        shell: |
-          virtctl image-upload dv openstack-base-img -n {{ namespace }} --size={{ osp.controller.disk_size }}G --image-path={{ osp_controller_base_image_url_path }} --insecure
-
-  - name: Wait for the datavolume to be ready
-    retries: 5
-    delay: 5
-    shell: |
-      oc wait datavolume openstack-base-img --for condition=Ready -n "{{ namespace }}" --timeout={{ default_timeout }}s
-    environment:
-      <<: *oc_env
+  - name: create datavolume for vmset roles
+    include_tasks: datavolume_tasks.yaml
+    loop: "{{ osp.vmset.keys() | list }}"
+    loop_control:
+      loop_var: _role
+    when: osp.vmset[_role].count > 0

--- a/ansible/datavolume_cleanup.yaml
+++ b/ansible/datavolume_cleanup.yaml
@@ -6,7 +6,11 @@
   - oc_local
 
   tasks:
-  - name: Delete {{ osp_controller_base_image_url_path }}
+  - name: Set combined osp dict
+    set_fact:
+      osp: "{{ osp_defaults | combine((osp_release_defaults | default({})), recursive=True) | combine((osp_local | default({})), recursive=True) }}"
+
+  - name: Delete base image {{ osp.base_image_url | basename }}
     file:
       path: "{{ item }}"
       state: absent
@@ -14,9 +18,9 @@
     - "{{ base_path }}/ironic/html/images/*.qcow2"
     - "/opt/http_store/data/images/*.qcow2"
 
-  - name: Delete datavolume
+  - name: Delete all datavolumes
     shell: >
-      oc delete datavolume --ignore-not-found=true openstack-base-img -n {{ namespace }}
+      oc delete dv --all -n {{ namespace }}
     environment: &oc_env
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"

--- a/ansible/datavolume_tasks.yaml
+++ b/ansible/datavolume_tasks.yaml
@@ -1,0 +1,47 @@
+---
+- name: Set datavolume image fact
+  set_fact:
+    _datavolume: "{{ _role | lower }}-base-img"
+
+# Make sure we delete the datavolume e.g. when switch from rhel image to centos image
+# This won't solve the problem when the both images exist and we switch back.
+- name: delete {{ _datavolume }} datavolume if image got downloaded
+  when: not stat_result.stat.exists
+  shell: >
+    oc delete datavolume --ignore-not-found=true {{ _datavolume }} -n {{ namespace }}
+  environment: &oc_env
+    PATH: "{{ oc_env_path }}"
+    KUBECONFIG: "{{ kubeconfig }}"
+
+- name: does the datavolume {{ _datavolume }} already exist
+  ignore_errors: true
+  shell: >
+    oc get datavolume {{ _datavolume }} -n {{ namespace }}
+  environment:
+    <<: *oc_env
+  register: datavolume_switch
+
+- name: Deploy the datavolume {{ _datavolume }}
+  when: datavolume_switch.rc == 1
+  environment:
+    <<: *oc_env
+  block:
+    - name: Upload OSP Controller base image
+      shell: |
+        virtctl image-upload dv {{ _datavolume }} -n {{ namespace }} --size={{ osp.vmset[_role].disk_size }}G --image-path={{ osp_base_image_url_path }} --insecure
+  rescue:
+    - name: Remove datavolume {{ _datavolume }} from failed upload
+      command: oc delete datavolume {{ _datavolume }} -n {{ namespace }}
+      ignore_errors: yes
+
+    - name: Re-Upload base image {{ _datavolume }}
+      shell: |
+        virtctl image-upload dv {{ _datavolume }} -n {{ namespace }} --size={{ osp.vmset[_role].disk_size }}G --image-path={{ osp_base_image_url_path }} --insecure
+
+- name: Wait for the datavolume {{ _datavolume }} to be ready
+  retries: 5
+  delay: 5
+  shell: |
+    oc wait datavolume {{ _datavolume }} --for condition=Ready -n "{{ namespace }}" --timeout={{ default_timeout }}s
+  environment:
+    <<: *oc_env

--- a/ansible/files/osp/16.2/roles_data.yaml
+++ b/ansible/files/osp/16.2/roles_data.yaml
@@ -8,7 +8,6 @@
   description: |
     Controller role that has all the controler services loaded and handles
     Database, Messaging and Network functions.
-  CountDefault: 1
   tags:
     - primary
     - controller
@@ -194,6 +193,208 @@
     - OS::TripleO::Services::Tuned
     - OS::TripleO::Services::Vpp
     - OS::TripleO::Services::Zaqar
+###############################################################################
+# Role: ControllerNovaStandalone                                              #
+###############################################################################
+- name: ControllerNovaStandalone
+  description: |
+    Controller role that does not contain the nova control component.  Use in
+    combination with the Novacontrol role.
+  tags:
+    - primary
+    - controller
+  networks:
+    External:
+      subnet: external_subnet
+    InternalApi:
+      subnet: interanl_api_subnet
+    Storage:
+      subnet: storage_subnet
+    StorageMgmt:
+      subnet: storage_mgmt_subnet
+    Tenant:
+      subnet: tenant_subnet
+  default_route_networks: ['External']
+  HostnameFormatDefault: '%stackname%-controller-%index%'
+  update_serial: 1
+  ServicesDefault:
+    - OS::TripleO::Services::AodhApi
+    - OS::TripleO::Services::AodhEvaluator
+    - OS::TripleO::Services::AodhListener
+    - OS::TripleO::Services::AodhNotifier
+    - OS::TripleO::Services::AuditD
+    - OS::TripleO::Services::BarbicanApi
+    - OS::TripleO::Services::BarbicanBackendSimpleCrypto
+    - OS::TripleO::Services::BootParams
+    - OS::TripleO::Services::CACerts
+    - OS::TripleO::Services::CeilometerAgentCentral
+    - OS::TripleO::Services::CeilometerAgentNotification
+    - OS::TripleO::Services::CephExternal
+    - OS::TripleO::Services::CephMds
+    - OS::TripleO::Services::CephMgr
+    - OS::TripleO::Services::CephMon
+    - OS::TripleO::Services::CephRbdMirror
+    - OS::TripleO::Services::CephRgw
+    - OS::TripleO::Services::CertmongerUser
+    - OS::TripleO::Services::CinderApi
+    - OS::TripleO::Services::CinderBackendDellPs
+    - OS::TripleO::Services::CinderBackendDellSc
+    - OS::TripleO::Services::CinderBackendDellEMCPowerFlex
+    - OS::TripleO::Services::CinderBackendDellEMCPowermax
+    - OS::TripleO::Services::CinderBackendDellEMCPowerStore
+    - OS::TripleO::Services::CinderBackendDellEMCSc
+    - OS::TripleO::Services::CinderBackendDellEMCUnity
+    - OS::TripleO::Services::CinderBackendDellEMCVMAXISCSI
+    - OS::TripleO::Services::CinderBackendDellEMCVNX
+    - OS::TripleO::Services::CinderBackendDellEMCVxFlexOS
+    - OS::TripleO::Services::CinderBackendDellEMCXtremio
+    - OS::TripleO::Services::CinderBackendDellEMCXTREMIOISCSI
+    - OS::TripleO::Services::CinderBackendNetApp
+    - OS::TripleO::Services::CinderBackendPure
+    - OS::TripleO::Services::CinderBackendScaleIO
+    - OS::TripleO::Services::CinderBackendVRTSHyperScale
+    - OS::TripleO::Services::CinderBackup
+    - OS::TripleO::Services::CinderHPELeftHandISCSI
+    - OS::TripleO::Services::CinderScheduler
+    - OS::TripleO::Services::CinderVolume
+    - OS::TripleO::Services::Clustercheck
+    - OS::TripleO::Services::Collectd
+    - OS::TripleO::Services::Docker
+    - OS::TripleO::Services::Etcd
+    - OS::TripleO::Services::ExternalSwiftProxy
+    - OS::TripleO::Services::GlanceApi
+    - OS::TripleO::Services::GnocchiApi
+    - OS::TripleO::Services::GnocchiMetricd
+    - OS::TripleO::Services::GnocchiStatsd
+    - OS::TripleO::Services::HAproxy
+    - OS::TripleO::Services::HeatApi
+    - OS::TripleO::Services::HeatApiCloudwatch
+    - OS::TripleO::Services::HeatApiCfn
+    - OS::TripleO::Services::HeatEngine
+    - OS::TripleO::Services::Horizon
+    - OS::TripleO::Services::Ipsec
+    - OS::TripleO::Services::IronicApi
+    - OS::TripleO::Services::IronicConductor
+    - OS::TripleO::Services::IronicInspector
+    - OS::TripleO::Services::IronicPxe
+    - OS::TripleO::Services::IronicNeutronAgent
+    - OS::TripleO::Services::Iscsid
+    - OS::TripleO::Services::Keepalived
+    - OS::TripleO::Services::Kernel
+    - OS::TripleO::Services::Keystone
+    - OS::TripleO::Services::LoginDefs
+    - OS::TripleO::Services::ManilaApi
+    - OS::TripleO::Services::ManilaBackendCephFs
+    - OS::TripleO::Services::ManilaBackendIsilon
+    - OS::TripleO::Services::ManilaBackendNetapp
+    - OS::TripleO::Services::ManilaBackendUnity
+    - OS::TripleO::Services::ManilaBackendVNX
+    - OS::TripleO::Services::ManilaBackendVMAX
+    - OS::TripleO::Services::ManilaScheduler
+    - OS::TripleO::Services::ManilaShare
+    - OS::TripleO::Services::Memcached
+    - OS::TripleO::Services::MetricsQdr
+    - OS::TripleO::Services::MistralApi
+    - OS::TripleO::Services::MistralEngine
+    - OS::TripleO::Services::MistralExecutor
+    - OS::TripleO::Services::MistralEventEngine
+    - OS::TripleO::Services::Multipathd
+    - OS::TripleO::Services::MySQL
+    - OS::TripleO::Services::MySQLClient
+    - OS::TripleO::Services::NeutronApi
+    - OS::TripleO::Services::NeutronBgpVpnApi
+    - OS::TripleO::Services::NeutronSfcApi
+    - OS::TripleO::Services::NeutronCorePlugin
+    - OS::TripleO::Services::NeutronDhcpAgent
+    - OS::TripleO::Services::NeutronL2gwAgent
+    - OS::TripleO::Services::NeutronL2gwApi
+    - OS::TripleO::Services::NeutronL3Agent
+    - OS::TripleO::Services::NeutronLinuxbridgeAgent
+    - OS::TripleO::Services::NeutronMetadataAgent
+    - OS::TripleO::Services::NeutronML2FujitsuCfab
+    - OS::TripleO::Services::NeutronML2FujitsuFossw
+    - OS::TripleO::Services::NeutronOvsAgent
+    - OS::TripleO::Services::NeutronVppAgent
+    - OS::TripleO::Services::NovaIronic
+    - OS::TripleO::Services::ContainersLogrotateCrond
+    - OS::TripleO::Services::OctaviaApi
+    - OS::TripleO::Services::OctaviaDeploymentConfig
+    - OS::TripleO::Services::OctaviaHealthManager
+    - OS::TripleO::Services::OctaviaHousekeeping
+    - OS::TripleO::Services::OctaviaWorker
+    - OS::TripleO::Services::OpenStackClients
+    - OS::TripleO::Services::OVNDBs
+    - OS::TripleO::Services::OVNController
+    - OS::TripleO::Services::Pacemaker
+    - OS::TripleO::Services::PankoApi
+    - OS::TripleO::Services::OsloMessagingRpc
+    - OS::TripleO::Services::OsloMessagingNotify
+    - OS::TripleO::Services::Podman
+    - OS::TripleO::Services::Redis
+    - OS::TripleO::Services::Rhsm
+    - OS::TripleO::Services::Rsyslog
+    - OS::TripleO::Services::RsyslogSidecar
+    - OS::TripleO::Services::SaharaApi
+    - OS::TripleO::Services::SaharaEngine
+    - OS::TripleO::Services::Securetty
+    - OS::TripleO::Services::Snmp
+    - OS::TripleO::Services::Sshd
+    - OS::TripleO::Services::SwiftProxy
+    - OS::TripleO::Services::SwiftDispersion
+    - OS::TripleO::Services::SwiftRingBuilder
+    - OS::TripleO::Services::SwiftStorage
+    - OS::TripleO::Services::Timesync
+    - OS::TripleO::Services::Timezone
+    - OS::TripleO::Services::TripleoFirewall
+    - OS::TripleO::Services::TripleoPackages
+    - OS::TripleO::Services::Tuned
+    - OS::TripleO::Services::Vpp
+    - OS::TripleO::Services::Zaqar
+###############################################################################
+# Role: Novacontrol
+###############################################################################
+- name: Novacontrol
+  description: |
+    Standalone nova-control role to run Nova control agents on their own.
+  networks:
+    InternalApi:
+      subnet: internal_api_subnet
+    Storage:
+      subnet: storage_subnet
+  HostnameFormatDefault: '%stackname%-novacontrol-%index%'
+  update_serial: 25
+  ServicesDefault:
+    - OS::TripleO::Services::AuditD
+    - OS::TripleO::Services::BootParams
+    - OS::TripleO::Services::CACerts
+    - OS::TripleO::Services::CertmongerUser
+    - OS::TripleO::Services::Collectd
+    - OS::TripleO::Services::Docker
+    - OS::TripleO::Services::IpaClient
+    - OS::TripleO::Services::Ipsec
+    - OS::TripleO::Services::Kernel
+    - OS::TripleO::Services::LoginDefs
+    - OS::TripleO::Services::MetricsQdr
+    - OS::TripleO::Services::MySQLClient
+    - OS::TripleO::Services::NovaApi
+    - OS::TripleO::Services::NovaConductor
+    - OS::TripleO::Services::NovaMetadata
+    - OS::TripleO::Services::NovaScheduler
+    - OS::TripleO::Services::NovaVncProxy
+    - OS::TripleO::Services::Ec2Api
+    - OS::TripleO::Services::ContainersLogrotateCrond
+    - OS::TripleO::Services::PlacementApi
+    - OS::TripleO::Services::Podman
+    - OS::TripleO::Services::Rhsm
+    - OS::TripleO::Services::Rsyslog
+    - OS::TripleO::Services::Securetty
+    - OS::TripleO::Services::Snmp
+    - OS::TripleO::Services::Sshd
+    - OS::TripleO::Services::Timesync
+    - OS::TripleO::Services::Timezone
+    - OS::TripleO::Services::TripleoFirewall
+    - OS::TripleO::Services::TripleoPackages
+    - OS::TripleO::Services::Tuned
 ###############################################################################
 # Role: Compute                                                               #
 ###############################################################################

--- a/ansible/install_computes.yaml
+++ b/ansible/install_computes.yaml
@@ -51,10 +51,10 @@
     shell: |
       #!/bin/bash
       for domain in $(virsh list --inactive --name); do
-        qemu-img create -f qcow2 -o preallocation=falloc {{ base_path }}/pool/${domain}-ceph-disk-{{ item }}.qcow2 {{ osp.compute.ceph_num_osd_disk_size }}G
+        qemu-img create -f qcow2 -o preallocation=falloc {{ base_path }}/pool/${domain}-ceph-disk-{{ item }}.qcow2 {{ osp.ceph_num_osd_disk_size }}G
         virsh attach-disk ${domain} --source {{ base_path }}/pool/${domain}-ceph-disk-{{ item }}.qcow2 --target {{ item }} --persistent
       done
-    with_items: "{{ osp.compute.ceph_osd_disks }}"
+    with_items: "{{ osp.ceph_osd_disks }}"
     become: true
     become_user: root
 
@@ -79,18 +79,25 @@
       KUBECONFIG: "{{ kubeconfig }}"
     when: ocp_ai|bool and ocp_num_extra_workers > 0
 
+  # render openstackbaremetalset.yaml per bmset
   - name: Render templates to yaml dir
     template:
-      src: "osp/compute/{{ item }}.j2"
-      dest: "{{ compute_yaml_dir }}/{{ item }}"
+      src: "osp/compute/openstackbaremetalset.yaml.j2"
+      dest: "{{ compute_yaml_dir }}/{{ _role }}_openstackbaremetalset.yaml"
       mode: '0644'
-    with_items:
-    - "openstackprovisionserver.yaml"
-    - "openstackbaremetalset.yaml"
+    loop: "{{ osp.bmset.keys() | list }}"
+    loop_control:
+      loop_var: _role
+
+  - name: Render provisionserver template to yaml dir
+    template:
+      src: "osp/compute/openstackprovisionserver.yaml.j2"
+      dest: "{{ compute_yaml_dir }}/openstackprovisionserver.yaml"
+      mode: '0644'
 
   - name: does the provisionserver already exist
     shell: >
-      oc get -n openstack osprovserver openstack -o json --ignore-not-found
+      oc get -n {{ namespace }} osprovserver openstack -o json --ignore-not-found
     environment: &oc_env
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"
@@ -99,14 +106,16 @@
   - name: Start provisionserver
     shell: |
       set -e
-      oc apply -n openstack -f "{{ compute_yaml_dir }}/openstackprovisionserver.yaml"
+      oc apply -n {{ namespace }} -f "{{ compute_yaml_dir }}/openstackprovisionserver.yaml"
     environment:
       <<: *oc_env
     when: provisionserver_switch.stdout | length == 0
 
-  - name: Start baremetalset
+  - name: Start all baremetalsets
     shell: |
       set -e
-      oc apply -n openstack -f "{{ compute_yaml_dir }}/openstackbaremetalset.yaml"
+      oc apply -n {{ namespace }} -f "{{ item }}"
     environment:
       <<: *oc_env
+    with_fileglob:
+    - "{{ compute_yaml_dir }}/*_openstackbaremetalset.yaml"

--- a/ansible/install_ctlplane.yaml
+++ b/ansible/install_ctlplane.yaml
@@ -39,7 +39,7 @@
   - name: Start ctlplane
     shell: |
       set -e
-      oc apply -n openstack -f "{{ ctlplane_yaml_dir }}"
+      oc apply -n {{ namespace }} -f "{{ ctlplane_yaml_dir }}"
     environment: &oc_env
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"

--- a/ansible/ocp_ai_destroy.yaml
+++ b/ansible/ocp_ai_destroy.yaml
@@ -127,15 +127,15 @@
         - pr
     ignore_errors: true
 
-  ### remove osp_controller_base_image
+  ### remove osp_base_image
 
   - name: Set path to RHEL base image for assisted installer
     set_fact:
-      osp_controller_base_image_url_path: "/opt/http_store/data/images/{{ osp.controller.base_image_url | basename }}"
+      osp_base_image_url_path: "/opt/http_store/data/images/{{ osp.base_image_url | basename }}"
 
-  - name: Delete {{ osp_controller_base_image_url_path }}
+  - name: Delete {{ osp_base_image_url_path }}
     file:
-      path: "{{ osp_controller_base_image_url_path }}"
+      path: "{{ osp_base_image_url_path }}"
       state: absent
 
   - name: Find discovery images

--- a/ansible/ocp_dev_scripts_destroy.yaml
+++ b/ansible/ocp_dev_scripts_destroy.yaml
@@ -19,13 +19,13 @@
       chdir: "{{ base_path }}/dev-scripts"
     ignore_errors: true
 
-  ### remove osp_controller_base_image
+  ### remove osp_base_image
 
   - name: Set path to RHEL base image for dev-scripts
     set_fact:
-      osp_controller_base_image_url_path: "{{ base_path }}/ironic/html/images/{{ osp.controller.base_image_url | basename }}"
+      osp_base_image_url_path: "{{ base_path }}/ironic/html/images/{{ osp.base_image_url | basename }}"
 
-  - name: Delete {{ osp_controller_base_image_url_path }}
+  - name: Delete {{ osp_base_image_url_path }}
     file:
-      path: "{{ osp_controller_base_image_url_path }}"
+      path: "{{ osp_base_image_url_path }}"
       state: absent

--- a/ansible/osp_tripleo_fencing_overrides.yaml
+++ b/ansible/osp_tripleo_fencing_overrides.yaml
@@ -9,6 +9,14 @@
     set_fact:
       osp: "{{ osp_defaults | combine((osp_release_defaults | default({})), recursive=True) | combine((osp_local | default({})), recursive=True) }}"
 
+  # Note: with this the expectation is that the vmset with the largest role count is the one running the pacemaker cluster
+  - name: get VM role with biggest number of vmset role count
+    set_fact:
+      max_vm_role_count: "{{ osp.vmset[_role].count if osp.vmset[_role].count|int > max_vm_role_count|default(0)|int else max_vm_role_count|default(0) }}"
+    loop: "{{ osp.vmset.keys() | list }}"
+    loop_control:
+      loop_var: _role
+
   - name: Fencing overrides for TripleO
     block:
     - name: Set directory for fencing override playbook
@@ -38,7 +46,7 @@
     - name: Copy TripleO fencing overrides playbook to openstackclient
       shell: |
         #!/bin/bash
-        oc cp -n openstack {{ fencing_yaml_dir }}/tripleo_fencing_overrides.yaml openstackclient:/home/cloud-admin/tripleo_fencing_overrides.yaml
+        oc cp -n {{ namespace }} {{ fencing_yaml_dir }}/tripleo_fencing_overrides.yaml openstackclient:/home/cloud-admin/tripleo_fencing_overrides.yaml
       environment: &oc_env
         PATH: "{{ oc_env_path }}"
         KUBECONFIG: "{{ kubeconfig }}"
@@ -46,7 +54,7 @@
     - name: Run TripleO fencing overrides playbook via openstackclient
       shell: |
         #!/bin/bash
-        oc rsh -n openstack openstackclient ansible-playbook -i /home/cloud-admin/playbooks/tripleo-ansible/tripleo-ansible-inventory.yaml /home/cloud-admin/tripleo_fencing_overrides.yaml
+        oc rsh -n {{ namespace }} openstackclient ansible-playbook -i /home/cloud-admin/playbooks/tripleo-ansible/tripleo-ansible-inventory.yaml /home/cloud-admin/tripleo_fencing_overrides.yaml
       environment:
         <<: *oc_env
-    when: osp.controller.count == 3
+    when: max_vm_role_count|int > 2

--- a/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
+++ b/ansible/templates/osp/compute/openstackbaremetalset.yaml.j2
@@ -1,17 +1,13 @@
 apiVersion: osp-director.openstack.org/v1beta1
 kind: OpenStackBaremetalSet
 metadata:
-{% if "hci" in osp.extrafeatures %}
-  name: computehci
-{% else %}
-  name: compute
-{% endif %}
-  namespace: openstack
+  name: {{ _role|lower }}
+  namespace: {{ namespace }}
 spec:
   # How many nodes to provision
-  count: {{ osp.compute.count }}
+  count: {{ osp.bmset[_role].count }}
   # The image to install on the provisioned nodes
-  baseImageUrl: http://192.168.111.1/images/{{ osp.controller.base_image_url | basename }}
+  baseImageUrl: http://192.168.111.1/images/{{ osp.base_image_url | basename }}
   provisionServerName: openstack
   # The secret containing the SSH pub key to place on the provisioned nodes
   deploymentSSHSecret: osp-controlplane-ssh-keys
@@ -19,15 +15,8 @@ spec:
   ctlplaneInterface: {{ osp.networks.ctlplane.attach_config.interface }}
   # Networks to associate with this host
   networks:
-    - ctlplane
-    - external
-    - internalapi
-    - tenant
-    - storage
-{% if "hci" in osp.extrafeatures %}
-    - storagemgmt
-  roleName: ComputeHCI
-{% else %}
-  roleName: Compute
-{% endif %}
+{% for net in osp.bmset[_role].networks %}
+        - {{ net }}
+{% endfor %}
+  roleName: {{ _role }}
   passwordSecret: userpassword

--- a/ansible/templates/osp/compute/openstackprovisionserver.yaml.j2
+++ b/ansible/templates/osp/compute/openstackprovisionserver.yaml.j2
@@ -5,4 +5,4 @@ metadata:
   namespace: openstack
 spec:
   port: 8080
-  baseImageUrl: http://192.168.111.1/images/{{ osp.controller.base_image_url | basename }}
+  baseImageUrl: http://192.168.111.1/images/{{ osp.base_image_url | basename }}

--- a/ansible/templates/osp/ctlplane/osp-director_openstackcontrolplane.yaml.j2
+++ b/ansible/templates/osp/ctlplane/osp-director_openstackcontrolplane.yaml.j2
@@ -6,29 +6,27 @@ metadata:
 spec:
   gitSecret: git-secret
   openStackClientImageURL: {{ openstackclient_image }}
-  openStackClientNetworks:
-        - ctlplane
-        - external
-        - internalapi
-  openStackClientStorageClass: {{ osp.controller.storage_class }}
+  openStackClientNetworks: {{ openstackclient_networks }}
+  openStackClientStorageClass: {{ openstackclient_storage_class }}
   passwordSecret: userpassword
   domainName: {{ ocp_cluster_name }}.{{ ocp_domain_name }}
   virtualMachineRoles:
-    controller:
-      roleName: Controller
-      roleCount: {{ osp.controller.count }}
+{% for name, role in osp.vmset.items() %}
+{% if role.count > 0 %}
+    {{ name }}:
+      roleName: {{ name }}
+      roleCount: {{ role.count }}
       networks:
-        - ctlplane
-        - internalapi
-        - external
-        - tenant
-        - storage
-        - storagemgmt
-      cores: {{ osp.controller.cores }}
-      memory: {{ osp.controller.memory }}
-      diskSize: {{ osp.controller.disk_size }}
-      baseImageVolumeName: openstack-base-img
-      storageClass: {{ osp.controller.storage_class }}
+{% for net in role.networks %}
+        - {{ net }}
+{% endfor %}
+      cores: {{ role.cores }}
+      memory: {{ role.memory }}
+      diskSize: {{ role.disk_size }}
+      baseImageVolumeName: {{ name|lower }}-base-img
+      storageClass: {{ role.storage_class }}
+{% endif %}
+{% endfor %}
   enableFencing: {{ enable_fencing }}
 {% if osp.release == "train" %}
   # for upstream train release the image URLs are different, force the release via parameter

--- a/ansible/vars/16.2_hci.yaml
+++ b/ansible/vars/16.2_hci.yaml
@@ -1,3 +1,13 @@
 osp_release_defaults:
+  bmset:
+    ComputeHCI:
+      count: 2
+      networks:
+        - ctlplane
+        - internalapi
+        - external
+        - tenant
+        - storage
+        - storagemgmt
   extrafeatures:
     - hci

--- a/ansible/vars/16.2_novacontrol.yaml
+++ b/ansible/vars/16.2_novacontrol.yaml
@@ -1,0 +1,28 @@
+osp_release_defaults:
+  vmset:
+    Controller:
+      # Reset default Controller roleCount to 0
+      count: 0
+    ControllerNovaStandalone:
+      count: 1
+      cores: 6
+      disk_size: 40
+      memory: 20
+      networks:
+        - ctlplane
+        - internalapi
+        - external
+        - tenant
+        - storage
+        - storagemgmt
+      storage_class: host-nfs-storageclass
+    Novacontrol:
+      count: 1
+      cores: 2
+      disk_size: 40
+      memory: 10
+      networks:
+        - ctlplane
+        - internalapi
+        - storage
+      storage_class: host-nfs-storageclass

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -161,30 +161,50 @@ default_timeout: 240
 
 # openstackclient container image
 openstackclient_image: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
+openstackclient_storage_class: host-nfs-storageclass
+openstackclient_networks:
+  - ctlplane
+  - external
+  - internalapi
 
 nfs_server: '192.168.25.1'
 
 osp_defaults:
   release: 16.2
+  # use http://download.devel.redhat.com to get the local mirror depending on where the server is
+  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/8.4/1168/images/rhel-guest-image-8.4-1168.x86_64.qcow2
   # OSP controller VM sizing
-  controller:
-    count: 1
-    cores: 6
-    memory: 20
-    disk_size: 40
-    # use http://download.devel.redhat.com to get the local mirror depending on where the server is
-    base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/8.4/1168/images/rhel-guest-image-8.4-1168.x86_64.qcow2
-    storage_class: host-nfs-storageclass
+  vmset:
+    Controller:
+      count: 1
+      cores: 6
+      disk_size: 40
+      memory: 20
+      networks:
+        - ctlplane
+        - internalapi
+        - external
+        - tenant
+        - storage
+        - storagemgmt
+      storage_class: host-nfs-storageclass
   # OSP compute OCP worker settings
-  compute:
-    # number of OCP worker nodes should be OSP compute hosts
-    count: 2
-    # number of OSD disks per compute node
-    ceph_osd_disks:
-      - sdb
-      - sdc
-    # size of OSD disk size in GB
-    ceph_num_osd_disk_size: 20
+  bmset:
+    Compute:
+      # number of OCP worker nodes should be OSP compute hosts
+      count: 2
+      networks:
+        - ctlplane
+        - internalapi
+        - external
+        - tenant
+        - storage
+  # number of OSD disks per compute node
+  ceph_osd_disks:
+    - sdb
+    - sdc
+  # size of OSD disk size in GB
+  ceph_num_osd_disk_size: 20
   networks:
     ctlplane:
       cidr: 192.168.25.0/24

--- a/ansible/vars/train.yaml
+++ b/ansible/vars/train.yaml
@@ -3,11 +3,10 @@ openstackclient_image: quay.io/tripleotraincentos8/centos-binary-tripleoclient:c
 osp_release_defaults:
   release: train
   container_tag: current-tripleo
+  base_image_url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2
   #TODO: which ceph images tag to use for upstream train?
   #ceph_tag: 5-12
   #ceph_image: daemon
-  controller:
-    base_image_url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2
 ephemeral_heat:
   heat_api_image: quay.io/tripleotraincentos8/centos-binary-heat-api:current-tripleo
   heat_engine_image: quay.io/tripleotraincentos8/centos-binary-heat-engine:current-tripleo

--- a/ansible/vars/wallaby.yaml
+++ b/ansible/vars/wallaby.yaml
@@ -4,11 +4,10 @@ openstackclient_image: quay.io/openstack-k8s-operators/tripleowallaby-openstack-
 osp_release_defaults:
   release: wallaby
   container_tag: current-tripleo
+  base_image_url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2
   #TODO: which ceph images tag to use for upstream train?
   #ceph_tag: 5-12
   #ceph_image: daemon
-  controller:
-    base_image_url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2
 ephemeral_heat:
   heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
   heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo


### PR DESCRIPTION
This allows to more easy configure overcloud customization using
composable roles, like use multiple VMset to split off controller
services into separate VMs.
Also adds vars/16.2_novacontrol.yaml example which then use
controllernovastandalone and novacontrol tripleo roles to split
off nova services into a separate VM

Note: The role count for the default controller need to be set to 0 to overwrite the default.yaml entry.