### PR TITLE
[OSPK8-431] Remove ext network from computes and relocate preserveReservations param

### DIFF
--- a/ansible/openstack_cleanup.yaml
+++ b/ansible/openstack_cleanup.yaml
@@ -16,9 +16,11 @@
       - "oc delete -n openstack openstackephemeralheat --all"
       - "oc delete -n openstack openstackbaremetalset --all"
       - "oc delete -n openstack openstackcontrolplane --all"
+      - "oc delete -n openstack openstackvmset --all"
       - "oc delete -n openstack openstackclient --all"
       - "oc delete -n openstack openstacknetconfig --all"
       - "oc delete -n openstack cm tripleo-deploy-config heat-env-config tripleo-tarball-config --ignore-not-found=true"
+      - "oc delete -n opensatck events --all"
 
   - name: delete playbooks git repo dir
     become: true

--- a/ansible/openstack_cleanup.yaml
+++ b/ansible/openstack_cleanup.yaml
@@ -20,7 +20,7 @@
       - "oc delete -n openstack openstackclient --all"
       - "oc delete -n openstack openstacknetconfig --all"
       - "oc delete -n openstack cm tripleo-deploy-config heat-env-config tripleo-tarball-config --ignore-not-found=true"
-      - "oc delete -n opensatck events --all"
+      - "oc delete -n openstack events --all"
 
   - name: delete playbooks git repo dir
     become: true

--- a/ansible/templates/osp/netconfig/osnetconfig.yaml.j2
+++ b/ansible/templates/osp/netconfig/osnetconfig.yaml.j2
@@ -103,7 +103,6 @@ spec:
       name: {{ physnet.name }}
 {% endfor %}
 {% endif %}
-    preserveReservations: {{ osp.ovn_bridge_mac_mappings.preserve_reservations|default(true)|bool }}
 {% if osp.ovn_bridge_mac_mappings.static_reservations is defined and osp.ovn_bridge_mac_mappings.static_reservations|length %}
     staticReservations:
 {% for node, reservations in osp.ovn_bridge_mac_mappings.static_reservations.items() %}
@@ -115,3 +114,4 @@ spec:
 {% endfor %}
 {% endif %}
 {% endif %}
+  preserveReservations: {{ osp.preserve_reservations|default(true)|bool }}

--- a/ansible/vars/16.2_fencing_subnet.yaml
+++ b/ansible/vars/16.2_fencing_subnet.yaml
@@ -32,7 +32,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf1
-        - external
         - tenant_leaf1
         - storage_leaf1
     ComputeLeaf2:
@@ -41,6 +40,5 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf2
-        - external
         - tenant_leaf2
         - storage_leaf2

--- a/ansible/vars/16.2_fencing_subnet_3combo.yaml
+++ b/ansible/vars/16.2_fencing_subnet_3combo.yaml
@@ -37,7 +37,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf1
-        - external
         - tenant_leaf1
         - storage_leaf1
     ComputeLeaf2:
@@ -46,6 +45,5 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf2
-        - external
         - tenant_leaf2
         - storage_leaf2

--- a/ansible/vars/16.2_hci.yaml
+++ b/ansible/vars/16.2_hci.yaml
@@ -8,7 +8,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api
-        - external
         - tenant
         - storage
         - storage_mgmt

--- a/ansible/vars/16.2_hci_subnet.yaml
+++ b/ansible/vars/16.2_hci_subnet.yaml
@@ -22,7 +22,6 @@ osp_release_defaults:
       ctlplane_interface: enp7s0
       networks:
         - ctlplane
-        - external
         - internal_api_leaf1
         - storage_leaf1
         - storage_mgmt_leaf1

--- a/ansible/vars/16.2_hci_tlse_subnet.yaml
+++ b/ansible/vars/16.2_hci_tlse_subnet.yaml
@@ -26,7 +26,6 @@ osp_release_defaults:
       ctlplane_interface: enp7s0
       networks:
         - ctlplane
-        - external
         - internal_api_leaf1
         - storage_leaf1
         - storage_mgmt_leaf1

--- a/ansible/vars/16.2_ipv6_hci_subnet.yaml
+++ b/ansible/vars/16.2_ipv6_hci_subnet.yaml
@@ -12,7 +12,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api
-        - external
         - tenant
         - storage
         - storage_mgmt

--- a/ansible/vars/16.2_ipv6_hci_tlse_subnet.yaml
+++ b/ansible/vars/16.2_ipv6_hci_tlse_subnet.yaml
@@ -26,24 +26,24 @@ osp_release_defaults:
   bmset:
     Compute:
       count: 0
-    ComputeLeaf1:
+    ComputeHCILeaf1:
       count: 1
       ctlplane_interface: enp7s0
       networks:
         - ctlplane
         - internal_api_leaf1
-        - external
-        - tenant_leaf1
         - storage_leaf1
-    ComputeLeaf2:
+        - storage_mgmt_leaf1
+        - tenant_leaf1
+    ComputeHCILeaf2:
       count: 1
       ctlplane_interface: enp7s0
       networks:
         - ctlplane
         - internal_api_leaf2
-        - external
-        - tenant_leaf2
         - storage_leaf2
+        - storage_mgmt_leaf2
+        - tenant_leaf2
   extrafeatures:
   - hci
   - ipv6

--- a/ansible/vars/16.2_ipv6_novacontrol_hci_tlse_subnet.yaml
+++ b/ansible/vars/16.2_ipv6_novacontrol_hci_tlse_subnet.yaml
@@ -45,7 +45,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf1
-        - external
         - tenant_leaf1
         - storage_leaf1
     ComputeLeaf2:
@@ -54,7 +53,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf2
-        - external
         - tenant_leaf2
         - storage_leaf2
   extrafeatures:

--- a/ansible/vars/16.2_ipv6_novacontrol_hci_tlse_subnet.yaml
+++ b/ansible/vars/16.2_ipv6_novacontrol_hci_tlse_subnet.yaml
@@ -39,7 +39,7 @@ osp_release_defaults:
   bmset:
     Compute:
       count: 0
-    ComputeLeaf1:
+    ComputeHCILeaf1:
       count: 1
       ctlplane_interface: enp7s0
       networks:
@@ -47,7 +47,7 @@ osp_release_defaults:
         - internal_api_leaf1
         - tenant_leaf1
         - storage_leaf1
-    ComputeLeaf2:
+    ComputeHCILeaf2:
       count: 1
       ctlplane_interface: enp7s0
       networks:

--- a/ansible/vars/16.2_ipv6_subnet.yaml
+++ b/ansible/vars/16.2_ipv6_subnet.yaml
@@ -30,7 +30,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf1
-        - external
         - tenant_leaf1
         - storage_leaf1
     ComputeLeaf2:
@@ -39,7 +38,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf2
-        - external
         - tenant_leaf2
         - storage_leaf2
   extrafeatures:

--- a/ansible/vars/16.2_novacontrol_hci_subnet.yaml
+++ b/ansible/vars/16.2_novacontrol_hci_subnet.yaml
@@ -43,7 +43,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf1
-        - external
         - tenant_leaf1
         - storage_leaf1
     ComputeLeaf2:
@@ -52,7 +51,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf2
-        - external
         - tenant_leaf2
         - storage_leaf2
   extrafeature:

--- a/ansible/vars/16.2_novacontrol_hci_subnet.yaml
+++ b/ansible/vars/16.2_novacontrol_hci_subnet.yaml
@@ -37,7 +37,7 @@ osp_release_defaults:
   bmset:
     Compute:
       count: 0
-    ComputeLeaf1:
+    ComputeHCILeaf1:
       count: 1
       ctlplane_interface: enp7s0
       networks:
@@ -45,7 +45,7 @@ osp_release_defaults:
         - internal_api_leaf1
         - tenant_leaf1
         - storage_leaf1
-    ComputeLeaf2:
+    ComputeHCILeaf2:
       count: 1
       ctlplane_interface: enp7s0
       networks:

--- a/ansible/vars/16.2_novacontrol_hci_tlse_subnet.yaml
+++ b/ansible/vars/16.2_novacontrol_hci_tlse_subnet.yaml
@@ -45,7 +45,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf1
-        - external
         - tenant_leaf1
         - storage_leaf1
     ComputeLeaf2:
@@ -54,7 +53,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf2
-        - external
         - tenant_leaf2
         - storage_leaf2
   extrafeature:

--- a/ansible/vars/16.2_novacontrol_hci_tlse_subnet.yaml
+++ b/ansible/vars/16.2_novacontrol_hci_tlse_subnet.yaml
@@ -39,7 +39,7 @@ osp_release_defaults:
   bmset:
     Compute:
       count: 0
-    ComputeLeaf1:
+    ComputeHCILeaf1:
       count: 1
       ctlplane_interface: enp7s0
       networks:
@@ -47,7 +47,7 @@ osp_release_defaults:
         - internal_api_leaf1
         - tenant_leaf1
         - storage_leaf1
-    ComputeLeaf2:
+    ComputeHCILeaf2:
       count: 1
       ctlplane_interface: enp7s0
       networks:

--- a/ansible/vars/16.2_subnet.yaml
+++ b/ansible/vars/16.2_subnet.yaml
@@ -30,7 +30,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf1
-        - external
         - tenant_leaf1
         - storage_leaf1
     ComputeLeaf2:
@@ -39,6 +38,5 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf2
-        - external
         - tenant_leaf2
         - storage_leaf2

--- a/ansible/vars/16.2_tlse_subnet.yaml
+++ b/ansible/vars/16.2_tlse_subnet.yaml
@@ -33,7 +33,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf1
-        - external
         - tenant_leaf1
         - storage_leaf1
     ComputeLeaf2:
@@ -42,6 +41,5 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf2
-        - external
         - tenant_leaf2
         - storage_leaf2

--- a/ansible/vars/17.0_ipv6_subnet.yaml
+++ b/ansible/vars/17.0_ipv6_subnet.yaml
@@ -30,7 +30,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf1
-        - external
         - tenant_leaf1
         - storage_leaf1
     ComputeLeaf2:
@@ -39,7 +38,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf2
-        - external
         - tenant_leaf2
         - storage_leaf2
   extrafeatures:

--- a/ansible/vars/17.0_subnet.yaml
+++ b/ansible/vars/17.0_subnet.yaml
@@ -41,7 +41,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf1
-        - external
         - tenant_leaf1
         - storage_leaf1
     ComputeLeaf2:
@@ -50,6 +49,5 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf2
-        - external
         - tenant_leaf2
         - storage_leaf2

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -180,7 +180,7 @@ default_timeout: 240
 
 # openstackclient container image
 # TODO: change once we have a 16.2.2 tripleoclient image that includes ipa-client
-#openstackclient_image: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
+# openstackclient_image: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
 openstackclient_image: docker-registry.upshift.redhat.com/openstack-k8s-operators/openstack-tripleoclient:16.2_ipa_client
 openstackclient_storage_class: host-nfs-storageclass
 openstackclient_networks:
@@ -255,11 +255,11 @@ osp_defaults:
       prefix: fa:16:3a
     - name: datacentre2
       prefix: fa:16:3b
-    preserve_reservations: true
     static_reservations:
       controller-0:
         datacentre: fa:16:3a:aa:aa:aa
         datacentre2: fa:16:3b:aa:aa:aa
+  preserve_reservations: true
   container_tag: 16.2_20211110.2
   ceph_image: rhceph
   ceph_tag: 4-59

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -180,7 +180,7 @@ default_timeout: 240
 
 # openstackclient container image
 # TODO: change once we have a 16.2.2 tripleoclient image that includes ipa-client
-# openstackclient_image: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
+#openstackclient_image: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
 openstackclient_image: docker-registry.upshift.redhat.com/openstack-k8s-operators/openstack-tripleoclient:16.2_ipa_client
 openstackclient_storage_class: host-nfs-storageclass
 openstackclient_networks:
@@ -218,7 +218,6 @@ osp_defaults:
       networks:
         - ctlplane
         - internal_api
-        - external
         - tenant
         - storage
   # number of OSD disks per compute node

--- a/ansible/vars/train_ipv6_subnet.yaml
+++ b/ansible/vars/train_ipv6_subnet.yaml
@@ -43,7 +43,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf1
-        - external
         - tenant_leaf1
         - storage_leaf1
     ComputeLeaf2:
@@ -52,7 +51,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf2
-        - external
         - tenant_leaf2
         - storage_leaf2
   extrafeatures:

--- a/ansible/vars/train_subnet.yaml
+++ b/ansible/vars/train_subnet.yaml
@@ -42,7 +42,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf1
-        - external
         - tenant_leaf1
         - storage_leaf1
     ComputeLeaf2:
@@ -51,7 +50,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf2
-        - external
         - tenant_leaf2
         - storage_leaf2
 

--- a/ansible/vars/wallaby_ipv6_subnet.yaml
+++ b/ansible/vars/wallaby_ipv6_subnet.yaml
@@ -44,7 +44,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf1
-        - external
         - tenant_leaf1
         - storage_leaf1
     ComputeLeaf2:
@@ -53,7 +52,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf2
-        - external
         - tenant_leaf2
         - storage_leaf2
   extrafeatures:

--- a/ansible/vars/wallaby_subnet.yaml
+++ b/ansible/vars/wallaby_subnet.yaml
@@ -43,7 +43,6 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf1
-        - external
         - tenant_leaf1
         - storage_leaf1
     ComputeLeaf2:
@@ -52,6 +51,5 @@ osp_release_defaults:
       networks:
         - ctlplane
         - internal_api_leaf2
-        - external
         - tenant_leaf2
         - storage_leaf2


### PR DESCRIPTION
* Remove external network from compute nodes
Compute nodes do not need an IP on the external network,
therefore remove the external network form the role networks list
so that no IP get created.

* [OSPK8-431] Move preserveReservations parameter on level higher
This parameter now controls both MAC and IP reservations.

Depends-On: openstack-k8s-operators/osp-director-operator#495
