### PR TITLE
Change freeipa-server image tag to centos-8-stream

### DIFF
--- a/ansible/freeipa.yaml
+++ b/ansible/freeipa.yaml
@@ -41,7 +41,7 @@
           ip: 10.89.0.2
           conmon_pidfile: /run/podman-freeipa-server-conman.pid
           hostname: freeipa.test.metalkube.org
-          image: quay.io/freeipa/freeipa-server:centos-8
+          image: quay.io/freeipa/freeipa-server:centos-8-stream
           #FIXME: need this to workaround a bug in podman ansible module
           stop_signal: 37
           env:


### PR DESCRIPTION
Deployment fails right now as the centos-8 tage got removed:

~~~
0;31mtime="2022-02-23T06:59:46Z" level=warning msg="failed, retrying in 1s ... (1/3). Error: Error initializing source docker://quay.io/freeipa/freeipa-server:centos-8: Error reading manifest centos-8 in quay.io/freeipa/freeipa-server: unknown: Tag centos-8 was deleted or has expired. To pull, revive via time machine"[0m
~~~

Let change the tag to centos-8-stream