### PR TITLE
Install required upstream go components

### DIFF
--- a/ansible/download_tools.yaml
+++ b/ansible/download_tools.yaml
@@ -48,14 +48,46 @@
       mode: '0755'
       timeout: 30
 
+  - name: Deinstall golang
+    package:
+      state: absent
+      name:
+      - golang-bin
+      - golang-src
+      - golang
+
+  - name: Delete old go version installed from upstream
+    file:
+      path: "{{ item }}"
+      state: absent
+    with_items:
+    - /usr/local/go
+    - "{{ lookup('env', 'HOME') }}/bin/go"
+    - "{{ lookup('env', 'HOME') }}/bin/gofmt"
+    - /usr/local/bin/go
+    - /usr/local/bin/gofmt
+
   - name: Download and extract golang
     unarchive:
-      src: https://golang.org/dl/go{{ go_version }}.linux-amd64.tar.gz
-      dest: "{{ lookup('env', 'HOME') }}/bin/"
+      src: "https://golang.org/dl/go{{ go_version }}.linux-amd64.tar.gz"
+      dest: "/usr/local"
       remote_src: yes
       extra_opts:
-        - "--add-file"
-        - "go/bin/go"
-        - "--add-file"
-        - "go/bin/gofmt"
-        - "--strip-components=2"
+        - "--exclude"
+        - "go/misc"
+        - "--exclude"
+        - "go/pkg/linux_amd64_race"
+        - "--exclude"
+        - "go/test"
+
+  - name: set alternatives link to installed go version
+    shell: |
+      set -e
+      update-alternatives --install /usr/local/bin/{{ item }} {{ item }} /usr/local/go/bin/{{ item }} 1
+    with_items:
+    - go
+    - gofmt
+
+  - name: Clean bash cache
+    debug:
+      msg: When move from rpm to upstream version, make sure to clean bash cache using `hash -d go`


### PR DESCRIPTION
Makes sure all golang packages got removed and installs upstream
go version. Sets go/gofmt via alternatives.

Note: when move from rpm to upstream version, make sure to clean
bash cache using `hash -d go`