### PR TITLE
[cnosp] remove namespace create from ovn files

### DIFF
--- a/ansible/roles/cnosp/files/ovn/namespace.yaml
+++ b/ansible/roles/cnosp/files/ovn/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-    name: openstack


### PR DESCRIPTION
It is already handled in install_namespace.yaml via olm target
and cleaning up conflicts removing the namespace.