### PR TITLE
Use proper user when deinstalling/installing golang

### DIFF
--- a/ansible/download_tools.yaml
+++ b/ansible/download_tools.yaml
@@ -48,45 +48,50 @@
       mode: '0755'
       timeout: 30
 
-  - name: Deinstall golang
-    package:
-      state: absent
-      name:
-      - golang-bin
-      - golang-src
-      - golang
+  - name: Set proper golang on the system
+    become: true
+    become_user: root
+    block:
 
-  - name: Delete old go version installed from upstream
-    file:
-      path: "{{ item }}"
-      state: absent
-    with_items:
-    - /usr/local/go
-    - "{{ lookup('env', 'HOME') }}/bin/go"
-    - "{{ lookup('env', 'HOME') }}/bin/gofmt"
-    - /usr/local/bin/go
-    - /usr/local/bin/gofmt
+    - name: Deinstall golang
+      package:
+        state: absent
+        name:
+        - golang-bin
+        - golang-src
+        - golang
 
-  - name: Download and extract golang
-    unarchive:
-      src: "https://golang.org/dl/go{{ go_version }}.linux-amd64.tar.gz"
-      dest: "/usr/local"
-      remote_src: yes
-      extra_opts:
-        - "--exclude"
-        - "go/misc"
-        - "--exclude"
-        - "go/pkg/linux_amd64_race"
-        - "--exclude"
-        - "go/test"
+    - name: Delete old go version installed from upstream
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+      - /usr/local/go
+      - "{{ lookup('env', 'HOME') }}/bin/go"
+      - "{{ lookup('env', 'HOME') }}/bin/gofmt"
+      - /usr/local/bin/go
+      - /usr/local/bin/gofmt
 
-  - name: set alternatives link to installed go version
-    shell: |
-      set -e
-      update-alternatives --install /usr/local/bin/{{ item }} {{ item }} /usr/local/go/bin/{{ item }} 1
-    with_items:
-    - go
-    - gofmt
+    - name: Download and extract golang
+      unarchive:
+        src: "https://golang.org/dl/go{{ go_version }}.linux-amd64.tar.gz"
+        dest: "/usr/local"
+        remote_src: yes
+        extra_opts:
+          - "--exclude"
+          - "go/misc"
+          - "--exclude"
+          - "go/pkg/linux_amd64_race"
+          - "--exclude"
+          - "go/test"
+
+    - name: set alternatives link to installed go version
+      shell: |
+        set -e
+        update-alternatives --install /usr/local/bin/{{ item }} {{ item }} /usr/local/go/bin/{{ item }} 1
+      with_items:
+      - go
+      - gofmt
 
   - name: Clean bash cache
     debug:


### PR DESCRIPTION
If ansible user is different then root then appropriate
lifting perms needs to happen for the system wide tasks.