### PR TITLE
Fix "Get the ocp client tar gunzip file"

### DIFF
--- a/ansible/ocp_ai.yaml
+++ b/ansible/ocp_ai.yaml
@@ -84,19 +84,9 @@
   ### OC CLIENT
 
   tasks:
-  - name: Get the ocp client tar gunzip file 4.6/4.7
-    when: ocp_version < 4.8
+  - name: Get the ocp client tar gunzip file
     get_url:
       url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-{{ ocp_version }}/openshift-client-linux.tar.gz"
-      dest: "/tmp/openshift-client-linux.tar.gz"
-      mode: '0755'
-      timeout: 30
-
-  # FIXME: remove when 4.8 is hosted in the format above
-  - name: Get the ocp client tar gunzip file 4.8
-    when: ocp_version == 4.8
-    get_url:
-      url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.8.2/openshift-client-linux.tar.gz"
       dest: "/tmp/openshift-client-linux.tar.gz"
       mode: '0755'
       timeout: 30


### PR DESCRIPTION
This updates the logic for getting the client tools to work with
OCP 4.6-4.9 in the standard way.