### PR TITLE
Front-load custom registries for AI

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -653,6 +653,21 @@
           insertafter: '^\s\s\s\s-\s50-master-scheduler\.yml'
           line: '    - 60-ingress-controller.yml'
 
+    - name: Add custom registries manifest
+      block:
+      - name: Create custom registries manifest
+        template:
+          src: ai/cluster_mgnt_roles/70-image.yml.j2
+          dest: "{{ base_path }}/cluster_mgnt_roles/create_cluster/templates/70-image.yml.j2"
+          mode: '0664'
+
+      - name: Inject custom registries manifest
+        lineinfile:
+          path: "{{ base_path }}/cluster_mgnt_roles/create_cluster/tasks/main.yml"
+          regexp: '^\s\s\s\s-\s70-image\.yml'
+          insertafter: '^\s\s\s\s-\s60-ingress-controller\.yml'
+          line: '    - 70-image.yml'
+
     - name: Force serial execution of boot_iso role
       replace:
         after: "Mounting, Booting the Assisted Installer Discovery ISO"

--- a/ansible/ocp_custom_registries.yaml
+++ b/ansible/ocp_custom_registries.yaml
@@ -17,6 +17,7 @@
     environment:
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"
+    when: not (ocp_ai | bool)
 
   - name: wait for the machine config pools to update for image registry customizations
     shell: |
@@ -34,3 +35,4 @@
     ignore_errors: yes
     retries: "{{ (default_timeout / 5)|int }}"
     delay: 5
+    when: not (ocp_ai | bool)

--- a/ansible/templates/ai/cluster_mgnt_roles/70-image.yml.j2
+++ b/ansible/templates/ai/cluster_mgnt_roles/70-image.yml.j2
@@ -1,0 +1,15 @@
+apiVersion: config.openshift.io/v1
+kind: Image
+metadata:
+  name: cluster
+spec:
+  registrySources:
+    allowedRegistries:
+    - docker-registry.upshift.redhat.com
+    - registry.redhat.io
+    - quay.io
+    - registry-proxy.engineering.redhat.com
+    - gcr.io
+    insecureRegistries:
+    - docker-registry.upshift.redhat.com
+    - registry-proxy.engineering.redhat.com


### PR DESCRIPTION
Adds a new install-time manifest to AI OCP deployments so that custom registries are already configured when the cluster deploys, rather than spending extra time post-install to reconfigure