### PR TITLE
dev-scripts fixes

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -268,12 +268,11 @@ nfs_cleanup: hosts
 	 rm \$$temp"
 
 destroy_ocp: hosts local-defaults.yaml
-	$(MAKE) openstack_cleanup
 	ANSIBLE_FORCE_COLOR=true ansible-playbook -i hosts \
 	-e @vars/${OSP_RELEASE}.yaml \
 	-e @local-defaults.yaml \
 	ocp_installer_destroy.yaml
-	$(MAKE) nfs_cleanup
+	$(MAKE) openstack_cleanup nfs_cleanup
 
 demo: hosts
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \

--- a/ansible/ocp_dev_scripts_destroy.yaml
+++ b/ansible/ocp_dev_scripts_destroy.yaml
@@ -19,6 +19,44 @@
       chdir: "{{ base_path }}/dev-scripts"
     ignore_errors: true
 
+  - name: Kill any orphaned install
+    command:
+      cmd: pkill -9 -f '{{ ocp_cluster_name }}/openshift-baremetal-install'
+    ignore_errors: true
+
+  - name: Ensure dev_scripts VMs and networks are deleted
+    become: true
+    become_user: root
+    shell: |
+      for i in $(virsh list --name | grep "^{{ ocp_cluster_name }}_"); do
+        virsh destroy $i
+      done
+
+      for i in $(virsh list --all --name | grep "^{{ ocp_cluster_name }}_"); do
+        virsh undefine $i --remove-all-storage --nvram
+      done
+
+      for i in $(virsh net-list --name | grep "^{{ ocp_cluster_name }}"); do
+        virsh net-destroy $i
+      done
+
+      for i in $(virsh net-list --all --name | grep "^{{ ocp_cluster_name }}"); do
+        virsh net-undefine $i
+      done
+
+  - name: Kill any orphaned dnsmasq
+    command:
+      cmd: pkill -f 'dnsmasq .*--conf-file=/var/lib/libvirt/dnsmasq/{{ ocp_cluster_name }}'
+    ignore_errors: true
+
+  - name: Removed cached deployment data
+    file:
+      path: "{{ item }}"
+      state: absent
+    with_items:
+      - "{{ base_path }}/dev-scripts/ocp/{{ ocp_cluster_name }}"
+      - "{{ base_path }}/{{ ocp_cluster_name }}"
+
   ### remove osp_base_image
 
   - name: Set path to RHEL base image for dev-scripts

--- a/ansible/ocp_vm_setup_extra_nics.yaml
+++ b/ansible/ocp_vm_setup_extra_nics.yaml
@@ -156,18 +156,30 @@
         when: not (ocp_ai|bool)
         block:
         # HACK to fix dev-scripts bug
-        - name: "destroy vm {{ item }}"
-          command: "virsh destroy {{ item }}"
-          with_items: "{{ worker_ocp_active[0].split(' ') }}"
+        # It's not possible to hot-plug 2 nics with the default libvirt pci topology
+        # The "right way" to fix this is to add more pci root ports at VM create.
+        # However the VM xml is managed deep in the openshift installer (terraform libvirt plugin)
+        #
+        # Instead we gracefully stop the VM to attach the nics (libvirt adds the root ports implicitly)
+        # Sushy-tools is paused while this is being done so that it and metal3/ironic do not react to the
+        # power state changing.
+
+        - name: pause sushy-tools
+          command:
+            cmd: podman pause sushy-tools
+
         - name: attach interfaces to vm
           shell: |
-            virsh attach-interface {{ item.0 }} bridge {{ item.1 }} --model virtio --persistent --config
-          with_nested:
-          - "{{ worker_ocp_active[0].split(' ') }}"
-          - ['external', 'ospnetwork']
-        - name: "start vm {{ item }}"
-          command: "virsh start {{ item }}"
+            virsh destroy {{ item }} --graceful
+            for net in "external" "ospnetwork"; do
+              virsh attach-interface {{ item }} bridge ${net} --model virtio --persistent --config
+            done
+            virsh start {{ item }}
           with_items: "{{ worker_ocp_active[0].split(' ') }}"
+
+        - name: unpause sushy-tools
+          command:
+            cmd: podman unpause sushy-tools
 
       - name: Attach the osp network to ACTIVE worker VM's
         command: "virsh attach-interface {{ item.0 }} bridge {{ item.1 }} --model virtio --persistent --config"


### PR DESCRIPTION
If dev-scripts is interrupted (e.g Jenkins job abort/timeout) then the VMs/ironic/sushy-tools/terraform can be in an inconsistent state.
In subsequent runs dev-scripts will reuse the VMs. If the initial state is out of whack we will have OCP deploy errors e.g no worker nodes running.

This blasts away anything that remains. It also must remove the cached state as this references the VM uuids.