### PR TITLE
Set CertmongerKerberosRealm for TLSe deployments

### DIFF
--- a/ansible/templates/osp/tripleo_heat_envs/common/tls.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/common/tls.yaml.j2
@@ -3,6 +3,7 @@ parameter_defaults:
   IdMServer: freeipa.{{ base_domain_name }}
   IdMDomain: {{ osp.domain_name }}
   IdMInstallClientPackages: true
+  CertmongerKerberosRealm: {{ base_domain_name|upper }}
 {% endif %}
 
 {% if osp.tlse|default(false)|bool or osp.tls_public_endpoints|default(false)|bool %}


### PR DESCRIPTION
Required since https://review.opendev.org/#/q/I0a217b4a457881367de27414faca347e50f2db72
if the IPA realm differs from the domain name.