### PR TITLE
Use correct ntp server on internal network

### DIFF
--- a/ansible/roles/oc_local/tasks/main.yaml
+++ b/ansible/roles/oc_local/tasks/main.yaml
@@ -5,6 +5,11 @@
     mode: 0755
   register: working_directory
 
+- name: Gather facts
+  setup:
+    gather_subset:
+      - min
+
 - name: Get working directory absolute path
   set_fact:
     working_dir: "{{ working_directory.path }}"

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -278,7 +278,7 @@ openstackclient_networks:
   - internal_api
 
 nfs_server: '172.22.0.1'
-ntp_server: pool.ntp.org
+ntp_server: "{{ 'clock.redhat.com' if 'redhat.com' in ansible_fqdn else 'pool.ntp.org' }}"
 
 external_dns:
   - 10.11.5.19


### PR DESCRIPTION
Use the correct ntp server on internal network, pool.ntp.org is blocked