### PR TITLE
Fix train_subnet networks definition and wait for osnetcfg finished

### DIFF
--- a/ansible/install_networks.yaml
+++ b/ansible/install_networks.yaml
@@ -41,13 +41,20 @@
   - name: Start networks
     shell: |
       set -e
-      oc apply -n openstack -f "{{ network_yaml_dir }}"
+      oc apply -n {{ namespace }} -f "{{ network_yaml_dir }}"
     environment: &oc_env
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"
     # Retry on failure, probably osnet does not exist yet
     retries: 15
     delay: 10
+
+  - name: wait for osnetcfg to have configured interfaces + networks
+    shell: |
+      set -e
+      oc wait osnetcfg --for condition=provisioned -n {{ namespace }} openstacknetconfig --timeout="{{ (default_timeout * 2)|int }}s"
+    environment:
+      <<: *oc_env
 
   # Notes:
   # * can not use nmcli module https://github.com/ansible/ansible/issues/48055

--- a/ansible/vars/train_subnet.yaml
+++ b/ansible/vars/train_subnet.yaml
@@ -19,6 +19,7 @@ osp_release_defaults:
   #TODO: which ceph images tag to use for upstream train?
   #ceph_tag: 5-12
   #ceph_image: daemon
+  networks: ipv4_subnet
   vmset:
     Controller:
       count: 1


### PR DESCRIPTION
Sometimes the create of the osnetcfg and related resources take longer and
later tasks fail, e.g. get ControlPlane IP. Lets wait for the osnetcfg to have its resources created correct or fail early.

Also fixes the used networks definition for train_subnet scenario.