### PR TITLE
Use v1-friendly AI client lib by default

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -26,6 +26,21 @@
       extra_args: "--user"
       executable: /usr/bin/pip-3
 
+  - name: Install assisted installed CLI lib
+    become: true
+    become_user: root
+    pip:
+      name: assisted-service-client
+      version: "{{ ocp_ai_cli_lib_version }}"
+      executable: /usr/bin/pip-3
+
+  - name: Install assisted installed CLI lib - user directory
+    pip:
+      name: assisted-service-client
+      version: "{{ ocp_ai_cli_lib_version }}"
+      extra_args: "--user"
+      executable: /usr/bin/pip-3
+
 
   ### ADDITIONAL SET-FACTS
 

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -17,3 +17,6 @@ ocp_ai_libvirt_storage_dir: /var/lib/libvirt/images
 # Pin aicli to a version that uses AI API v1 by default, as this is the API version
 # that Crucible uses for the time being
 ocp_ai_cli_version: "99.0.202112021829.202103111306"
+
+# Pin aicli client library version to a AI-API-v1-friendly version by default
+ocp_ai_cli_lib_version: "2.1.1.post1"


### PR DESCRIPTION
A missing piece that aligns `aicli`'s underlying client library to AI API v1