### PR TITLE
Allow OCP version selection for Crucible AI

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -557,6 +557,66 @@
         regexp: 'openshift_full_version in supported_ocp_versions'
         replace: 'openshift_full_version is defined'
 
+    - name: Override/inject OCP live ISO version
+      replace:
+        path: "{{ base_path }}/crucible/roles/setup_assisted_installer/defaults/main.yml"
+        after: "assisted_service_openshift_versions_defaults:"
+        before: "assisted_installer_images:"
+        regexp: 'dependencies/rhcos/{{ ocp_version | replace(".", "\.") }}/.*iso'
+        replace: 'dependencies/rhcos/{{ ocp_version }}/latest/rhcos-live.x86_64.iso'
+
+    - name: Override/inject OCP live rootfs version
+      replace:
+        path: "{{ base_path }}/crucible/roles/setup_assisted_installer/defaults/main.yml"
+        after: "assisted_service_openshift_versions_defaults:"
+        before: "assisted_installer_images:"
+        regexp: 'dependencies/rhcos/{{ ocp_version | replace(".", "\.") }}/.*img'
+        replace: 'dependencies/rhcos/{{ ocp_version }}/latest/rhcos-live-rootfs.x86_64.img'
+
+    - name: Override/inject desired OCP version (display_name/release_version)
+      replace:
+        path: "{{ base_path }}/crucible/roles/setup_assisted_installer/defaults/main.yml"
+        after: "assisted_service_openshift_versions_defaults:"
+        before: "assisted_installer_images:"
+        regexp: '{{ ocp_version | replace(".", "\.") }}\.\d+'
+        replace: '{{ ocp_version }}.{{ ocp_minor_version }}'
+
+    - name: Inject specific RHCOS image version
+      block:
+      - name: Inject RHCOS image tag
+        replace:
+          path: "{{ base_path }}/crucible/roles/setup_assisted_installer/defaults/main.yml"
+          after: "assisted_service_openshift_versions_defaults:"
+          before: "assisted_installer_images:"
+          regexp: 'release_image:.*release_{{ ocp_version | replace(".", "\.") }}.*'
+          replace: 'release_image: "quay.io/openshift-release-dev/ocp-release:{{ ocp_version }}.{{ ocp_minor_version }}-x86_64"'
+
+      - name: Get RHCOS image version raw data for {{ ocp_version }}.{{ ocp_minor_version }}
+        uri:
+          url: "https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/{{ ocp_version }}.{{ ocp_minor_version }}"
+          method: GET
+          status_code: [200]
+          return_content: True
+        register: rhcos_image_version_raw_data
+
+      - name: Get RHCOS image version for {{ ocp_version }}.{{ ocp_minor_version }}
+        set_fact:
+          rhcos_image_version: "{{ rhcos_image_version_raw_data.content | regex_search('second_release=([^&]+)', '\\1') | default ([''], true) | first }}"
+          rhcos_image_version_alt: "{{ rhcos_image_version_raw_data.content | regex_search('/\\?release=([^&]+)', '\\1') | default ([''], true) | first }}"
+
+      - name: Fail when an RHCOS version cannot be determined
+        fail:
+          msg: "Unable to determine RHCOS version for OCP version {{ ocp_version }}.{{ ocp_minor_version }}"
+        when: rhcos_image_version == "" and rhcos_image_version_alt == ""
+
+      - name: Inject RHCOS image version
+        replace:
+          path: "{{ base_path }}/crucible/roles/setup_assisted_installer/defaults/main.yml"
+          after: "assisted_service_openshift_versions_defaults:"
+          before: "assisted_installer_images:"
+          regexp: 'rhcos_version:\s{{ ocp_version | replace(".", "") }}\..+'
+          replace: 'rhcos_version: {{ rhcos_image_version if rhcos_image_version != "" else rhcos_image_version_alt }}'
+
     - name: Force linear execution of boot_iso role
       block:
       - name: Force linear execution


### PR DESCRIPTION
Allows finger-granularity for setting OCP version via the existing dev-tools `ocp_version` and `ocp_minor_version` Ansible variables for AI deployments