### PR TITLE
[cnosp] create openstack-proto and fix cnosp_csv_version var name

### DIFF
--- a/ansible/cnosp_olm.yaml
+++ b/ansible/cnosp_olm.yaml
@@ -11,5 +11,5 @@
       name: cnosp
       tasks_from: olm
     vars:
-      _cnv_version: "{{ cnosp_cnv_version }}"
+      _csv_version: "{{ cnosp_csv_version }}"
 

--- a/ansible/cnosp_olm_cleanup.yaml
+++ b/ansible/cnosp_olm_cleanup.yaml
@@ -11,4 +11,4 @@
       name: cnosp
       tasks_from: olm_cleanup
     vars:
-      _cnv_version: "{{ cnosp_cnv_version }}"
+      _csv_version: "{{ cnosp_csv_version }}"

--- a/ansible/roles/cnosp/files/ovn/namespace.yaml
+++ b/ansible/roles/cnosp/files/ovn/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: openstack

--- a/ansible/roles/cnosp/files/ovn/role.yaml
+++ b/ansible/roles/cnosp/files/ovn/role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openstack-proto
+  namespace: openstack
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - openstack-proto
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/ansible/roles/cnosp/files/ovn/rolebinding.yaml
+++ b/ansible/roles/cnosp/files/ovn/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openstack-proto
+  namespace: openstack
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openstack-proto
+subjects:
+- kind: ServiceAccount
+  name: openstack-proto
+  namespace: openstack

--- a/ansible/roles/cnosp/files/ovn/sa.yaml
+++ b/ansible/roles/cnosp/files/ovn/sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openstack-proto
+  namespace: openstack

--- a/ansible/roles/cnosp/files/ovn/scc.yaml
+++ b/ansible/roles/cnosp/files/ovn/scc.yaml
@@ -1,0 +1,44 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: A custom SCC for use by prototype OpenStack services.
+  name: openstack-proto
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+
+# XXX: Required only by OVN to work round lack of multi-bridge in compute.
+# Not to be used outside this prototype.
+allowHostPorts: true
+
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+- system:authenticated
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+#- SETUID
+#- SETGID
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/ansible/roles/cnosp/tasks/olm.yaml
+++ b/ansible/roles/cnosp/tasks/olm.yaml
@@ -21,7 +21,7 @@
   args:
     chdir: "{{ repo_dir }}"
 
-- name: build CSV manifest locally
+- name: build CSV manifest {{ _csv_version }} locally
   command: /bin/bash "{{ repo_dir }}/scripts/build-manifests.sh"
   args:
     chdir: "{{ repo_dir }}"

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -353,4 +353,4 @@ must_gather_image: quay.io/openstack-k8s-operators/must-gather:0.0.2
 # must_gather_directory: "{{ working_log_dir }}"
 must_gather_compress_logs: false
 
-cnosp_cnv_version: 0.0.1
+cnosp_csv_version: 0.0.1


### PR DESCRIPTION
openstack-proto sa is required for current ovn operator. Create it in its resources.
Also fixes misspelled cnosp_csv_version var name.