### PR TITLE
[OSPK8-417] remove dns settings from ctlplane and osclient CRs

### DIFF
--- a/ansible/templates/osp/ctlplane/osp-director_openstackcontrolplane.yaml.j2
+++ b/ansible/templates/osp/ctlplane/osp-director_openstackcontrolplane.yaml.j2
@@ -10,13 +10,6 @@ spec:
   openStackClientStorageClass: {{ openstackclient_storage_class }}
   passwordSecret: userpassword
   caConfigMap: cacerts
-  domainName: {{ osp.domain_name }}
-{% if osp.dns_search_domains is defined and osp.dns_search_domains|length %}
-  dnsServers: {{ osp.dns_servers }}
-{% endif %}
-{% if osp.dns_search_domains is defined and osp.dns_search_domains|length %}
-  dnsSearchDomains: {{ osp.dns_search_domains }}
-{% endif %}
 {% if osp.tlse|default(false)|bool %}
   idmSecret: idmsecret
 {% endif %}

--- a/ansible/templates/tempest/tempest_openstackclient.yaml.j2
+++ b/ansible/templates/tempest/tempest_openstackclient.yaml.j2
@@ -15,10 +15,3 @@ spec:
   runUID: 42480
   runGID: 42480
   caConfigMap: cacerts
-  domainName: {{ osp.domain_name }}
-{% if osp.dns_search_domains is defined and osp.dns_search_domains|length %}
-  dnsServers: {{ osp.dns_servers }}
-{% endif %}
-{% if osp.dns_search_domains is defined and osp.dns_search_domains|length %}
-  dnsSearchDomains: {{ osp.dns_search_domains }}
-{% endif %}


### PR DESCRIPTION
The get now added by the operator from the osnetcfg if not specified.

Depends-On: https://github.com/openstack-k8s-operators/osp-director-operator/pull/556