### PR TITLE
Use trusted zone for ospnetwork and make sure not to nat

### DIFF
--- a/ansible/host_prep.yaml
+++ b/ansible/host_prep.yaml
@@ -322,5 +322,5 @@
 
     - name: Make sure all outgoing traffic via ext_intf get masqueraded
       shell: |
-        firewall-cmd --direct --permanent --add-rule ipv4 nat POSTROUTING 0 -o "{{ ext_intf.stdout }}" -j MASQUERADE;
+        firewall-cmd --direct --permanent --add-rule ipv4 nat POSTROUTING 0 -o "{{ ext_intf.stdout }}" ! -d 172.16.0.0/12 -j MASQUERADE;
         firewall-cmd --reload

--- a/ansible/install_networks.yaml
+++ b/ansible/install_networks.yaml
@@ -86,7 +86,8 @@
       ip addr flush dev ospnetwork.{{ item.1.vlan }}
       ip addr add {{ item.1.ipv4.gateway }}/{{ cidr_suffix }} dev ospnetwork.{{ item.1.vlan }}
       ip link set ospnetwork.{{ item.1.vlan }} up
-      firewall-cmd --zone=libvirt --change-interface=ospnetwork.{{ item.1.vlan }}
+      firewall-cmd --zone=trusted --change-interface=ospnetwork.{{ item.1.vlan }}
+      firewall-cmd --zone=trusted --add-source={{ item.1.ipv4.cidr }}
       iptables -I FORWARD 1 -s {{ item.1.ipv4.cidr }} ! -d {{ item.1.ipv4.cidr }} -j ACCEPT
     with_subelements:
     - "{{ osp_networks }}"
@@ -110,7 +111,8 @@
       ip addr flush dev ospnetwork.{{ item.1.vlan }}
       ip addr add {{ item.1.ipv6.gateway }}/{{ cidr_suffix }} dev ospnetwork.{{ item.1.vlan }}
       ip link set ospnetwork.{{ item.1.vlan }} up
-      firewall-cmd --zone=libvirt --change-interface=ospnetwork.{{ item.1.vlan }}
+      firewall-cmd --zone=trusted --change-interface=ospnetwork.{{ item.1.vlan }}
+      firewall-cmd --zone=trusted --add-source={{ item.1.ipv6.cidr }}
       ip6tables -I FORWARD 1 -s {{ item.1.ipv6.cidr }} ! -d {{ item.1.ipv6.cidr }} -j ACCEPT
     args:
       executable: /bin/bash


### PR DESCRIPTION
When multiple subnets is used where nat is performed at the gateways,
the geneve tunnel won't come up as ovs will not see the endpoint IP
but the gateway IP instead:

```
[root@computeleaf2-0 ~]# ovs-vsctl show
43834973-998a-49d5-aee7-8313928a98f4
    Manager "ptcp:6640:127.0.0.1"
        is_connected: true
    Bridge br-int
        fail_mode: secure
        datapath_type: system
        Port tape62170c5-ce
            Interface tape62170c5-ce
        Port br-int
            Interface br-int
                type: internal
        Port ovn-b45a84-0
            Interface ovn-b45a84-0
                type: geneve
                options: {csum="true", key=flow, remote_ip="172.20.2.10"}
                bfd_status: {diagnostic="No Diagnostic", flap_count="0", forwarding="false", remote_diagnostic="No Diagnostic", remote_state=down, state=down}
        Port patch-br-int-to-provnet-1ad75f70-c617-4c6e-9322-884ed25ebfc4
            Interface patch-br-int-to-provnet-1ad75f70-c617-4c6e-9322-884ed25ebfc4
                type: patch
                options: {peer=patch-provnet-1ad75f70-c617-4c6e-9322-884ed25ebfc4-to-br-int}
        Port ovn-b1c733-0
            Interface ovn-b1c733-0
                type: geneve
                options: {csum="true", key=flow, remote_ip="172.20.0.20"}
                bfd_status: {diagnostic="No Diagnostic", flap_count="0", forwarding="false", remote_diagnostic="No Diagnostic", remote_state=down, state=down}
        Port tap9ff36960-00
            Interface tap9ff36960-00
    ovs_version: "2.15.5"
```

This change puts the ospnetwork interfaces into the trusted firewalld
zone instead, where is no restriction and nat. Also makes sure that
any nat/masq rule which gets applied in the playbooks exclude the
172.16.0.0/12 from being nat-ed as traffic in any osp networks should
be routed instead of nat-ed.