### PR TITLE
Support for new osdeploy CR

### DIFF
--- a/ansible/openstack_cleanup.yaml
+++ b/ansible/openstack_cleanup.yaml
@@ -12,7 +12,9 @@
       KUBECONFIG: "{{ kubeconfig }}"
     ignore_errors: true
     with_items:
+      - "oc delete -n openstack openstackdeploy --all"
       - "oc delete -n openstack openstackconfiggenerator --all"
+      - "oc delete -n openstack openstackconfigversion --all"
       - "oc delete -n openstack openstackephemeralheat --all"
       - "oc delete -n openstack openstackbaremetalset --all"
       - "oc delete -n openstack openstackcontrolplane --all"

--- a/ansible/osp_deploy.yaml
+++ b/ansible/osp_deploy.yaml
@@ -53,6 +53,14 @@
       <<: *oc_env
     register: deploy_switch
 
+  - name: Delete deployment (if it exists)
+    shell: |
+      set -e
+      oc delete -n openstack osdeploy default
+    environment:
+      <<: *oc_env
+    when: deploy_switch.stdout | length > 0
+
   - name: Start deployment
     shell: |
       set -e

--- a/ansible/osp_deploy.yaml
+++ b/ansible/osp_deploy.yaml
@@ -8,26 +8,62 @@
   - name: Include variables
     include_vars: vars/default.yaml
 
-  - name: Set combined osp dict
+  - name: Set directory for generator yaml files
     set_fact:
-      osp: "{{ osp_defaults | combine((osp_release_defaults | default({})), recursive=True) | combine((osp_local | default({})), recursive=True) }}"
+      deploy_yamls_dir: "{{ working_yamls_dir }}/deploy"
 
-  - name: Accept rendered playbooks
-    shell: |
-      #!/bin/bash
-      set -e
-      oc rsh -n openstack openstackclient /home/cloud-admin/tripleo-deploy.sh -a
+  - debug:
+      msg: "yamls will be written to {{ deploy_yamls_dir }} locally"
+
+  - name: Clean yaml dir
+    file:
+      state: absent
+      path: "{{ deploy_yamls_dir }}/"
+
+  - name: Create yaml dir
+    file:
+      path: "{{ deploy_yamls_dir }}"
+      state: directory
+      mode: '0755'
+
+  - name: Lookup configVersion hash
+    shell: >
+      oc get -n openstack --sort-by {.metadata.creationTimestamp} osconfigversions -o json | jq -re .items[0].spec.hash
+    register: config_version_cmd
     environment: &oc_env
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"
-    register: playbooks_accept
 
-  - name: Run playbooks, deployment log at {{ working_log_dir }}/osp-deploy.log
-    shell: |
-      #!/bin/bash
-      set -e
-      oc rsh -n openstack openstackclient timeout {{ osp.deploy_timeout }} /home/cloud-admin/tripleo-deploy.sh -p > {{ working_log_dir }}/osp-deploy.log 2>&1
+  - name: Set config_version fact
+    set_fact:
+      config_version: "{{ config_version_cmd.stdout }}"
+
+  - name: Render templates to yaml dir
+    template:
+      src: "osp/deploy/{{ item }}.j2"
+      dest: "{{ deploy_yamls_dir }}/{{ item }}"
+      mode: '0644'
+    with_items:
+    - "openstackdeploy.yaml"
+
+  - name: does the deployment already exist
+    shell: >
+      oc get -n openstack osdeploy default -o json --ignore-not-found
     environment:
       <<: *oc_env
-    when: playbooks_accept.rc == 0
+    register: deploy_switch
 
+  - name: Start deployment
+    shell: |
+      set -e
+      oc apply -n openstack -f "{{ deploy_yamls_dir }}/openstackdeploy.yaml"
+    environment:
+      <<: *oc_env
+    when: deploy_switch.stdout | length == 0
+
+  - name: wait for deployment to finish
+    shell: |
+      set -e
+      oc wait -n openstack osdeploy default --for condition=Finished --timeout="{{ (default_timeout * 25)|int }}s"
+    environment:
+      <<: *oc_env

--- a/ansible/osp_deploy.yaml
+++ b/ansible/osp_deploy.yaml
@@ -72,6 +72,6 @@
   - name: wait for deployment to finish
     shell: |
       set -e
-      oc wait -n openstack osdeploy default --for condition=Finished --timeout="{{ (default_timeout * 25)|int }}s"
+      oc wait -n openstack osdeploy default --for condition=Finished --timeout="{{ (default_timeout * 40)|int }}s"
     environment:
       <<: *oc_env

--- a/ansible/osp_register_overcloud_nodes.yaml
+++ b/ansible/osp_register_overcloud_nodes.yaml
@@ -30,17 +30,6 @@
       state: directory
       mode: '0755'
 
-  - name: wait for OpenstackConfigGenerator finished rendering playbooks
-    shell: |
-      oc wait osconfiggenerator -n openstack --for condition=Finished default --timeout={{ default_timeout }}s
-    environment: &oc_env
-      PATH: "{{ oc_env_path }}"
-      KUBECONFIG: "{{ kubeconfig }}"
-    retries: 50
-    delay: 5
-    register: result
-    until: result.rc == 0
-
   - name: Register to subscription manager
     when: osp_registry_method == "rhsm"
     block:
@@ -98,24 +87,14 @@
     shell: |
       #!/bin/bash
       oc cp -n openstack {{ rhsm_yaml_dir }}/rhsm.yaml openstackclient:/home/cloud-admin/rhsm.yaml
-    environment:
-      <<: *oc_env
-    register: result
-
-  - name: Accept rendered playbooks to get the current inventory
-    shell: |
-      #!/bin/bash
-      set -e
-      oc rsh -n openstack openstackclient /home/cloud-admin/tripleo-deploy.sh -a
-    environment:
-      <<: *oc_env
-    register: playbooks_accept
-    when: result.rc == 0
+    environment: &oc_env
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
 
   - name: run rhsm playbook via openstackclient
     shell: |
-      #!/bin/bash
-      oc rsh -n openstack openstackclient ansible-playbook -i /home/cloud-admin/playbooks/tripleo-ansible/tripleo-ansible-inventory.yaml /home/cloud-admin/rhsm.yaml
+      oc rsh -n openstack openstackclient <<"EOF_RSH"
+        ansible-playbook -i /home/cloud-admin/ctlplane-ansible-inventory /home/cloud-admin/rhsm.yaml
+      EOF_RSH
     environment:
       <<: *oc_env
-    when: playbooks_accept.rc == 0

--- a/ansible/templates/osp/deploy/openstackdeploy.yaml.j2
+++ b/ansible/templates/osp/deploy/openstackdeploy.yaml.j2
@@ -1,0 +1,10 @@
+apiVersion: osp-director.openstack.org/v1beta1
+kind: OpenStackDeploy
+metadata:
+  name: default
+spec:
+  configVersion: {{ config_version }}
+  configGenerator: default
+{% if openstackdeploy_image is defined %}
+  imageURL: {{ openstackdeploy_image }}
+{% endif %}


### PR DESCRIPTION
Updates the osp_register_overcloud_nodes.yaml so it avoids
using tripleo-deploy.sh to generate an Ansible inventory.

Instead this playbook generates a simple inventory
by using /etc/hosts on the openstackclient pod.

Also, updates the osp_deploy playbook to support the new
osdeploy CR.