### PR TITLE
Fix olm_cleanup

### DIFF
--- a/ansible/olm_cleanup.yaml
+++ b/ansible/olm_cleanup.yaml
@@ -19,7 +19,7 @@
 
   - name: Lookup currentCSV for osp-director-operator
     shell: >
-      oc get -o json packagemanifest osp-director-operator | jq -re .status.channels[0].currentCSV
+      oc get -n {{ namespace }} -o json packagemanifest osp-director-operator | jq -re .status.channels[0].currentCSV
     register: _current_csv
     environment:
       <<: *oc_env


### PR DESCRIPTION
Add namespace option to the oc command when looking up the currentCSV.

This resolves an issue with olm cleanup that got broken in
9dd498c529240147898bae3c562377b39be0469b