### PR TITLE
Use user configured network type when deploying using AI

### DIFF
--- a/ansible/templates/ai/crucible/inventory.ospd.yml.j2
+++ b/ansible/templates/ai/crucible/inventory.ospd.yml.j2
@@ -36,6 +36,7 @@ all:
     # # The default is OpenShift SDN unless otherwise specified.
     # network_type: OVNKubernetes
     # network_type: OpenShiftSDN
+    network_type: {{ ocp_network_type }}
 
     ######################################
     # Prerequisite Service Configuration #


### PR DESCRIPTION
Refer to ocp_network_type for user configured value instead of default OpenShiftSDN plugin

Resolves: #351 

Signed-off-by: Purandhar Sairam Mannidi [pmannidi@redhat.com](mailto:pmannidi@redhat.com)