### PR TITLE
Fix osp_release_auto

### DIFF
--- a/ansible/roles/oc_local/tasks/main.yaml
+++ b/ansible/roles/oc_local/tasks/main.yaml
@@ -49,6 +49,7 @@
         dest: "{{ osp_release_auto_file }}"
         mode: '0644'
         timeout: 30
+        force: true
 
     # dict container-image-prepare is not conform with ansible var naming convention.
     # therefore can not just be included as var file


### PR DESCRIPTION
The osp_release_auto yaml can persist between runs. `make openstack_cleanup`
will remove it, but `make olm_cleanup` (which is often run after
openstack_cleanup) includes the local role and fetch it again.

For now force it to be downloaded every time to ensure it does the
"right thing".