### PR TITLE
[v1.2.x-backports] Fix BMH provisioning for 3-combo-node OCP clusters (#344)

### DIFF
--- a/ansible/install_networks.yaml
+++ b/ansible/install_networks.yaml
@@ -56,6 +56,19 @@
     environment:
       <<: *oc_env
 
+  # For virtualized 3-combo-node deployments, switch Metal3 provisioning network to the OSP control plane bridge
+  - name: Adjust Metal3 provisioning network for OCP 3-combo-node scenario
+    when: ocp_worker_count|int < 1 and ocp_num_masters > 0
+    block:
+    - name: Get name of OSP control plane bridge on OCP nodes
+      shell: |
+        oc get osnet -n {{ namespace }} ctlplane -o json | jq -r '.spec.attachConfiguration'
+      register: osnetconfig_ctlplane_intf
+
+    - name: Patch Metal3 Provisioning CR with desired interface name
+      shell: |
+        oc patch provisioning provisioning-configuration --type='json' -p='[{"op": "replace", "path": "/spec/provisioningInterface", "value": "{{ osnetconfig_ctlplane_intf.stdout }}"}]'
+
   # Notes:
   # * can not use nmcli module https://github.com/ansible/ansible/issues/48055
   # * don't apply these persistent, in case of a host reboot those need to be reapplied

--- a/ansible/ocp_ai_post_install.yaml
+++ b/ansible/ocp_ai_post_install.yaml
@@ -69,20 +69,6 @@
       environment:
         <<: *oc_env
 
-    - name: Pause for 15 seconds to allow Metal3 to begin reconciliation
-      pause:
-        seconds: 15
-
-    - name: Wait for Metal3 pods to restart
-      shell: |
-        oc wait pod --for condition=ready -n openshift-machine-api -l k8s-app=metal3 --timeout={{ default_timeout }}s
-      environment:
-        <<: *oc_env
-      retries: 5
-      delay: 5
-      register: result
-      until: result.rc == 0
-
 
     ### OCS (if requested)
     - name: Install Local Storage and OCS

--- a/ansible/openstack_cleanup.yaml
+++ b/ansible/openstack_cleanup.yaml
@@ -22,6 +22,26 @@
       - "oc delete -n openstack cm tripleo-deploy-config heat-env-config tripleo-tarball-config --ignore-not-found=true"
       - "oc delete -n openstack events --all"
 
+  # For virtualized 3-combo-node deployments, switch Metal3 provisioning network back to the default provisioning interface
+  - name: Adjust Metal3 provisioning network for OCP 3-combo-node scenario
+    when: ocp_worker_count|int < 1 and ocp_num_masters > 0
+    block:
+    - name: Reset AI provisioning interface
+      when: ocp_ai|bool
+      block:
+      - name: Include AI variables
+        include_vars: vars/ocp_ai.yaml
+
+      - name: Reset AI provisioning interface
+        shell: |
+          oc patch provisioning provisioning-configuration --type='json' -p='[{"op": "replace", "path": "/spec/provisioningInterface", "value": "{{ ocp_ai_prov_interface }}"}]'
+        ignore_errors: true
+
+    - name: Reset dev-scripts provisioning interface
+      when: not (ocp_ai|bool)
+      shell: |
+        oc patch provisioning provisioning-configuration --type='json' -p='[{"op": "replace", "path": "/spec/provisioningInterface", "value": "enp1s0"}]'
+
   - name: delete playbooks git repo dir
     become: true
     become_user: root

--- a/ansible/templates/ai/metal3/provisioning.yml.j2
+++ b/ansible/templates/ai/metal3/provisioning.yml.j2
@@ -7,6 +7,6 @@ metadata:
 spec:
   provisioningDHCPRange: 172.22.0.10,172.22.0.50
   provisioningIP: 172.22.0.3
-  provisioningInterface: enp1s0
+  provisioningInterface: {{ ocp_ai_prov_interface }}
   provisioningNetwork: Managed
   provisioningNetworkCIDR: 172.22.0.0/24

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -10,6 +10,9 @@ ocp_ai_bm_bridge_worker_mac_prefix: 3c:fd:fe:78:ab:1
 ocp_ai_prov_bridge_master_mac_prefix: 3c:fd:fe:78:cd:0
 ocp_ai_prov_bridge_worker_mac_prefix: 3c:fd:fe:78:cd:1
 
+# Metal3 provisioning interface on OCP nodes
+ocp_ai_prov_interface: enp1s0
+
 # ocp_ai_sushy_port: defaults to "8082"
 
 ocp_ai_libvirt_storage_dir: /var/lib/libvirt/images


### PR DESCRIPTION
(cherry-picked from commit d86ceaa934bb3a9102f49c52ec986d3c26046f13)