### PR TITLE
Introduce external_ceph to osp.extrafeatures

### DIFF
--- a/ansible/templates/osp/tripleo_heat_envs/common/storage-backend.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/common/storage-backend.yaml.j2
@@ -13,6 +13,15 @@ resource_registry:
 {% endif %}
 {% endif %}
 
+{% if "external_ceph" in osp.extrafeatures %}
+resource_registry:
+{% if osp.release|int >= 17 %}
+  OS::TripleO::Services::CephExternal: deployment/cephadm/ceph-client.yaml
+{% else %}
+  OS::TripleO::Services::CephExternal: deployment/ceph-ansible/ceph-client.yaml
+{% endif %}
+{% endif %}
+
 parameter_defaults:
 {% if "hci" in osp.extrafeatures %}
 {% if osp.release|int >= 17 %}
@@ -53,6 +62,20 @@ parameter_defaults:
   GlanceRbdPoolName: "images"
   CephPoolDefaultPgNum: 32
   CephPoolDefaultSize: 2
+{% elif "external_ceph" in osp.extrafeatures %}
+    CinderEnableIscsiBackend: false
+    CinderEnableRbdBackend: true
+    CinderEnableNfsBackend: false
+    NovaEnableRbdBackend: true
+    GlanceBackend: rbd
+    CinderRbdPoolName: '{{ external_ceph_data.cinder_rbd_pool_name }}'
+    NovaRbdPoolName: '{{ external_ceph_data.nova_rbd_pool_name }}'
+    GlanceRbdPoolName: '{{ external_ceph_data.glance_rbd_pool_name }}'
+    CinderBackupRbdPoolName: '{{ external_ceph_data.cinder_backup_rbd_pool_name }}'
+    CephClientUserName: '{{ external_ceph_data.ceph_client_user_name }}'
+    CephClusterFSID: '{{ external_ceph_data.ceph_cluster_fsid }}'
+    CephExternalMonHost: '{{ external_ceph_data.ceph_external_mon_host }}'
+    CephClientKey: '{{ external_ceph_data.ceph_client_key }}'
 {% else %}
   GlanceEnabledImportMethods: web-download
   GlanceNetappNfsEnabled: False

--- a/ansible/vars/17.0_external_ceph.yaml
+++ b/ansible/vars/17.0_external_ceph.yaml
@@ -1,0 +1,26 @@
+---
+osp_release_auto_version: 17.0-RHEL-9
+osp_release_auto_compose: passed_phase1
+ephemeral_heat:
+  heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
+  heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo
+  mariadb_image: quay.io/tripleowallaby/openstack-mariadb:current-tripleo
+  rabbit_image: quay.io/tripleowallaby/openstack-rabbitmq:current-tripleo
+
+osp_release_defaults:
+  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20220428.0/images/rhel-guest-image-9.0-20220428.0.x86_64.qcow2
+  extrafeatures:
+    - external_ceph
+
+# 16 requires RHCSv4 in RDU
+# 17 requires RHCSv5 in TLV
+# https://code.engineering.redhat.com/gerrit/c/rhos-infrared/+/313490
+external_ceph_data:
+  cinder_rbd_pool_name: ''
+  nova_rbd_pool_name: ''
+  glance_rbd_pool_name: ''
+  cinder_backup_rbd_pool_name: ''
+  ceph_client_user_name: ''
+  ceph_cluster_fsid: ''
+  ceph_external_mon_host: ''
+  ceph_client_key: ''


### PR DESCRIPTION
If osp.extrafeatures contains external_ceph, then
information about an already existing Ceph cluster
should be added to the external_ceph_data map in
vars/17.0_external_ceph.yaml or similar. The config
will then contain an updated storage-backend.yaml
with THT directives for tripleo to configure OpenStack
to use that external Ceph cluster.