### PR TITLE
v1.2.x - various backports

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -149,7 +149,14 @@ register_overcloud_nodes: hosts local-defaults.yaml
 	-i hosts \
 	-e @vars/${OSP_RELEASE}.yaml \
 	-e @local-defaults.yaml \
-	osp_register_overcloud_nodes.yaml \
+	osp_register_overcloud_nodes.yaml
+	$(MAKE) fencing_prep
+
+fencing_prep: hosts local-defaults.yaml
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-i hosts \
+	-e @vars/${OSP_RELEASE}.yaml \
+	-e @local-defaults.yaml \
 	osp_tripleo_fencing_overrides.yaml
 
 openstack_cleanup: hosts local-defaults.yaml

--- a/ansible/datavolume.yaml
+++ b/ansible/datavolume.yaml
@@ -51,6 +51,8 @@
             --run-command 'sed -i -e "s/^\(GRUB_CMDLINE_LINUX=.*\)net.ifnames=0 \(.*\)/\1\2/" /etc/default/grub' \
             --run-command 'grub2-mkconfig -o /etc/grub2.cfg' \
             --run-command 'rm -f /etc/sysconfig/network-scripts/ifcfg-ens* /etc/sysconfig/network-scripts/ifcfg-eth*'
+        environment:
+          LIBGUESTFS_BACKEND: direct
 
   - name: create datavolume for vmset roles
     include_tasks: datavolume_tasks.yaml

--- a/ansible/files/ospnetwork.xml
+++ b/ansible/files/ospnetwork.xml
@@ -10,4 +10,6 @@
   <mac address='52:54:00:7d:4c:46'/>
   <ip address='192.168.25.1' netmask='255.255.255.0'>
   </ip>
+  <ip family='ipv6' address='2001:db8:fd00:2000::1' prefix='64'>
+  </ip>
 </network>

--- a/ansible/install_networks.yaml
+++ b/ansible/install_networks.yaml
@@ -53,6 +53,8 @@
   # * can not use nmcli module https://github.com/ansible/ansible/issues/48055
   # * don't apply these persistent, in case of a host reboot those need to be reapplied
   - name: Create IPv4 gateways on isolated vlan networks
+    become: true
+    become_user: root
     vars:
       cidr_suffix: "{{ item.1.ipv4.cidr | regex_search('.*/(.+)', '\\1') | first }}"
     shell: |
@@ -72,6 +74,8 @@
     - item.1.ipv4.gateway is defined
 
   - name: Create IPv6 gateways on isolated vlan networks
+    become: true
+    become_user: root
     vars:
       cidr_suffix: "{{ item.1.ipv6.cidr | regex_search('.*/(.+)', '\\1') | first }}"
     shell: |

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -653,6 +653,21 @@
           insertafter: '^\s\s\s\s-\s50-master-scheduler\.yml'
           line: '    - 60-ingress-controller.yml'
 
+    - name: Add custom registries manifest
+      block:
+      - name: Create custom registries manifest
+        template:
+          src: ai/cluster_mgnt_roles/70-image.yml.j2
+          dest: "{{ base_path }}/cluster_mgnt_roles/create_cluster/templates/70-image.yml.j2"
+          mode: '0664'
+
+      - name: Inject custom registries manifest
+        lineinfile:
+          path: "{{ base_path }}/cluster_mgnt_roles/create_cluster/tasks/main.yml"
+          regexp: '^\s\s\s\s-\s70-image\.yml'
+          insertafter: '^\s\s\s\s-\s60-ingress-controller\.yml'
+          line: '    - 70-image.yml'
+
     - name: Force serial execution of boot_iso role
       replace:
         after: "Mounting, Booting the Assisted Installer Discovery ISO"

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -544,6 +544,12 @@
         regexp: 'SERVICE_BASE_URL=.*'
         replace: 'SERVICE_BASE_URL=http://192.168.111.1:{{ ocp_ai_service_port | default("8090", true) }}'
 
+    - name: Set assisted installer service image
+      ansible.builtin.lineinfile:
+        path: "{{ base_path }}/assisted-service-onprem/start-assisted-service.sh"
+        regexp: '^OAS_IMAGE='
+        line: 'OAS_IMAGE={{ ocp_ai_service_image | default("quay.io/ocpmetal/assisted-service:latest", true) }}'
+
     - name: Create dict of upstream AI onprem variables
       set_fact:
         ocp_ai_onprem_env_dict: "{{ ocp_ai_onprem_env_dict|default({}) | combine( {item.split('=')[0]: item.split('=')[1]} ) }}"

--- a/ansible/ocp_custom_registries.yaml
+++ b/ansible/ocp_custom_registries.yaml
@@ -17,6 +17,7 @@
     environment:
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"
+    when: not (ocp_ai | bool)
 
   - name: wait for the machine config pools to update for image registry customizations
     shell: |
@@ -34,3 +35,4 @@
     ignore_errors: yes
     retries: "{{ (default_timeout / 5)|int }}"
     delay: 5
+    when: not (ocp_ai | bool)

--- a/ansible/ocp_default_storageclass.yaml
+++ b/ansible/ocp_default_storageclass.yaml
@@ -9,9 +9,9 @@
     - size: 4
       number: 16
     - size: 128
-      number: 8
-    - size: 128
       number: 4
+    - size: 128
+      number: 8
       shared: true
     exports: "{{ pvs | expand_pvs | list }}"
 
@@ -91,6 +91,11 @@
   - name: Set directory for host-nfs-storageclass yaml files
     set_fact:
       yaml_dir: "{{ working_yamls_dir }}/host-nfs-storageclass"
+
+  - name: Clean yaml dir
+    file:
+      state: absent
+      path: "{{ yaml_dir }}/"
 
   - name: Create local yamldir
     file:

--- a/ansible/openstack_cleanup.yaml
+++ b/ansible/openstack_cleanup.yaml
@@ -7,7 +7,7 @@
   tasks:
   - name: openstack cleanup
     command: "{{ item }}"
-    environment:
+    environment: &oc_env
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"
     ignore_errors: true
@@ -28,6 +28,15 @@
     file:
       path: /home/git/playbooks.git
       state: absent
+
+  - name: Remove bindings of PV's in Failed or Released state
+    environment:
+      <<: *oc_env
+    shell: |
+      #!/bin/bash
+      for i in $(oc get pv | egrep "Failed|Released" | awk {'print $1'}); do
+        oc patch pv $i --type='json' -p='[{"op": "remove", "path": "/spec/claimRef"}]'
+      done
 
   - name: Detach additional Ceph OSD disks
     become: true

--- a/ansible/osp_tripleo_fencing_overrides.yaml
+++ b/ansible/osp_tripleo_fencing_overrides.yaml
@@ -55,7 +55,7 @@
     - name: Run TripleO fencing overrides playbook via openstackclient
       shell: |
         #!/bin/bash
-        oc rsh -n {{ namespace }} openstackclient ansible-playbook -i /home/cloud-admin/playbooks/tripleo-ansible/tripleo-ansible-inventory.yaml /home/cloud-admin/tripleo_fencing_overrides.yaml
+        oc rsh -n {{ namespace }} openstackclient ansible-playbook -i /home/cloud-admin/ctlplane-ansible-inventory /home/cloud-admin/tripleo_fencing_overrides.yaml
       environment:
         <<: *oc_env
     when: max_vm_role_count|int > 2

--- a/ansible/templates/ai/cluster_mgnt_roles/70-image.yml.j2
+++ b/ansible/templates/ai/cluster_mgnt_roles/70-image.yml.j2
@@ -1,0 +1,15 @@
+apiVersion: config.openshift.io/v1
+kind: Image
+metadata:
+  name: cluster
+spec:
+  registrySources:
+    allowedRegistries:
+    - docker-registry.upshift.redhat.com
+    - registry.redhat.io
+    - quay.io
+    - registry-proxy.engineering.redhat.com
+    - gcr.io
+    insecureRegistries:
+    - docker-registry.upshift.redhat.com
+    - registry-proxy.engineering.redhat.com

--- a/ansible/templates/osp/netconfig/osnetconfig.yaml.j2
+++ b/ansible/templates/osp/netconfig/osnetconfig.yaml.j2
@@ -28,6 +28,10 @@ spec:
             type: ethernet
 {% endif %}
             state: up
+            ipv4:
+              enabled: false
+            ipv6:
+              enabled: false
 {% if ifcfg.mtu is defined %}
             mtu: {{ ifcfg.mtu }}
 {% endif %}
@@ -103,15 +107,23 @@ spec:
       name: {{ physnet.name }}
 {% endfor %}
 {% endif %}
-{% if osp.ovn_bridge_mac_mappings.static_reservations is defined and osp.ovn_bridge_mac_mappings.static_reservations|length %}
-    staticReservations:
-{% for node, reservations in osp.ovn_bridge_mac_mappings.static_reservations.items() %}
-      {{ node }}:
-        reservations:
-{% for physnet, reservation in reservations.items() %}
-          {{ physnet }}: {{ reservation }}
-{% endfor %}
+{% endif %}
+{% if osp_reservations is defined and osp_reservations|length %}
+  reservations:
+{% for node, reservations in osp_reservations.items() %}
+    {{ node }}:
+{% if reservations.ip_reservations is defined and reservations.ip_reservations|length %}
+      ipReservations:
+{% for subnet, reservation in reservations.ip_reservations.items() %}
+        {{ subnet  }}: {{ reservation }}
 {% endfor %}
 {% endif %}
+{% if reservations.mac_reservations is defined and reservations.mac_reservations|length %}
+      macReservations:
+{% for physnet, reservation in reservations.mac_reservations.items() %}
+        {{ physnet }}: {{ reservation }}
+{% endfor %}
+{% endif %}
+{% endfor %}
 {% endif %}
   preserveReservations: {{ osp.preserve_reservations|default(true)|bool }}

--- a/ansible/templates/osp/tripleo_fencing_overrides.yaml.j2
+++ b/ansible/templates/osp/tripleo_fencing_overrides.yaml.j2
@@ -3,48 +3,12 @@
   become: true
 
   tasks:
-  - name: Install Kubevirt fencing agent dependencies
-    shell: |
-      #!/bin/bash
-      /usr/libexec/platform-python -m pip install openshift
-
-  # Note: can be removed when is available https://review.opendev.org/q/topic:%22fence_kubevirt%22
-  - name: Pre-install certain packages
+  - name: Pre-install fencing agents which support fence_kubevirt
     package:
       state: installed
-      name: "{{ '{{' }} item {{ '}}' }}"
-    with_items:
-      - puppet-tripleo
-      - puppet-pacemaker
-      - patch
-      - patchutils
-
-  - name: Get noarch fencing agent dependencies
-    shell: |
-      curl -S http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/fence-agents/4.2.1/82.el8/noarch/ | grep "href=\"fence-agents" | cut -d '"' -f 6 | awk '{print "http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/fence-agents/4.2.1/82.el8/noarch/"$1}'
-    register: fence_agent_noarch_deps
-  
-  # Using yum module instead of package module here because the latter fails GPG key validation
-  - name: Pre-install latest fencing agents
-    yum:
-      name: "{{ '{{' }} fence_agent_noarch_deps.stdout_lines | join(',') {{ '}}' }}, http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/fence-agents/4.2.1/82.el8/x86_64/fence-agents-redfish-4.2.1-82.el8.x86_64.rpm, http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/fence-agents/4.2.1/82.el8/x86_64/fence-agents-kdump-4.2.1-82.el8.x86_64.rpm,  http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/fence-agents/4.2.1/82.el8/x86_64/fence-agents-kubevirt-4.2.1-82.el8.x86_64.rpm, http://download.eng.bos.redhat.com/brewroot/vol/rhel-8/packages/fence-agents/4.2.1/82.el8/x86_64/fence-agents-all-4.2.1-82.el8.x86_64.rpm"
-      state: installed
+      name:
+{% for pkg in fencing_agent_packages %}
+        - {{ pkg }}
+{% endfor %}
       disable_gpg_check: yes
       validate_certs: no
-
-  # Note: can be removed when is available https://review.opendev.org/q/topic:%22fence_kubevirt%22
-  - name: Apply patches to puppet modules on controller VMs
-    shell: |
-      #!/bin/bash
-      set -x
-      if ! curl https://review.opendev.org/changes/openstack%2Fpuppet-pacemaker~806924/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -R -s -f --dry-run -d /usr/share/openstack-puppet/modules/pacemaker -p1; then
-        curl https://review.opendev.org/changes/openstack%2Fpuppet-pacemaker~806924/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -d /usr/share/openstack-puppet/modules/pacemaker -b -z .orig -p1
-      fi
-      if ! curl https://review.opendev.org/changes/openstack%2Fpuppet-pacemaker~807299/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -R -s -f --dry-run -d /usr/share/openstack-puppet/modules/pacemaker -p1; then
-        curl https://review.opendev.org/changes/openstack%2Fpuppet-pacemaker~807299/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -d /usr/share/openstack-puppet/modules/pacemaker -b -z .orig -p1
-      fi
-      if [[ "{{ osp.release }}" == "16.2" ]]; then
-        if ! curl https://review.opendev.org/changes/openstack%2Fpuppet-tripleo~810682/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -R -s -f --dry-run -d /usr/share/openstack-puppet/modules/tripleo -p1; then
-          curl https://review.opendev.org/changes/openstack%2Fpuppet-tripleo~810682/revisions/1/patch?download | base64 -d | filterdiff -p1 -x 'spec/*' | patch -d /usr/share/openstack-puppet/modules/tripleo -b -z .orig -p1
-        fi
-      fi

--- a/ansible/vars/17.0.yaml
+++ b/ansible/vars/17.0.yaml
@@ -1,10 +1,10 @@
 ---
-openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20211130.1
+openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20220124.1
 osp_rhos_release_compose: latest-RHOS-17-RHEL-8.4
 osp_release_defaults:
   release: 17.0
-  container_tag: 17.0_20211130.1
-  ceph_tag: 5-35
+  container_tag: 17.0_20220124.1
+  ceph_tag: 5-67
 ephemeral_heat:
   heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
   heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo

--- a/ansible/vars/17.0_ipv6.yaml
+++ b/ansible/vars/17.0_ipv6.yaml
@@ -1,11 +1,11 @@
 ---
-openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20211130.1
+openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20220124.1
 osp_rhos_release_compose: latest-RHOS-17-RHEL-8.4
 
 osp_release_defaults:
   release: 17.0
-  container_tag: 17.0_20211130.1
-  ceph_tag: 5-35
+  container_tag: 17.0_20220124.1
+  ceph_tag: 5-67
   networks: ipv6
   extrafeatures:
     - ipv6

--- a/ansible/vars/17.0_ipv6_subnet.yaml
+++ b/ansible/vars/17.0_ipv6_subnet.yaml
@@ -1,11 +1,11 @@
 ---
-openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20211130.1
+openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20220124.1
 osp_rhos_release_compose: latest-RHOS-17-RHEL-8.4
 
 osp_release_defaults:
   release: 17.0
-  container_tag: 17.0_20211130.1
-  ceph_tag: 5-35
+  container_tag: 17.0_20220124.1
+  ceph_tag: 5-67
   networks: ipv6_subnet
   vmset:
     Controller:

--- a/ansible/vars/17.0_subnet.yaml
+++ b/ansible/vars/17.0_subnet.yaml
@@ -1,5 +1,5 @@
 ---
-openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20211130.1
+openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:17.0_20220124.1
 osp_rhos_release_compose: latest-RHOS-17-RHEL-8.4
 ephemeral_heat:
   heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
@@ -15,8 +15,8 @@ openstackclient_networks:
 
 osp_release_defaults:
   release: 17.0
-  container_tag: 17.0_20211130.1
-  ceph_tag: 5-35
+  container_tag: 17.0_20220124.1
+  ceph_tag: 5-67
   networks: ipv4_subnet
   vmset:
     Controller:

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -257,10 +257,6 @@ osp_defaults:
       prefix: fa:16:3a
     - name: datacentre2
       prefix: fa:16:3b
-    static_reservations:
-      controller-0:
-        datacentre: fa:16:3a:aa:aa:aa
-        datacentre2: fa:16:3b:aa:aa:aa
   preserve_reservations: true
   container_tag: 16.2_20211110.2
   ceph_image: rhceph

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -181,7 +181,7 @@ default_timeout: 240
 # openstackclient container image
 # TODO: change once we have a 16.2.2 tripleoclient image that includes ipa-client
 # openstackclient_image: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
-openstackclient_image: docker-registry.upshift.redhat.com/openstack-k8s-operators/openstack-tripleoclient:16.2_ipa_client
+openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp16-openstack-tripleoclient:16.2_20220209.2
 openstackclient_storage_class: host-nfs-storageclass
 openstackclient_networks:
   - ctlplane
@@ -258,7 +258,7 @@ osp_defaults:
     - name: datacentre2
       prefix: fa:16:3b
   preserve_reservations: true
-  container_tag: 16.2_20211110.2
+  container_tag: 16.2_20220209.2
   ceph_image: rhceph
   ceph_tag: 4-59
   # OSP deployment timeout
@@ -310,7 +310,12 @@ virt_sriov_domains:
   - "{{ ocp_cluster_name }}_worker_3"
   - "{{ ocp_cluster_name }}_worker_4"
 
+# enable fencing on overcloud controllers
 enable_fencing: false
+# fencing agent packages to be installed until available via RHEL channels and auto installed by tripleo
+fencing_agent_packages:
+  - https://people.redhat.com/~mschuppe/fence_agents/fence-agents-common-4.2.1-65.el8_4.2.osptest.noarch.rpm
+  - https://people.redhat.com/~mschuppe/fence_agents/fence-agents-kubevirt-4.2.1-65.el8_4.2.osptest.x86_64.rpm
 
 # HTTP Proxy
 http_proxy: ""

--- a/ansible/vars/ipv4.yaml
+++ b/ansible/vars/ipv4.yaml
@@ -78,3 +78,46 @@ osp_networks:
           start: 172.20.0.10
           end: 172.20.0.250
       attach_config: br-osp
+osp_reservations:
+  openstackclient-0:
+    ip_reservations:
+      ctlplane: 192.168.25.251
+      external: 10.0.0.251
+      internal_api: 172.17.0.251
+  controlplane:
+    ip_reservations:
+      ctlplane: 192.168.25.10
+      external: 10.0.0.10
+      internal_api: 172.17.0.10
+      storage: 172.18.0.10
+      storage_mgmt: 172.19.0.10
+  controller-0:
+    ip_reservations:
+      ctlplane: 192.168.25.20
+      external: 10.0.0.20
+      internal_api: 172.17.0.20
+      storage: 172.18.0.20
+      storage_mgmt: 172.19.0.20
+      tenant: 172.20.0.20
+    mac_reservations:
+      datacentre: fa:16:3a:aa:aa:aa
+      datacentre2: fa:16:3b:aa:aa:aa
+  controller-1:
+    ip_reservations:
+      ctlplane: 192.168.25.30
+      external: 10.0.0.30
+      internal_api: 172.17.0.30
+      storage: 172.18.0.30
+      storage_mgmt: 172.19.0.30
+      tenant: 172.20.0.30
+    macReservations:
+      datacentre: fa:16:3a:aa:aa:bb
+      datacentre2: fa:16:3b:aa:aa:bb
+  compute-0:
+    ip_reservations:
+      ctlplane: 192.168.25.40
+      internal_api: 172.17.0.40
+      storage: 172.18.0.40
+      tenant: 172.20.0.40
+    macReservations:
+      datacentre: fa:16:3a:bb:bb:bb

--- a/ansible/vars/ipv4_subnet.yaml
+++ b/ansible/vars/ipv4_subnet.yaml
@@ -216,3 +216,52 @@ osp_networks:
         - destination: 172.20.1.0/24
           nexthop: 172.20.2.1
       attach_config: br-osp
+osp_reservations:
+  openstackclient-0:
+    ip_reservations:
+      ctlplane: 192.168.25.251
+      external: 10.0.0.251
+      internal_api: 172.17.0.251
+  controlplane:
+    ip_reservations:
+      ctlplane: 192.168.25.10
+      external: 10.0.0.10
+      internal_api: 172.17.0.10
+      storage: 172.18.0.10
+      storage_mgmt: 172.19.0.10
+  controller-0:
+    ip_reservations:
+      ctlplane: 192.168.25.20
+      external: 10.0.0.20
+      internal_api: 172.17.0.20
+      storage: 172.18.0.20
+      storage_mgmt: 172.19.0.20
+      tenant: 172.20.0.20
+    mac_reservations:
+      datacentre: fa:16:3a:aa:aa:aa
+      datacentre2: fa:16:3b:aa:aa:aa
+  controller-1:
+    ip_reservations:
+      ctlplane: 192.168.25.30
+      external: 10.0.0.30
+      internal_api: 172.17.0.30
+      storage: 172.18.0.30
+      storage_mgmt: 172.19.0.30
+      tenant: 172.20.0.30
+    macReservations:
+      datacentre: fa:16:3a:aa:aa:bb
+      datacentre2: fa:16:3b:aa:aa:bb
+  compute-0:
+    ip_reservations:
+      ctlplane: 192.168.25.40
+      internal_api: 172.17.0.40
+      storage: 172.18.0.40
+      tenant: 172.20.0.40
+    macReservations:
+      datacentre: fa:16:3a:bb:bb:bb
+  computeleaf1-0:
+    ip_reservations:
+      ctlplane: 192.168.25.50
+      internal_api_leaf1: 172.17.1.40
+      storage_leaf1: 172.18.1.40
+      tenant_leaf1: 172.20.1.40

--- a/ansible/vars/ipv6.yaml
+++ b/ansible/vars/ipv6.yaml
@@ -78,3 +78,46 @@ osp_networks:
           start: 172.20.0.10
           end: 172.20.0.250
       attach_config: br-osp
+osp_reservations:
+  openstackclient-0:
+    ip_reservations:
+      ctlplane: 192.168.25.251
+      external: 2001:db8:fd00:1000::251
+      internal_api: fd00:fd00:fd00:2000::251
+  controlplane:
+    ip_reservations:
+      ctlplane: 192.168.25.10
+      external: 2001:db8:fd00:1000::10
+      internal_api: fd00:fd00:fd00:2000::10
+      storage: fd00:fd00:fd00:3000::10
+      storage_mgmt: fd00:fd00:fd00:4000::10
+  controller-0:
+    ip_reservations:
+      ctlplane: 192.168.25.20
+      external: 2001:db8:fd00:1000::20
+      internal_api: fd00:fd00:fd00:2000::20
+      storage: fd00:fd00:fd00:3000::20
+      storage_mgmt: fd00:fd00:fd00:4000::20
+      tenant: 172.20.0.20
+    mac_reservations:
+      datacentre: fa:16:3a:aa:aa:aa
+      datacentre2: fa:16:3b:aa:aa:aa
+  controller-1:
+    ip_reservations:
+      ctlplane: 192.168.25.30
+      external: 2001:db8:fd00:1000::30
+      internal_api: fd00:fd00:fd00:2000::30
+      storage: fd00:fd00:fd00:3000::30
+      storage_mgmt: fd00:fd00:fd00:4000::30
+      tenant: 172.20.0.30
+    macReservations:
+      datacentre: fa:16:3a:aa:aa:bb
+      datacentre2: fa:16:3b:aa:aa:bb
+  compute-0:
+    ip_reservations:
+      ctlplane: 192.168.25.40
+      internal_api: fd00:fd00:fd00:2000::40
+      storage: fd00:fd00:fd00:3000::40
+      tenant: 172.20.0.40
+    macReservations:
+      datacentre: fa:16:3a:bb:bb:bb

--- a/ansible/vars/ipv6_subnet.yaml
+++ b/ansible/vars/ipv6_subnet.yaml
@@ -217,3 +217,52 @@ osp_networks:
         - destination: 172.20.1.0/24
           nexthop: 172.20.2.1
       attach_config: br-osp
+osp_reservations:
+  openstackclient-0:
+    ip_reservations:
+      ctlplane: 192.168.25.251
+      external: 2001:db8:fd00:1000::251
+      internal_api: fd00:fd00:fd00:2000::251
+  controlplane:
+    ip_reservations:
+      ctlplane: 192.168.25.10
+      external: 2001:db8:fd00:1000::10
+      internal_api: fd00:fd00:fd00:2000::10
+      storage: fd00:fd00:fd00:3000::10
+      storage_mgmt: fd00:fd00:fd00:4000::10
+  controller-0:
+    ip_reservations:
+      ctlplane: 192.168.25.20
+      external: 2001:db8:fd00:1000::20
+      internal_api: fd00:fd00:fd00:2000::20
+      storage: fd00:fd00:fd00:3000::20
+      storage_mgmt: fd00:fd00:fd00:4000::20
+      tenant: 172.20.0.20
+    mac_reservations:
+      datacentre: fa:16:3a:aa:aa:aa
+      datacentre2: fa:16:3b:aa:aa:aa
+  controller-1:
+    ip_reservations:
+      ctlplane: 192.168.25.30
+      external: 2001:db8:fd00:1000::30
+      internal_api: fd00:fd00:fd00:2000::30
+      storage: fd00:fd00:fd00:3000::30
+      storage_mgmt: fd00:fd00:fd00:4000::30
+      tenant: 172.20.0.30
+    macReservations:
+      datacentre: fa:16:3a:aa:aa:bb
+      datacentre2: fa:16:3b:aa:aa:bb
+  compute-0:
+    ip_reservations:
+      ctlplane: 192.168.25.40
+      internal_api: fd00:fd00:fd00:2000::40
+      storage: fd00:fd00:fd00:3000::40
+      tenant: 172.20.0.40
+    macReservations:
+      datacentre: fa:16:3a:bb:bb:bb
+  computeleaf1-0:
+    ip_reservations:
+      ctlplane: 192.168.25.50
+      internal_api_leaf1: fd00:fd00:fd00:2001::40
+      storage_leaf1: fd00:fd00:fd00:3001::40
+      tenant_leaf1: 172.20.1.40

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -26,4 +26,7 @@ ocp_ai_prov_bridge_worker_mac_prefix: 3c:fd:fe:78:cd:1
 # ocp_ai_service_store_dir: defaults to "/opt/assisted-service"
 # ocp_ai_service_port: defaults to "8090"
 
+# for now pin the ai image to a more stable tag - lastest started to fail on Feb 14th
+ocp_ai_service_image: quay.io/ocpmetal/assisted-service:v2.0.11
+
 ocp_ai_libvirt_storage_dir: /var/lib/libvirt/images


### PR DESCRIPTION
clean backports for v1.2.x branch of the following patches:
```
44445834b5560e2f271d5a1c849766af182c0028 - Fix inventory for fencing override playbook
c01ea372f75f8e415cf0ba4c3aa78daa76fc6e11 - On cleanup, remove bindings of PV's in Failed or Released state
fb19a57c21dc70a1b37731dcdb78854580aa05e2 - [OSPK8-327] static ip reservation (#289)
9b67296fa5ad3d332ee0530d9d405926886defaf - Bump OSP tag to 16.2_20220209.2 and remove fencing workarounds
26900309efc3a0619b7c4d3d936f68378f0f67d7 - bump osp17 tag to 17.0_20220124.1
1361994d3f5d8420b3ce680a70a762991dc095ef - Front-load custom registries for AI (#291)
e80f13089bddb8a69d37b0258579a4c48eeda6bf - pin AI service image to v2.0.11 tag
033e08d743d17d830501e615af3bae8966b82735 - use LIBGUESTFS_BACKEND=direct for virt-customize
b929910b7e17110ab7cad8cafe9fc80dff57f92e - Make sure subnet gateway tasks run as root user
```

Depends-On: https://github.com/openstack-k8s-operators/osp-director-operator/pull/515