### PR TITLE
Switch to OCP 4.8.39

### DIFF
--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -14,7 +14,7 @@ podman_insecure_registries:
 
 # To set a specific release to install.
 ocp_version: 4.8
-ocp_minor_version: 35
+ocp_minor_version: 39
 ocp_release_image: "quay.io/openshift-release-dev/ocp-release:{{ ocp_version }}.{{ ocp_minor_version }}-x86_64"
 ocp_release_data_url: "https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/{{ ocp_version }}.{{ ocp_minor_version }}"
 ocp_release_type: ga


### PR DESCRIPTION
OCP 4.8.35 is failing because the status page is broken:
https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/4.8.35