### PR TITLE
[v1.2.x-backport] add workaround for BZ2087231

### DIFF
--- a/ansible/templates/osp/tripleo_heat_envs/16.2/workarounds.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/16.2/workarounds.yaml.j2
@@ -1,0 +1,3 @@
+parameter_defaults:
+  # https://bugzilla.redhat.com/show_bug.cgi?id=2087231
+  ValidateGatewaysIcmp: false


### PR DESCRIPTION
Add workaround for [1] to disable ping_test_gateway_ips
until the BZ is fixed.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2087231

(cherry picked from commit b78608974ce84d7fc99c52bc929b84f7b2450768)