### PR TITLE
Expose arbitrary inclusion of pre-existing heat env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __pycache__/
 
 # Env for testing
 .venv-ansible-lint/
+
+# VSCode
+.vscode

--- a/ansible/templates/osp/config_generator/openstackconfiggenerator.yaml.j2
+++ b/ansible/templates/osp/config_generator/openstackconfiggenerator.yaml.j2
@@ -23,6 +23,9 @@ spec:
     - services/haproxy-public-tls-certmonger.yaml
     - ssl/enable-internal-tls.yaml
 {%- endif %}
+{%- for envfile in osp_extra_env_files|default([]) %}
+    - {{ envfile }}
+{%- endfor %}
 {%- if config_generator_action|default('deploy') == 'update' %}
   heatEnvConfigMap: heat-env-config-update
   tarballConfigMap: tripleo-tarball-config-update

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -410,6 +410,11 @@ osp_release_defaults: {}
 # overwrite elements from osp_defaults or osp_release_defaults for local settings
 osp_local: {}
 
+# Relative paths to arbitrary extra Heat environment templates to include during OsConfigGenerator generation.
+# Relative to /usr/share/openstack-tripleo-heat-templates/environments/.
+# Example: ["services/neutron-ovn-sriov.yaml"]
+osp_extra_env_files: []
+
 # registration of the overcloud nodes, either rhsm or rhos-release
 osp_registry_method: rhos-release
 osp_rhos_release_compose: "{{ osp_release_auto.compose }}"


### PR DESCRIPTION
Exposes the `OsConfigGenerator`'s `heatEnvs` field for use with dev-tools via an Ansible list variable