### PR TITLE
Add skopeo (for latest build_and_push_images.sh)

### DIFF
--- a/ansible/host_prep.yaml
+++ b/ansible/host_prep.yaml
@@ -155,6 +155,9 @@
           - git
           - make
 
+          # Required to run osp-director-operator/scripts/build_and_push_images.sh
+          - skopeo
+
           # Required for assisted installer
           - dnsmasq
           - libvirt-devel


### PR DESCRIPTION
This is now utilized to pull image digests into our CSV
for offline OCP install support of our operator.

OSPK8-400 add skopeo to our environments