### PR TITLE
[OSPK8-447] Fix ipv6 routes and scenario config errors

### DIFF
--- a/ansible/files/osp/16.2/net-config-two-nic-vlan-compute.yaml
+++ b/ansible/files/osp/16.2/net-config-two-nic-vlan-compute.yaml
@@ -54,6 +54,14 @@ parameters:
       Unless the default is changed, the parameter is automatically resolved
       from the subnet host_routes attribute.
     type: json
+  StorageRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   InternalApiIpSubnet:
     default: ''
     description: IP address/subnet on the internal_api network
@@ -76,6 +84,14 @@ parameters:
       Unless the default is changed, the parameter is automatically resolved
       from the subnet host_routes attribute.
     type: json
+  InternalApiRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   TenantIpSubnet:
     default: ''
     description: IP address/subnet on the tenant network
@@ -91,6 +107,14 @@ parameters:
       Tenant network.
     type: number
   TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantRoutes:
     default: []
     description: >
       Routes for the tenant network traffic.
@@ -185,6 +209,7 @@ resources:
                       get_param: StorageIpSubnet
                   routes:
                     list_concat_unique:
+                      - get_param: StorageRoutes
                       - get_param: StorageInterfaceRoutes
                 - type: vlan
                   mtu:
@@ -196,6 +221,7 @@ resources:
                       get_param: InternalApiIpSubnet
                   routes:
                     list_concat_unique:
+                      - get_param: InternalApiRoutes
                       - get_param: InternalApiInterfaceRoutes
                 - type: vlan
                   mtu:
@@ -207,6 +233,7 @@ resources:
                       get_param: TenantIpSubnet
                   routes:
                     list_concat_unique:
+                      - get_param: TenantRoutes
                       - get_param: TenantInterfaceRoutes
               - type: ovs_bridge
                 # This will default to br-ex, anything else requires specific

--- a/ansible/files/osp/16.2/net-config-two-nic-vlan-computehci.yaml
+++ b/ansible/files/osp/16.2/net-config-two-nic-vlan-computehci.yaml
@@ -54,6 +54,14 @@ parameters:
       Unless the default is changed, the parameter is automatically resolved
       from the subnet host_routes attribute.
     type: json
+  StorageRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   StorageMgmtIpSubnet:
     default: ''
     description: IP address/subnet on the storage_mgmt network
@@ -69,6 +77,14 @@ parameters:
       StorageMgmt network.
     type: number
   StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtRoutes:
     default: []
     description: >
       Routes for the storage_mgmt network traffic.
@@ -98,6 +114,14 @@ parameters:
       Unless the default is changed, the parameter is automatically resolved
       from the subnet host_routes attribute.
     type: json
+  InternalApiRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   TenantIpSubnet:
     default: ''
     description: IP address/subnet on the tenant network
@@ -113,6 +137,14 @@ parameters:
       Tenant network.
     type: number
   TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantRoutes:
     default: []
     description: >
       Routes for the tenant network traffic.
@@ -208,6 +240,7 @@ resources:
                       get_param: StorageIpSubnet
                   routes:
                     list_concat_unique:
+                      - get_param: StorageRoutes
                       - get_param: StorageInterfaceRoutes
                 - type: vlan
                   mtu:
@@ -219,6 +252,7 @@ resources:
                       get_param: StorageMgmtIpSubnet
                   routes:
                     list_concat_unique:
+                      - get_param: StorageMgmtRoutes
                       - get_param: StorageMgmtInterfaceRoutes
                 - type: vlan
                   mtu:
@@ -230,6 +264,7 @@ resources:
                       get_param: InternalApiIpSubnet
                   routes:
                     list_concat_unique:
+                      - get_param: InternalApiRoutes
                       - get_param: InternalApiInterfaceRoutes
                 - type: vlan
                   mtu:
@@ -241,6 +276,7 @@ resources:
                       get_param: TenantIpSubnet
                   routes:
                     list_concat_unique:
+                      - get_param: TenantRoutes
                       - get_param: TenantInterfaceRoutes
               - type: ovs_bridge
                 # This will default to br-ex, anything else requires specific

--- a/ansible/templates/osp/tripleo_heat_envs/features/16.2/ipv6/ipv6.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/features/16.2/ipv6/ipv6.yaml.j2
@@ -15,3 +15,8 @@ parameter_defaults:
   ManilaIPv6: True
   # Enable IPv6 environment for Redis.
   RedisIPv6: True
+
+  # Workaround until we have https://review.opendev.org/c/openstack/tripleo-heat-templates/+/832520 in the release
+  InternalApiRoutes: [{'destination': 'fd00:fd00:fd00:2001::/64', 'nexthop': 'fd00:fd00:fd00:2000::1'}, {'destination': 'fd00:fd00:fd00:2002::/64', 'nexthop': 'fd00:fd00:fd00:2000::1'}]
+  StorageRoutes: [{'destination': 'fd00:fd00:fd00:3001::/64', 'nexthop': 'fd00:fd00:fd00:3000::1'}, {'destination': 'fd00:fd00:fd00:3002::/64', 'nexthop': 'fd00:fd00:fd00:3000::1'}]
+  StorageMgmtRoutes: [{'destination': 'fd00:fd00:fd00:4001::/64', 'nexthop': 'fd00:fd00:fd00:4000::1'}, {'destination': 'fd00:fd00:fd00:4002::/64', 'nexthop': 'fd00:fd00:fd00:4000::1'}]

--- a/ansible/vars/16.2_ipv6_novacontrol_hci_tlse_subnet.yaml
+++ b/ansible/vars/16.2_ipv6_novacontrol_hci_tlse_subnet.yaml
@@ -47,6 +47,7 @@ osp_release_defaults:
         - internal_api_leaf1
         - tenant_leaf1
         - storage_leaf1
+        - storage_mgmt_leaf1
     ComputeHCILeaf2:
       count: 1
       ctlplane_interface: enp7s0
@@ -55,6 +56,7 @@ osp_release_defaults:
         - internal_api_leaf2
         - tenant_leaf2
         - storage_leaf2
+        - storage_mgmt_leaf2
   extrafeatures:
   - hci
   - ipv6

--- a/ansible/vars/16.2_novacontrol_hci_subnet.yaml
+++ b/ansible/vars/16.2_novacontrol_hci_subnet.yaml
@@ -45,6 +45,7 @@ osp_release_defaults:
         - internal_api_leaf1
         - tenant_leaf1
         - storage_leaf1
+        - storage_mgmt_leaf1
     ComputeHCILeaf2:
       count: 1
       ctlplane_interface: enp7s0
@@ -53,6 +54,7 @@ osp_release_defaults:
         - internal_api_leaf2
         - tenant_leaf2
         - storage_leaf2
+        - storage_mgmt_leaf2
   extrafeature:
     - hci
 

--- a/ansible/vars/16.2_novacontrol_hci_tlse_subnet.yaml
+++ b/ansible/vars/16.2_novacontrol_hci_tlse_subnet.yaml
@@ -47,6 +47,7 @@ osp_release_defaults:
         - internal_api_leaf1
         - tenant_leaf1
         - storage_leaf1
+        - storage_mgmt_leaf1
     ComputeHCILeaf2:
       count: 1
       ctlplane_interface: enp7s0
@@ -55,6 +56,7 @@ osp_release_defaults:
         - internal_api_leaf2
         - tenant_leaf2
         - storage_leaf2
+        - storage_mgmt_leaf2
   extrafeature:
     - hci
 


### PR DESCRIPTION
Check depends on PR for more details on NIC template changes.

Also adds workaround for multi subnet ipv6 routes until there is https://review.opendev.org/c/openstack/tripleo-heat-templates/+/832520 in the release

```
  InternalApiRoutes: [{'destination': 'fd00:fd00:fd00:2001::/64', 'nexthop': 'fd00:fd00:fd00:2000::1'}, {'destination': 'fd00:fd00:fd00:2002::/64', 'nexthop': 'fd00:fd00:fd00:2000::1'}]
  StorageRoutes: [{'destination': 'fd00:fd00:fd00:3001::/64', 'nexthop': 'fd00:fd00:fd00:3000::1'}, {'destination': 'fd00:fd00:fd00:3002::/64', 'nexthop': 'fd00:fd00:fd00:3000::1'}]
  StorageMgmtRoutes: [{'destination': 'fd00:fd00:fd00:4001::/64', 'nexthop': 'fd00:fd00:fd00:4000::1'}, {'destination': 'fd00:fd00:fd00:4002::/64', 'nexthop': 'fd00:fd00:fd00:4000::1'}]
```

Depends-On: https://github.com/openstack-k8s-operators/osp-director-operator/pull/529