### PR TITLE
Bump OSP 16.2 and 17.0 tag and remove fencing workarounds

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -149,7 +149,14 @@ register_overcloud_nodes: hosts local-defaults.yaml
 	-i hosts \
 	-e @vars/${OSP_RELEASE}.yaml \
 	-e @local-defaults.yaml \
-	osp_register_overcloud_nodes.yaml \
+	osp_register_overcloud_nodes.yaml
+	$(MAKE) fencing_prep
+
+fencing_prep: hosts local-defaults.yaml
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-i hosts \
+	-e @vars/${OSP_RELEASE}.yaml \
+	-e @local-defaults.yaml \
 	osp_tripleo_fencing_overrides.yaml
 
 openstack_cleanup: hosts local-defaults.yaml

--- a/ansible/local_cert_tasks.yaml
+++ b/ansible/local_cert_tasks.yaml
@@ -40,6 +40,7 @@
       template:
         src: templates/local_CA/openssl.cnf.j2
         dest: /opt/local_CA/certs/openstack/openssl.cnf
+        mode: "0644"
       vars:
         control_plane_dns_name: "overcloud.{{ osp.domain_name }}"
         control_plane_ip_ctlplane: "{{ get_control_plane_ip_ctlplane.stdout|trim }}"

--- a/ansible/osp_deploy.yaml
+++ b/ansible/osp_deploy.yaml
@@ -12,7 +12,8 @@
     set_fact:
       deploy_yamls_dir: "{{ working_yamls_dir }}/deploy"
 
-  - debug:
+  - name: show yaml output dir
+    debug:
       msg: "yamls will be written to {{ deploy_yamls_dir }} locally"
 
   - name: Clean yaml dir

--- a/ansible/templates/osp/tripleo_fencing_overrides.yaml.j2
+++ b/ansible/templates/osp/tripleo_fencing_overrides.yaml.j2
@@ -3,48 +3,12 @@
   become: true
 
   tasks:
-  - name: Install Kubevirt fencing agent dependencies
-    shell: |
-      #!/bin/bash
-      /usr/libexec/platform-python -m pip install openshift
-
-  # Note: can be removed when is available https://review.opendev.org/q/topic:%22fence_kubevirt%22
-  - name: Pre-install certain packages
+  - name: Pre-install fencing agents which support fence_kubevirt
     package:
       state: installed
-      name: "{{ '{{' }} item {{ '}}' }}"
-    with_items:
-      - puppet-tripleo
-      - puppet-pacemaker
-      - patch
-      - patchutils
-
-  - name: Get noarch fencing agent dependencies
-    shell: |
-      curl -S http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/fence-agents/4.2.1/82.el8/noarch/ | grep "href=\"fence-agents" | cut -d '"' -f 6 | awk '{print "http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/fence-agents/4.2.1/82.el8/noarch/"$1}'
-    register: fence_agent_noarch_deps
-  
-  # Using yum module instead of package module here because the latter fails GPG key validation
-  - name: Pre-install latest fencing agents
-    yum:
-      name: "{{ '{{' }} fence_agent_noarch_deps.stdout_lines | join(',') {{ '}}' }}, http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/fence-agents/4.2.1/82.el8/x86_64/fence-agents-redfish-4.2.1-82.el8.x86_64.rpm, http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/fence-agents/4.2.1/82.el8/x86_64/fence-agents-kdump-4.2.1-82.el8.x86_64.rpm,  http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/fence-agents/4.2.1/82.el8/x86_64/fence-agents-kubevirt-4.2.1-82.el8.x86_64.rpm, http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/fence-agents/4.2.1/82.el8/x86_64/fence-agents-all-4.2.1-82.el8.x86_64.rpm"
-      state: installed
+      name:
+{% for pkg in fencing_agent_packages %}
+        - {{ pkg }}
+{% endfor %}
       disable_gpg_check: yes
       validate_certs: no
-
-  # Note: can be removed when is available https://review.opendev.org/q/topic:%22fence_kubevirt%22
-  - name: Apply patches to puppet modules on controller VMs
-    shell: |
-      #!/bin/bash
-      set -x
-      if ! curl https://review.opendev.org/changes/openstack%2Fpuppet-pacemaker~806924/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -R -s -f --dry-run -d /usr/share/openstack-puppet/modules/pacemaker -p1; then
-        curl https://review.opendev.org/changes/openstack%2Fpuppet-pacemaker~806924/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -d /usr/share/openstack-puppet/modules/pacemaker -b -z .orig -p1
-      fi
-      if ! curl https://review.opendev.org/changes/openstack%2Fpuppet-pacemaker~807299/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -R -s -f --dry-run -d /usr/share/openstack-puppet/modules/pacemaker -p1; then
-        curl https://review.opendev.org/changes/openstack%2Fpuppet-pacemaker~807299/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -d /usr/share/openstack-puppet/modules/pacemaker -b -z .orig -p1
-      fi
-      if [[ "{{ osp.release }}" == "16.2" ]]; then
-        if ! curl https://review.opendev.org/changes/openstack%2Fpuppet-tripleo~810682/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -R -s -f --dry-run -d /usr/share/openstack-puppet/modules/tripleo -p1; then
-          curl https://review.opendev.org/changes/openstack%2Fpuppet-tripleo~810682/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -d /usr/share/openstack-puppet/modules/tripleo -b -z .orig -p1
-        fi
-      fi

--- a/ansible/vars/17.0.yaml
+++ b/ansible/vars/17.0.yaml
@@ -1,10 +1,10 @@
 ---
-openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20211130.1
+openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20220124.1
 osp_rhos_release_compose: latest-RHOS-17-RHEL-8.4
 osp_release_defaults:
   release: 17.0
-  container_tag: 17.0_20211130.1
-  ceph_tag: 5-35
+  container_tag: 17.0_20220124.1
+  ceph_tag: 5-67
 ephemeral_heat:
   heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
   heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo

--- a/ansible/vars/17.0_ipv6.yaml
+++ b/ansible/vars/17.0_ipv6.yaml
@@ -1,11 +1,11 @@
 ---
-openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20211130.1
+openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20220124.1
 osp_rhos_release_compose: latest-RHOS-17-RHEL-8.4
 
 osp_release_defaults:
   release: 17.0
-  container_tag: 17.0_20211130.1
-  ceph_tag: 5-35
+  container_tag: 17.0_20220124.1
+  ceph_tag: 5-67
   networks: ipv6
   extrafeatures:
     - ipv6

--- a/ansible/vars/17.0_ipv6_subnet.yaml
+++ b/ansible/vars/17.0_ipv6_subnet.yaml
@@ -1,11 +1,11 @@
 ---
-openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20211130.1
+openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20220124.1
 osp_rhos_release_compose: latest-RHOS-17-RHEL-8.4
 
 osp_release_defaults:
   release: 17.0
-  container_tag: 17.0_20211130.1
-  ceph_tag: 5-35
+  container_tag: 17.0_20220124.1
+  ceph_tag: 5-67
   networks: ipv6_subnet
   vmset:
     Controller:

--- a/ansible/vars/17.0_subnet.yaml
+++ b/ansible/vars/17.0_subnet.yaml
@@ -1,5 +1,5 @@
 ---
-openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20211130.1
+openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20220124.1
 osp_rhos_release_compose: latest-RHOS-17-RHEL-8.4
 ephemeral_heat:
   heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
@@ -15,8 +15,8 @@ openstackclient_networks:
 
 osp_release_defaults:
   release: 17.0
-  container_tag: 17.0_20211130.1
-  ceph_tag: 5-35
+  container_tag: 17.0_20220124.1
+  ceph_tag: 5-67
   networks: ipv4_subnet
   vmset:
     Controller:

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -181,7 +181,7 @@ default_timeout: 240
 # openstackclient container image
 # TODO: change once we have a 16.2.2 tripleoclient image that includes ipa-client
 # openstackclient_image: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
-openstackclient_image: docker-registry.upshift.redhat.com/openstack-k8s-operators/openstack-tripleoclient:16.2_ipa_client
+openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp16-openstack-tripleoclient:16.2_20220209.2
 openstackclient_storage_class: host-nfs-storageclass
 openstackclient_networks:
   - ctlplane
@@ -258,7 +258,7 @@ osp_defaults:
     - name: datacentre2
       prefix: fa:16:3b
   preserve_reservations: true
-  container_tag: 16.2_20211110.2
+  container_tag: 16.2_20220209.2
   ceph_image: rhceph
   ceph_tag: 4-59
   # OSP deployment timeout
@@ -310,7 +310,12 @@ virt_sriov_domains:
   - "{{ ocp_cluster_name }}_worker_3"
   - "{{ ocp_cluster_name }}_worker_4"
 
+# enable fencing on overcloud controllers
 enable_fencing: false
+# fencing agent packages to be installed until available via RHEL channels and auto installed by tripleo
+fencing_agent_packages:
+  - https://people.redhat.com/~mschuppe/fence_agents/fence-agents-common-4.2.1-65.el8_4.2.osptest.noarch.rpm
+  - https://people.redhat.com/~mschuppe/fence_agents/fence-agents-kubevirt-4.2.1-65.el8_4.2.osptest.x86_64.rpm
 
 # HTTP Proxy
 http_proxy: ""


### PR DESCRIPTION
This bumps OSP container tag
- 16.2 to 16.2_20220209.2 and to use osp16-openstack-tripleoclient:16.2_20220209.2 openstackclient image
- 17.0 to 17.0_20220124.1 and to use openstack-tripleoclient:17.0_20220124.1 openstackclient image

Also:
- removes no longer needed fencing workarounds
- introduce fencing_agent_packages to control via var file which fencing agent packages to install as a prep for RHEL8/9 difference on 16.2/17.0