### PR TITLE
[OSPK8-563] Allow LEGACY cryptographic policies for SHA1 in tempest pod

### DIFF
--- a/ansible/templates/tempest/tempest_script.sh.j2
+++ b/ansible/templates/tempest/tempest_script.sh.j2
@@ -1,6 +1,9 @@
 # Set the exit status for the command
 set -e
 
++# RHEL9 workaroud, allow LEGACY cryptographic policies for SHA1
++sudo update-crypto-policies --set LEGACY
+
 PUB_NETWORK_ID=$(openstack --os-cloud overcloud network list -f value -c ID --name public)
 if [ -z "$PUB_NETWORK_ID" ]; then
   openstack --os-cloud overcloud network create public --external  --provider-network-type flat --provider-physical-network datacentre


### PR DESCRIPTION
Tempest job on OSP17 using RHEL9 container image fail right
now with:

```
2022-05-09 12:37:59,867 126 ERROR    [paramiko.transport] cryptography.exceptions.UnsupportedAlgorithm: sha1 is not supported by this backend for RSA signing.
```
Enable LEGACY cryptographic policies for tempest pod to allow
SHA1.