### PR TITLE
Fix BMH provisioning for 3-combo-node OCP clusters

### DIFF
--- a/ansible/install_networks.yaml
+++ b/ansible/install_networks.yaml
@@ -56,6 +56,19 @@
     environment:
       <<: *oc_env
 
+  # For virtualized 3-combo-node deployments, switch Metal3 provisioning network to the OSP control plane bridge
+  - name: Adjust Metal3 provisioning network for OCP 3-combo-node scenario
+    when: ocp_worker_count|int < 1 and ocp_num_masters > 0
+    block:
+    - name: Get name of OSP control plane bridge on OCP nodes
+      shell: |
+        oc get osnet -n {{ namespace }} ctlplane -o json | jq -r '.spec.attachConfiguration'
+      register: osnetconfig_ctlplane_intf
+
+    - name: Patch Metal3 Provisioning CR with desired interface name
+      shell: |
+        oc patch provisioning provisioning-configuration --type='json' -p='[{"op": "replace", "path": "/spec/provisioningInterface", "value": "{{ osnetconfig_ctlplane_intf.stdout }}"}]'
+
   # Notes:
   # * can not use nmcli module https://github.com/ansible/ansible/issues/48055
   # * don't apply these persistent, in case of a host reboot those need to be reapplied

--- a/ansible/ocp_ai_post_install.yaml
+++ b/ansible/ocp_ai_post_install.yaml
@@ -69,20 +69,6 @@
       environment:
         <<: *oc_env
 
-    - name: Pause for 15 seconds to allow Metal3 to begin reconciliation
-      pause:
-        seconds: 15
-
-    - name: Wait for Metal3 pod to restart
-      shell: |
-        oc wait deployment --for condition=available -n openshift-machine-api metal3 --timeout={{ default_timeout }}s
-      environment:
-        <<: *oc_env
-      retries: 5
-      delay: 5
-      register: result
-      until: result.rc == 0
-
 
     ### OCS (if requested)
 

--- a/ansible/openstack_cleanup.yaml
+++ b/ansible/openstack_cleanup.yaml
@@ -24,6 +24,26 @@
       - "oc delete -n openstack cm tripleo-deploy-config heat-env-config tripleo-tarball-config --ignore-not-found=true"
       - "oc delete -n openstack events --all"
 
+  # For virtualized 3-combo-node deployments, switch Metal3 provisioning network back to the default provisioning interface
+  - name: Adjust Metal3 provisioning network for OCP 3-combo-node scenario
+    when: ocp_worker_count|int < 1 and ocp_num_masters > 0
+    block:
+    - name: Reset AI provisioning interface
+      when: ocp_ai|bool
+      block:
+      - name: Include AI variables
+        include_vars: vars/ocp_ai.yaml
+
+      - name: Reset AI provisioning interface
+        shell: |
+          oc patch provisioning provisioning-configuration --type='json' -p='[{"op": "replace", "path": "/spec/provisioningInterface", "value": "{{ ocp_ai_prov_interface }}"}]'
+        ignore_errors: true
+
+    - name: Reset dev-scripts provisioning interface
+      when: not (ocp_ai|bool)
+      shell: |
+        oc patch provisioning provisioning-configuration --type='json' -p='[{"op": "replace", "path": "/spec/provisioningInterface", "value": "enp1s0"}]'
+
   - name: delete playbooks git repo dir
     become: true
     become_user: root

--- a/ansible/templates/ai/metal3/provisioning.yml.j2
+++ b/ansible/templates/ai/metal3/provisioning.yml.j2
@@ -7,6 +7,6 @@ metadata:
 spec:
   provisioningDHCPRange: 172.22.0.10,172.22.0.50
   provisioningIP: 172.22.0.3
-  provisioningInterface: enp1s0
+  provisioningInterface: {{ ocp_ai_prov_interface }}
   provisioningNetwork: Managed
   provisioningNetworkCIDR: 172.22.0.0/24

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -10,6 +10,9 @@ ocp_ai_bm_bridge_worker_mac_prefix: 3c:fd:fe:78:ab:1
 ocp_ai_prov_bridge_master_mac_prefix: 3c:fd:fe:78:cd:0
 ocp_ai_prov_bridge_worker_mac_prefix: 3c:fd:fe:78:cd:1
 
+# Metal3 provisioning interface on OCP nodes
+ocp_ai_prov_interface: enp1s0
+
 # ocp_ai_sushy_port: defaults to "8082"
 
 ocp_ai_libvirt_storage_dir: /var/lib/libvirt/images


### PR DESCRIPTION
For 3-combo-node virtualized OCP clusters, we need to move the Metal3 provisioning interface target from `enp1s0` to the control plane bridge.  We attach `enp1s0` to the control plane bridge on the workers, and since the workers are also the masters (and since Metal3 sits there) we must ensure Metal3 points to the interface that actually holds the provisioning/ctlplane IP.

Also removes the wait for Metal3 pod to restart, as this is indirectly accounted for in the course of our reconcile loops anyhow.