### PR TITLE
In ansible 2.9 it is nmcli, not community.general.nmcli

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -91,7 +91,7 @@
         failed_when: dev_scripts_br_rm.stderr != "" and "no network with matching name" not in dev_scripts_br_rm.stderr and "is not active" not in dev_scripts_br_rm.stderr
 
       - name: Delete existing bridges (if any)
-        community.general.nmcli:
+        nmcli:
           conn_name: "{{ item }}"
           type: bridge
           state: absent
@@ -134,7 +134,7 @@
           - "{{ osp_ext_bm_interface }}"
 
       - name: Create BM bridge
-        community.general.nmcli:
+        nmcli:
           conn_name: "{{ ocp_cluster_name }}bm"
           type: bridge
           ifname: "{{ ocp_cluster_name }}bm"
@@ -154,7 +154,7 @@
           failed_when: bm_intf_down.stderr != "" and "no active connection provided" not in bm_intf_down.stderr
 
         - name: Add BM interface to BM bridge
-          community.general.nmcli:
+          nmcli:
             conn_name: "bridge-slave-{{ ocp_bm_interface }}"
             type: bridge-slave
             ifname: "{{ ocp_bm_interface }}"
@@ -164,7 +164,7 @@
             state: present
 
       - name: Create provisioning bridge
-        community.general.nmcli:
+        nmcli:
           conn_name: "{{ ocp_cluster_name }}pr"
           type: bridge
           ifname: "{{ ocp_cluster_name }}pr"


### PR DESCRIPTION
Deployments regularly fail with
```
[0;31mERROR! couldn't resolve module/action 'community.general.nmcli'. This often indicates a misspelling, missing collection, or incorrect module path.[0m
[0;31m[0m
[0;31mThe error appears to be in '/home/rhos-ci/jenkins/workspace/DFG-ospk8s-osp-director-dev-tools-17.0_hci_subnet/openstack-k8s/openstack-k8s/ansible/ocp_ai_prep.yaml': line 93, column 9, but may[0m
[0;31mbe elsewhere in the file depending on the exact syntax problem.[0m
[0;31m[0m
[0;31mThe offending line appears to be:[0m
[0;31m[0m
[0;31m[0m
```

From ansible docs in 2.9 it is nmcli, not community.general.nmcli:
https://docs.ansible.com/ansible/2.9/modules/nmcli_module.html

Lets use nmcli as we use in other parts of the playbooks.