### PR TITLE
Reduce ingress controller replicas to 2

### DIFF
--- a/ansible/templates/ai/cluster_mgnt_roles/60-ingress-controller.yml.j2
+++ b/ansible/templates/ai/cluster_mgnt_roles/60-ingress-controller.yml.j2
@@ -11,4 +11,4 @@ spec:
     nodeSelector:
       matchLabels:
         node-role.kubernetes.io/master: ""
-  replicas: {{ ocp_ai_ingress_replicas | default(3, true) }}
+  replicas: {{ ocp_ai_ingress_replicas | default(2, true) }}


### PR DESCRIPTION
We have been defaulting to 3 ingress controller replicas due to an earlier issue with AI deployments.  This is no longer required.  It also was preventing upgrades of 3-combo-node OCP clusters from updating the MachineConfig operator.