### PR TITLE
Add insecure registries to /etc/containers/registries.conf

### DIFF
--- a/ansible/roles/oc_local/tasks/main.yaml
+++ b/ansible/roles/oc_local/tasks/main.yaml
@@ -73,3 +73,20 @@
         - { 'key': 'compose' , 'value': "{{ osp_release_auto_content | regex_search('id: (.+)', '\\1') | first }}"}
         - { 'key': 'rhel_version' , 'value': "{{ osp_release_auto_content | regex_search('rhel_version: (.+)', '\\1') | first }}"}
 
+- name: add insecure registies to /etc/containers/registries.conf
+  when: podman_insecure_registies is defined
+  block:
+  - name: generate _registries string
+    set_fact:
+      _registries: "'{{ \"', '\".join(podman_insecure_registies)}}'"
+
+  - name: add {{ _registries }} to registries.insecure
+    become: true
+    become_user: root
+    community.general.ini_file:
+      path: /etc/containers/registries.conf
+      section: registries.insecure
+      option: registries
+      value: "[{{ _registries }}]"
+      mode: '0644'
+      backup: yes

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -8,6 +8,10 @@ dev_scripts_branch: b8c619c1515d03f162adf08cbb89f9ba5c6d5cf1
 
 base_domain_name: test.metalkube.org
 
+# registries to add to /etc/containers/registries.conf registries.insecure section
+podman_insecure_registies:
+  - default-route-openshift-image-registry.apps.{{ ocp_cluster_name }}.{{ base_domain_name }}
+
 # To set a specific release to install.
 ocp_version: 4.8
 ocp_minor_version: 35


### PR DESCRIPTION
adds podman_insecure_registries parameter to manage registries
parameter of the registries.insecure section in
/etc/containers/registries.conf.