### PR TITLE
Fix deployed network environment ipv6

### DIFF
--- a/ansible/files/osp/17.0/environments/deployed-network-environment.j2.yaml
+++ b/ansible/files/osp/17.0/environments/deployed-network-environment.j2.yaml
@@ -36,11 +36,18 @@ parameter_defaults:
         subnets:
         {%- for subnet in network.subnets %}
           {{ subnet }}:
+          {%- if not network.ipv6 %}
             cidr: {{ network.subnets[subnet].ip_subnet }}
-            dns_nameservers: []
             gateway_ip: {{ network.subnets[subnet].gateway_ip }}
             host_routes: {{ network.subnets[subnet].routes | default([]) }}
             ip_version: 4
+          {%- else %}
+            cidr: {{ network.subnets[subnet].ipv6_subnet }}
+            gateway_ip: {{ network.subnets[subnet].gateway_ipv6 }}
+            host_routes: {{ network.subnets[subnet].routes_ipv6 | default([]) }}
+            ip_version: 6
+          {%- endif %}
+            dns_nameservers: []
             name: {{ subnet }}
             tags:
               {%- if network.subnets[subnet].vlan %}
@@ -55,7 +62,11 @@ parameter_defaults:
       {%- for network in networks if network.enabled|default(true) %}
       {{ network.name_lower }}:
       {%- for subnet in network.subnets %}
+      {%- if not network.ipv6 %}
       - {{ network.subnets[subnet].ip_subnet }}
+      {%- else %}
+      - {{ network.subnets[subnet].ipv6_subnet }}
+      {%- endif %}
       {%- endfor %}
       {%- endfor %}
 

--- a/ansible/ocp_vm_setup_extra_nics.yaml
+++ b/ansible/ocp_vm_setup_extra_nics.yaml
@@ -113,6 +113,18 @@
           value: '2'
           sysctl_file: /etc/sysctl.d/90-network.conf
 
+      - name: enable ipv4 forwarding
+        sysctl:
+          name: net.ipv4.ip_forward
+          value: '1'
+          sysctl_file: /etc/sysctl.d/90-network.conf
+
+      - name: enable ipv6 forwarding
+        sysctl:
+          name: net.ipv6.conf.all.forwarding
+          value: '1'
+          sysctl_file: /etc/sysctl.d/90-network.conf
+
       - name: Reload bridges
         shell: |
           /usr/bin/nmcli con reload {{ item }}; /usr/bin/nmcli con up {{ item }}

--- a/ansible/ocp_vm_setup_extra_nics.yaml
+++ b/ansible/ocp_vm_setup_extra_nics.yaml
@@ -70,16 +70,17 @@
           ifname: "external"
           autoconnect: yes
           stp: off
-          ip4: "{{ osp_ext_bridge_ip }}"
+          ip4: "{{ osp_ext_bridge_ip4 }}"
+          ip6: "{{ osp_ext_bridge_ip6 }}"
           state: present
-        when: osp_ext_bridge_ip|default != ""
+        when: osp_ext_bridge_ip4|default != ""
 
       - name: Create osp external bridge (if IP unset)
         shell: |
           /usr/bin/nmcli connection add ifname external type bridge con-name external stp no ipv4.method disabled ipv6.method disabled
         register: add_external_bridge
         failed_when: add_external_bridge.stderr != '' and 'There is another connection with the name' not in add_external_bridge.stderr
-        when: osp_ext_bridge_ip|default == ""
+        when: osp_ext_bridge_ip4|default == ""
 
       - name: Handle external interface, if necessary
         when: osp_ext_bm_interface is defined and osp_ext_bm_interface != ""

--- a/ansible/templates/osp/tripleo_heat_envs/features/16.2/ipv6/ipv6.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/features/16.2/ipv6/ipv6.yaml.j2
@@ -15,8 +15,3 @@ parameter_defaults:
   ManilaIPv6: True
   # Enable IPv6 environment for Redis.
   RedisIPv6: True
-
-  # Workaround until we have https://review.opendev.org/c/openstack/tripleo-heat-templates/+/832520 in the release
-  InternalApiRoutes: [{'destination': 'fd00:fd00:fd00:2001::/64', 'nexthop': 'fd00:fd00:fd00:2000::1'}, {'destination': 'fd00:fd00:fd00:2002::/64', 'nexthop': 'fd00:fd00:fd00:2000::1'}]
-  StorageRoutes: [{'destination': 'fd00:fd00:fd00:3001::/64', 'nexthop': 'fd00:fd00:fd00:3000::1'}, {'destination': 'fd00:fd00:fd00:3002::/64', 'nexthop': 'fd00:fd00:fd00:3000::1'}]
-  StorageMgmtRoutes: [{'destination': 'fd00:fd00:fd00:4001::/64', 'nexthop': 'fd00:fd00:fd00:4000::1'}, {'destination': 'fd00:fd00:fd00:4002::/64', 'nexthop': 'fd00:fd00:fd00:4000::1'}]

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -302,7 +302,8 @@ external_dns:
 # bridge (used for OpenStack) created by this tool.  By default this should be
 # here for virtualized all-in-one deployments, as the default OSP templates included
 # with this tool use this IP on the "external" bridge as the external network gateway
-osp_ext_bridge_ip: 10.0.0.1/24
+osp_ext_bridge_ip4: 10.0.0.1/24
+osp_ext_bridge_ip6: 2001:db8:fd00:1000::1/64
 
 osp_defaults:
   release: "{{ osp_release_auto.release }}"


### PR DESCRIPTION
* add workaround for OSP17 until ipv6 for deployed-network-environment.j2.yaml is fixed
* make sure ip forwarding is enabled for ipv4 and ipv6
* remove workaround for https://review.opendev.org/c/openstack/tripleo-heat-templates/+/832520
* Also set ip6 GW address on the ext bridge to allow switch deployments

Depends-On: https://github.com/openstack-k8s-operators/osp-director-operator/pull/612