### PR TITLE
Cleanup insecure registry with 'destroy_ocp' task

### DIFF
--- a/ansible/ocp_installer_destroy.yaml
+++ b/ansible/ocp_installer_destroy.yaml
@@ -23,3 +23,6 @@
 
 - name: Cleanup libvirt resources
   import_playbook: libvirt_cleanup.yaml
+
+- name: Cleanup local registry.conf
+  import_playbook: registry_conf_cleanup.yaml

--- a/ansible/registry_conf_cleanup.yaml
+++ b/ansible/registry_conf_cleanup.yaml
@@ -1,0 +1,23 @@
+---
+- hosts: convergence_base
+  vars_files: vars/default.yaml
+  become: true
+
+  tasks:
+  - name: remove custom insecure registies entries in /etc/containers/registries.conf
+    when: podman_insecure_registries is defined
+    block:
+    - name: generate _registries string
+      set_fact:
+        _registries: "'{{ \"', '\".join(podman_insecure_registries)}}'"
+
+    - name: "remove {{ _registries }} from registries.insecure"
+      become: true
+      become_user: root
+      community.general.ini_file:
+        path: /etc/containers/registries.conf
+        section: registries.insecure
+        option: registries
+        value: "[{{ _registries }}]"
+        state: absent
+        exclusive: yes

--- a/ansible/roles/oc_local/tasks/main.yaml
+++ b/ansible/roles/oc_local/tasks/main.yaml
@@ -74,11 +74,11 @@
         - { 'key': 'rhel_version' , 'value': "{{ osp_release_auto_content | regex_search('rhel_version: (.+)', '\\1') | first }}"}
 
 - name: add insecure registies to /etc/containers/registries.conf
-  when: podman_insecure_registies is defined
+  when: podman_insecure_registries is defined
   block:
   - name: generate _registries string
     set_fact:
-      _registries: "'{{ \"', '\".join(podman_insecure_registies)}}'"
+      _registries: "'{{ \"', '\".join(podman_insecure_registries)}}'"
 
   - name: add {{ _registries }} to registries.insecure
     become: true

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -9,7 +9,7 @@ dev_scripts_branch: b8c619c1515d03f162adf08cbb89f9ba5c6d5cf1
 base_domain_name: test.metalkube.org
 
 # registries to add to /etc/containers/registries.conf registries.insecure section
-podman_insecure_registies:
+podman_insecure_registries:
   - default-route-openshift-image-registry.apps.{{ ocp_cluster_name }}.{{ base_domain_name }}
 
 # To set a specific release to install.


### PR DESCRIPTION
This patch adds a playbook go cleanup the insecure_registries
setting added in fde72ec21c462bcd3ffb63869ee79e7359b14db4 which
seems to break subsequent reinstallations with error messages
like:

loading registries configuration: loading registries configuration
\"/etc/containers/registries.conf\": mixing sysregistry v1/v2 is not
supported

Additionally the patch updates the name of the Ansible variable to
be 'podman_insecure_registries' instead of 'podman_insecure_registies'.