### PR TITLE
pin compose to RHOS-16.2-RHEL-8-20220329.n.2

### DIFF
--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -250,7 +250,9 @@ default_timeout: 240
 
 # OSP release and compose file to fetch if specified. This is used to populate osp_release_auto dict
 osp_release_auto_version: 16.2-RHEL-8
-osp_release_auto_compose: passed_phase2
+# temporary pin to RHOS-16.2-RHEL-8-20220329.n.2 because of https://bugzilla.redhat.com/show_bug.cgi?id=2080869
+#osp_release_auto_compose: passed_phase2
+osp_release_auto_compose: RHOS-16.2-RHEL-8-20220329.n.2
 osp_release_auto_url: http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/{{ osp_release_auto_version }}/{{ osp_release_auto_compose }}/container_image_prepare.yaml
 
 # openstackclient container image


### PR DESCRIPTION
A regression was introduces, lets pin to this specific
version until [1] is resolved.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2080869