### PR TITLE
Enable phase2 tempest tests for more scenarios

### DIFF
--- a/ansible/vars/16.2_ipv6_tlse_subnet.yaml
+++ b/ansible/vars/16.2_ipv6_tlse_subnet.yaml
@@ -49,22 +49,18 @@ osp_release_defaults:
   extrafeatures:
     - ipv6
 
-# TODO: create good set of ipv6 tempest tests, right now disabled those which create floating IP, which is not the case in IPv6
+# phase2 tempest tests
 tempest_test_dict:
-  regex: ''
-  includelist:
-      - "tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern"
-      - "tempest.scenario.test_minimum_basic.TestMinimumBasicScenario"
-      - "tempest.scenario.test_network_basic_ops.TestNetworkBasicOps"
-      - "tempest.scenario.test_snapshot_pattern.TestSnapshotPattern"
+  regex: '(?!.*\[.*\bslow\b.*\])(^tempest\.(api|scenario))'
+  includelist: []
   # per default with OVN there is no DHCPAgent, disable the tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON tests
   excludelist:
-      - "^tempest.scenario.test_network_basic_ops.TestNetworkBasicOps.test_port_security_macspoofing_port"
+      - "^tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_multi_create_auto_allocate"
+      - "^tempest.api.compute.admin.test_live_migration.LiveMigrationTest.test_live_block_migration_paused"
+      - "^tempest.api.compute.admin.test_live_migration.LiveAutoBlockMigrationV225Test.test_live_block_migration_paused"
+      - "^tempest.api.compute.admin.test_live_migration.LiveMigrationRemoteConsolesV26Test.test_live_block_migration_paused"
       - "^tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON.test_add_remove_network_from_dhcp_agent"
       - "^tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON.test_list_networks_hosted_by_one_dhcp"
-      - "^tempest.scenario.test_minimum_basic.TestMinimumBasicScenario.test_minimum_basic_scenario"
-      - "^tempest.scenario.test_snapshot_pattern.TestSnapshotPattern.test_snapshot_pattern"
-      - "^tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_volume_boot_pattern"
 
 tempest_enable_feature_dict:
   network:

--- a/ansible/vars/17.0.yaml
+++ b/ansible/vars/17.0.yaml
@@ -1,6 +1,6 @@
 ---
 osp_release_auto_version: 17.0-RHEL-9
-osp_release_auto_compose: passed_phase1
+osp_release_auto_compose: passed_phase2
 ephemeral_heat:
   heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
   heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo

--- a/ansible/vars/17.0_external_ceph.yaml
+++ b/ansible/vars/17.0_external_ceph.yaml
@@ -1,6 +1,6 @@
 ---
 osp_release_auto_version: 17.0-RHEL-9
-osp_release_auto_compose: passed_phase1
+osp_release_auto_compose: passed_phase2
 ephemeral_heat:
   heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
   heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo

--- a/ansible/vars/17.0_hci.yaml
+++ b/ansible/vars/17.0_hci.yaml
@@ -1,6 +1,6 @@
 ---
 osp_release_auto_version: 17.0-RHEL-9
-osp_release_auto_compose: passed_phase1
+osp_release_auto_compose: passed_phase2
 osp_release_defaults:
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20220428.0/images/rhel-guest-image-9.0-20220428.0.x86_64.qcow2
   bmset:

--- a/ansible/vars/17.0_hci_subnet.yaml
+++ b/ansible/vars/17.0_hci_subnet.yaml
@@ -1,6 +1,6 @@
 ---
 osp_release_auto_version: 17.0-RHEL-9
-osp_release_auto_compose: passed_phase1
+osp_release_auto_compose: passed_phase2
 
 ephemeral_heat:
   heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo

--- a/ansible/vars/17.0_hci_subnet.yaml
+++ b/ansible/vars/17.0_hci_subnet.yaml
@@ -48,3 +48,16 @@ osp_release_defaults:
         - tenant_leaf1
   extrafeatures:
     - hci
+
+# phase2 tempest tests
+tempest_test_dict:
+  regex: '(?!.*\[.*\bslow\b.*\])(^tempest\.(api|scenario))'
+  includelist: []
+  # per default with OVN there is no DHCPAgent, disable the tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON tests
+  excludelist:
+      - "^tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_multi_create_auto_allocate"
+      - "^tempest.api.compute.admin.test_live_migration.LiveMigrationTest.test_live_block_migration_paused"
+      - "^tempest.api.compute.admin.test_live_migration.LiveAutoBlockMigrationV225Test.test_live_block_migration_paused"
+      - "^tempest.api.compute.admin.test_live_migration.LiveMigrationRemoteConsolesV26Test.test_live_block_migration_paused"
+      - "^tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON.test_add_remove_network_from_dhcp_agent"
+      - "^tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON.test_list_networks_hosted_by_one_dhcp"

--- a/ansible/vars/17.0_ipv6.yaml
+++ b/ansible/vars/17.0_ipv6.yaml
@@ -1,6 +1,6 @@
 ---
 osp_release_auto_version: 17.0-RHEL-9
-osp_release_auto_compose: passed_phase1
+osp_release_auto_compose: passed_phase2
 
 osp_release_defaults:
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20220428.0/images/rhel-guest-image-9.0-20220428.0.x86_64.qcow2

--- a/ansible/vars/17.0_ipv6_subnet.yaml
+++ b/ansible/vars/17.0_ipv6_subnet.yaml
@@ -1,6 +1,6 @@
 ---
 osp_release_auto_version: 17.0-RHEL-9
-osp_release_auto_compose: passed_phase1
+osp_release_auto_compose: passed_phase2
 
 osp_release_defaults:
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20220428.0/images/rhel-guest-image-9.0-20220428.0.x86_64.qcow2

--- a/ansible/vars/17.0_subnet.yaml
+++ b/ansible/vars/17.0_subnet.yaml
@@ -1,6 +1,6 @@
 ---
 osp_release_auto_version: 17.0-RHEL-9
-osp_release_auto_compose: passed_phase1
+osp_release_auto_compose: passed_phase2
 
 ephemeral_heat:
   heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo


### PR DESCRIPTION
Now that we in stabilization, lets enable more phase2 tempest tests in the configured jobs.
phase2 tempest tests are right now only enabled for the DFG-ospk8s-osp-director-dev-tools-16.2_novacontrol_hci_tlse_subnet
job. Lets also enable it for the following jobs to have better coverage:
* DFG-ospk8s-osp-director-dev-tools-16.2_ipv6_tlse_subnet
* DFG-ospk8s-osp-director-dev-tools-17.0_hci_subnet

Also with OSP17 beta is released, switch all OSP17 configs to use passed_phase2 as the default.