### PR TITLE
Add jq to README install requirements and majorly bump ai timeout

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -22,7 +22,7 @@ git clone git@github.com:openstack-k8s-operators/osp-director-dev-tools.git
 If not already installed, install the required dependencies
 
 ```
-dnf install -y ansible git libvirt-client python3-netaddr python3-lxml
+dnf install -y ansible git libvirt-client python3-netaddr python3-lxml jq
 ```
 
 > NOTE: make sure you install ansible >= 2.9 otherwise ansible collections will not work correctly
@@ -169,14 +169,14 @@ Now you can access the OCP console using your local web browser: <https://consol
 
 You can also access the OCP CLI:
 
-IPI: 
+IPI:
 ```
 su - ocp
 export KUBECONFIG=/home/ocp/dev-scripts/ocp/ostest/auth/kubeconfig
 oc get pods -n openstack
 ```
 
-AI: 
+AI:
 ```
 su - ocp
 export KUBECONFIG=/home/ocp/cluster_mgnt_roles/kubeconfig.ostest
@@ -216,7 +216,7 @@ make destroy_ocp
 
 #### Delete OSP overcloud only
 
-NOTE: This deletes the overcloud and the OCP resources that are associated with it.  
+NOTE: This deletes the overcloud and the OCP resources that are associated with it.
       It does not remove the OCP cluster nor the OSP-D operator, however.
 
 ```
@@ -225,8 +225,8 @@ make openstack_cleanup
 
 #### Delete the operator only
 
-NOTE: This deletes the OSP-D operator, but leaves any resources it deployed intact.  
-      However, if those resources later change and would require OCP reconciliation, 
+NOTE: This deletes the OSP-D operator, but leaves any resources it deployed intact.
+      However, if those resources later change and would require OCP reconciliation,
       the OSP-D operator will obviously not be present to act upon them.
 
 ```

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -589,7 +589,7 @@
         aicli -U http://192.168.111.1:{{ ocp_ai_service_port | default('8090', true) }} list cluster
       register: assisted_service_ready
       until: '"Dns Domain" in assisted_service_ready.stdout'
-      retries: 60
+      retries: "{{ default_timeout|int }}"
       delay: 10
       environment:
         PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin


### PR DESCRIPTION
Adds jq to the README for required dependencies. My beaker box
didn't have it and failed at [1]. Also bumps the retries on
waiting for the AI service (aicli list cluster). At 60 with
delay 10 this means 10 minutes which consistently times out
for me. Let's use (at least) default_timeout (240) which means
40 mins (locally I would set this even higher my latest run took
38 mins). At least lets make it configurable by wiring up the var.

[1] https://github.com/openstack-k8s-operators/osp-director-dev-tools/blob/fb19a57c21dc70a1b37731dcdb78854580aa05e2/ansible/local_cert_tasks.yaml#L9