### PR TITLE
[OSPK8-449] Automate compose/puddle information based on input file

### DIFF
--- a/ansible/ocp_dev_scripts_destroy.yaml
+++ b/ansible/ocp_dev_scripts_destroy.yaml
@@ -1,4 +1,10 @@
+
 ---
+- hosts: localhost
+  vars_files: vars/default.yaml
+  roles:
+  - oc_local
+
 - hosts: convergence_base
   become: true
   become_user: ocp

--- a/ansible/openstack_cleanup.yaml
+++ b/ansible/openstack_cleanup.yaml
@@ -81,3 +81,8 @@
       state: restarted
     when:
       - ctlplane_dnsmasq.changed
+
+  - name: Remove "{{ working_vars_dir }}"
+    file:
+      path: "{{ working_vars_dir }}"
+      state: absent

--- a/ansible/roles/oc_local/tasks/main.yaml
+++ b/ansible/roles/oc_local/tasks/main.yaml
@@ -15,6 +15,7 @@
     working_src_dir: "{{ working_dir }}/src"
     working_yamls_dir: "{{ working_dir }}/yamls"
     working_log_dir: "{{ working_dir }}/logs"
+    working_vars_dir: "{{ working_dir }}/vars"
     kubeconfig: "{{ working_dir }}/kubeconfig"
 
 - name: Register oc and github operator paths
@@ -32,4 +33,41 @@
     - "{{ working_src_dir }}"
     - "{{ working_yamls_dir }}"
     - "{{ working_log_dir }}"
+    - "{{ working_vars_dir }}"
     - "{{ k8s_operators_dir }}"
+
+- name: pull "{{ osp_release_auto_url }}" if defined and include as var file
+  when: osp_release_auto_url is defined
+  block:
+    - name: Register osp_release_auto_url
+      set_fact:
+        osp_release_auto_file: "{{ working_vars_dir }}/container_image_prepare.yaml"
+
+    - name: Download {{ osp_release_auto_url }}
+      get_url:
+        url: "{{ osp_release_auto_url }}"
+        dest: "{{ osp_release_auto_file }}"
+        mode: '0644'
+        timeout: 30
+
+    # dict container-image-prepare is not conform with ansible var naming convention.
+    # therefore can not just be included as var file
+    - name: Read "{{ osp_release_auto_file }}" content
+      set_fact:
+        osp_release_auto_content: "{{ lookup('file', '{{ osp_release_auto_file }}') }}"
+
+    - name: Create osp_release_auto dict from input of "{{ osp_release_auto_file }}"
+      set_fact:
+        osp_release_auto: "{{ osp_release_auto | default({}) | combine ({ item.key : item.value }) }}"
+      with_items:
+        - { 'key': 'namespace' , 'value': "{{ osp_release_auto_content | regex_search('namespace: (.+)', '\\1') | first }}"}
+        - { 'key': 'prefix' , 'value': "{{ osp_release_auto_content | regex_search('prefix: (.+)', '\\1') | first }}"}
+        - { 'key': 'name_prefix' , 'value': "{{ osp_release_auto_content | regex_search('name_prefix: (.+)', '\\1') | first }}"}
+        - { 'key': 'tag' , 'value': "{{ osp_release_auto_content | regex_search('tag: (.+)', '\\1') | first }}"}
+        - { 'key': 'ceph_namespace' , 'value': "{{ osp_release_auto_content | regex_search('ceph[-_]namespace: (.+)', '\\1') | first }}"}
+        - { 'key': 'ceph_image' , 'value': "{{ osp_release_auto_content | regex_search('ceph[-_]image: (.+)', '\\1') | first }}"}
+        - { 'key': 'ceph_tag' , 'value': "{{ osp_release_auto_content | regex_search('ceph[-_]tag: (.+)', '\\1') | first }}"}
+        - { 'key': 'release' , 'value': "{{ osp_release_auto_content | regex_search('rhosp: (.+)', '\\1') | first }}"}
+        - { 'key': 'compose' , 'value': "{{ osp_release_auto_content | regex_search('id: (.+)', '\\1') | first }}"}
+        - { 'key': 'rhel_version' , 'value': "{{ osp_release_auto_content | regex_search('rhel_version: (.+)', '\\1') | first }}"}
+

--- a/ansible/roles/oc_local/tasks/main.yaml
+++ b/ansible/roles/oc_local/tasks/main.yaml
@@ -54,12 +54,14 @@
     # therefore can not just be included as var file
     - name: Read "{{ osp_release_auto_file }}" content
       set_fact:
-        osp_release_auto_content: "{{ lookup('file', '{{ osp_release_auto_file }}') }}"
+        osp_release_auto_content: "{{ lookup('file', '{{ osp_release_auto_file }}') | default({}) }}"
 
     - name: Create osp_release_auto dict from input of "{{ osp_release_auto_file }}"
       set_fact:
         osp_release_auto: "{{ osp_release_auto | default({}) | combine ({ item.key : item.value }) }}"
+      when: osp_release_auto_content is defined
       with_items:
+        - { 'key': 'debug' , 'value': "{{ osp_release_auto_content }}"}
         - { 'key': 'namespace' , 'value': "{{ osp_release_auto_content | regex_search('namespace: (.+)', '\\1') | first }}"}
         - { 'key': 'prefix' , 'value': "{{ osp_release_auto_content | regex_search('prefix: (.+)', '\\1') | first }}"}
         - { 'key': 'name_prefix' , 'value': "{{ osp_release_auto_content | regex_search('name_prefix: (.+)', '\\1') | first }}"}

--- a/ansible/vars/17.0.yaml
+++ b/ansible/vars/17.0.yaml
@@ -1,5 +1,6 @@
 ---
-osp_release_auto_url: http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/17.0-RHEL-8/passed_phase1/container_image_prepare.yaml
+osp_release_auto_version: 17.0-RHEL-8
+osp_release_auto_compose: passed_phase1
 ephemeral_heat:
   heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
   heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo

--- a/ansible/vars/17.0.yaml
+++ b/ansible/vars/17.0.yaml
@@ -1,10 +1,5 @@
 ---
-openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:{{ osp_release_defaults.container_tag }}
-osp_rhos_release_compose: passed_phase1
-osp_release_defaults:
-  release: 17.0
-  container_tag: 17.0_20220214.1
-  ceph_tag: 5-102
+osp_release_auto_url: http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/17.0-RHEL-8/passed_phase1/container_image_prepare.yaml
 ephemeral_heat:
   heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
   heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo

--- a/ansible/vars/17.0_hci.yaml
+++ b/ansible/vars/17.0_hci.yaml
@@ -1,10 +1,7 @@
 ---
-openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:{{ osp_release_defaults.container_tag }}
-osp_rhos_release_compose: passed_phase1
+osp_release_auto_version: 17.0-RHEL-8
+osp_release_auto_compose: passed_phase1
 osp_release_defaults:
-  release: 17.0
-  container_tag: 17.0_20220214.1
-  ceph_tag: 5-102
   bmset:
     Compute:
       count: 0

--- a/ansible/vars/17.0_hci_subnet.yaml
+++ b/ansible/vars/17.0_hci_subnet.yaml
@@ -1,6 +1,7 @@
 ---
-openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:{{ osp_release_defaults.container_tag }}
-osp_rhos_release_compose: passed_phase1
+osp_release_auto_version: 17.0-RHEL-8
+osp_release_auto_compose: passed_phase1
+
 ephemeral_heat:
   heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
   heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo
@@ -14,9 +15,6 @@ openstackclient_networks:
   - internal_api_leaf1
 
 osp_release_defaults:
-  release: 17.0
-  container_tag: 17.0_20220124.1
-  ceph_tag: 5-102
   networks: ipv4_subnet
   vmset:
     Controller:

--- a/ansible/vars/17.0_ipv6.yaml
+++ b/ansible/vars/17.0_ipv6.yaml
@@ -1,5 +1,6 @@
 ---
-osp_release_auto_url: http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/17.0-RHEL-8/passed_phase1/container_image_prepare.yaml
+osp_release_auto_version: 17.0-RHEL-8
+osp_release_auto_compose: passed_phase1
 
 osp_release_defaults:
   networks: ipv6

--- a/ansible/vars/17.0_ipv6.yaml
+++ b/ansible/vars/17.0_ipv6.yaml
@@ -1,11 +1,7 @@
 ---
-openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:{{ osp_release_defaults.container_tag }}
-osp_rhos_release_compose: passed_phase1
+osp_release_auto_url: http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/17.0-RHEL-8/passed_phase1/container_image_prepare.yaml
 
 osp_release_defaults:
-  release: 17.0
-  container_tag: 17.0_20220214.1
-  ceph_tag: 5-102
   networks: ipv6
   extrafeatures:
     - ipv6

--- a/ansible/vars/17.0_ipv6_subnet.yaml
+++ b/ansible/vars/17.0_ipv6_subnet.yaml
@@ -1,11 +1,7 @@
 ---
-openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:{{ osp_release_defaults.container_tag }}
-osp_rhos_release_compose: passed_phase1
+osp_release_auto_url: http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/17.0-RHEL-8/passed_phase1/container_image_prepare.yaml
 
 osp_release_defaults:
-  release: 17.0
-  container_tag: 17.0_20220214.1
-  ceph_tag: 5-102
   networks: ipv6_subnet
   vmset:
     Controller:

--- a/ansible/vars/17.0_ipv6_subnet.yaml
+++ b/ansible/vars/17.0_ipv6_subnet.yaml
@@ -1,5 +1,6 @@
 ---
-osp_release_auto_url: http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/17.0-RHEL-8/passed_phase1/container_image_prepare.yaml
+osp_release_auto_version: 17.0-RHEL-8
+osp_release_auto_compose: passed_phase1
 
 osp_release_defaults:
   networks: ipv6_subnet

--- a/ansible/vars/17.0_subnet.yaml
+++ b/ansible/vars/17.0_subnet.yaml
@@ -1,6 +1,6 @@
 ---
-openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp17-openstack-tripleoclient:{{ osp_release_defaults.container_tag }}
-osp_rhos_release_compose: passed_phase1
+osp_release_auto_url: http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/17.0-RHEL-8/passed_phase1/container_image_prepare.yaml
+
 ephemeral_heat:
   heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
   heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo
@@ -14,9 +14,6 @@ openstackclient_networks:
   - internal_api_leaf1
 
 osp_release_defaults:
-  release: 17.0
-  container_tag: 17.0_20220214.1
-  ceph_tag: 5-102
   networks: ipv4_subnet
   vmset:
     Controller:

--- a/ansible/vars/17.0_subnet.yaml
+++ b/ansible/vars/17.0_subnet.yaml
@@ -1,5 +1,6 @@
 ---
-osp_release_auto_url: http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/17.0-RHEL-8/passed_phase1/container_image_prepare.yaml
+osp_release_auto_version: 17.0-RHEL-8
+osp_release_auto_compose: passed_phase1
 
 ephemeral_heat:
   heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -121,7 +121,7 @@ csv_version: latest
 ocp_network_type: OpenShiftSDN
 
 # image used to run tempest
-tempest_image: docker-registry.upshift.redhat.com/openstack-k8s-operators/openstack-tempest:16.2_tempest_sudoers
+tempest_image: "{{ osp_release_auto.namespace }}/{{ osp_release_auto.name_prefix }}tempest:{{ osp_defaults.container_tag }}"
 
 # tempest timeout in seconds
 tempest_timeout: 3600
@@ -179,10 +179,13 @@ nfs_export_dir: /home/nfs
 
 default_timeout: 240
 
+# Compose file to fetch if specified, used to populate osp_release_auto dict
+# for auto switch of compose to use for OSP deployment
+osp_release_auto_url: http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/16.2-RHEL-8/passed_phase2/container_image_prepare.yaml
+
 # openstackclient container image
-# TODO: change once we have a 16.2.2 tripleoclient image that includes ipa-client
-# openstackclient_image: registry.redhat.io/rhosp-rhel8/openstack-tripleoclient:16.2
-openstackclient_image: registry-proxy.engineering.redhat.com/rh-osbs/rhosp16-openstack-tripleoclient:{{ osp_defaults.container_tag }}
+openstackclient_image: "{{ osp_release_auto.namespace }}/{{ osp_release_auto.name_prefix }}tripleoclient:{{ osp_defaults.container_tag }}"
+
 openstackclient_storage_class: host-nfs-storageclass
 openstackclient_networks:
   - ctlplane
@@ -199,7 +202,7 @@ external_dns:
   - 10.5.30.160
 
 osp_defaults:
-  release: 16.2
+  release: "{{ osp_release_auto.release }}"
   # use http://download.devel.redhat.com to get the local mirror depending on where the server is
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/8.4/992/images/rhel-guest-image-8.4-992.x86_64.qcow2
   # OSP controller VM sizing
@@ -273,9 +276,9 @@ osp_defaults:
     - name: datacentre2
       prefix: fa:16:3b
   preserve_reservations: true
-  container_tag: 16.2_20220310.1
-  ceph_image: rhceph
-  ceph_tag: 4-59
+  container_tag: "{{ osp_release_auto.tag }}"
+  ceph_image: "{{ osp_release_auto.ceph_image }}" # note for OSP17.0 its ceph_image
+  ceph_tag: "{{ osp_release_auto.ceph_tag }}" # note for OSP17.0 its ceph_tag
   # OSP deployment timeout
   deploy_timeout: 90m
   # extra features to enable
@@ -298,8 +301,8 @@ osp_local: {}
 
 # registration of the overcloud nodes, either rhsm or rhos-release
 osp_registry_method: rhos-release
-osp_rhos_release_compose: passed_phase2
-osp_rhel_subscription_release: 8.4
+osp_rhos_release_compose: "{{ osp_release_auto.compose }}"
+osp_rhel_subscription_release: "{{ osp_release_auto.rhel_version }}"
 osp_rhel_subscription_repos:
   - rhel-8-for-x86_64-baseos-eus-rpms
   - rhel-8-for-x86_64-appstream-eus-rpms

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -179,9 +179,10 @@ nfs_export_dir: /home/nfs
 
 default_timeout: 240
 
-# Compose file to fetch if specified, used to populate osp_release_auto dict
-# for auto switch of compose to use for OSP deployment
-osp_release_auto_url: http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/16.2-RHEL-8/passed_phase2/container_image_prepare.yaml
+# OSP release and compose file to fetch if specified. This is used to populate osp_release_auto dict
+osp_release_auto_version: 16.2-RHEL-8
+osp_release_auto_compose: passed_phase2
+osp_release_auto_url: http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/{{ osp_release_auto_version }}/{{ osp_release_auto_compose }}/container_image_prepare.yaml
 
 # openstackclient container image
 openstackclient_image: "{{ osp_release_auto.namespace }}/{{ osp_release_auto.name_prefix }}tripleoclient:{{ osp_defaults.container_tag }}"


### PR DESCRIPTION
Adds osp_release_auto_url var which can be used to point to the
compose container_image_prepare.yaml. From there information is
parsed on the RHEL relase and containers to use to deploy OSP.

With this it would be no longer required to manually bump container
tags when a new compos is available.

Per default osp_release_auto_url points to the OSP16.2 passed_phase2
compose url.