### PR TITLE
Fixes for DPDK testing

### DIFF
--- a/ansible/datavolume.yaml
+++ b/ansible/datavolume.yaml
@@ -48,9 +48,9 @@
           #!/bin/bash
           set -e
           virt-customize -a "{{ osp_base_image_url_path }}" \
-            --run-command 'sed -i -e "s/^\(GRUB_CMDLINE_LINUX=.*\)net.ifnames=0 \(.*\)/\1\2/" /etc/default/grub' \
-            --run-command 'grubby --remove-args="net.ifnames=0" --update-kernel=$(grubby --default-kernel)' \
+            --run-command 'sed -i -e "s/^\(GRUB_CMDLINE_LINUX=.*\)net.ifnames=0\s*\(.*\)/\1\2/" /etc/default/grub' \
             --run-command 'grub2-mkconfig -o /etc/grub2.cfg' \
+            --run-command 'grub2-mkconfig -o /etc/grub2-efi.cfg' \
             --run-command 'rm -f /etc/sysconfig/network-scripts/ifcfg-ens* /etc/sysconfig/network-scripts/ifcfg-eth*'
         environment:
           LIBGUESTFS_BACKEND: direct

--- a/ansible/patch_csv.yaml
+++ b/ansible/patch_csv.yaml
@@ -105,7 +105,7 @@
       cmd: oc exec -t -n openstack openstackclient -- /bin/bash -c "ansible -i ~/ctlplane-ansible-inventory -m ping all"
     register: osclient_network_check
     until: osclient_network_check.rc == 0
-    retries: 20
+    retries: 120
     delay: 30
     when: osclient_exists|bool
 


### PR DESCRIPTION
Fixes for DPDK testing.

Grubby messes with grub2 on RHEL8 when BLS is enabled (which is by default on the latest rhel8.4 kvm guest image).

Network is taking a very long time to come up on BM hosts so bump the timeout where we wait for this. Probably could improve some of the logic but I think this should be enough to get a successful DPDK deployment.