### PR TITLE
Workaround kernel cmdline insanity

### DIFF
--- a/ansible/datavolume.yaml
+++ b/ansible/datavolume.yaml
@@ -43,15 +43,41 @@
           mode: '0644'
           timeout: 30
 
-      - name: Remove net.ifnames=0 kernel param from {{ osp_base_image_url_path }}
-        shell: |
-          #!/bin/bash
-          set -e
-          virt-customize -a "{{ osp_base_image_url_path }}" \
-            --run-command 'sed -i -e "s/^\(GRUB_CMDLINE_LINUX=.*\)net.ifnames=0\s*\(.*\)/\1\2/" /etc/default/grub' \
-            --run-command 'grub2-mkconfig -o /etc/grub2.cfg' \
-            --run-command 'grub2-mkconfig -o /etc/grub2-efi.cfg' \
-            --run-command 'rm -f /etc/sysconfig/network-scripts/ifcfg-ens* /etc/sysconfig/network-scripts/ifcfg-eth*'
+      - name: Create virt-customize script to remove net.ifnames=0 kernel param from {{ osp_base_image_url_path }}
+        copy:
+          dest: "{{ osp_base_image_url_path }}_customize.sh"
+          mode: '0755'
+          content: |
+            #!/bin/bash
+            
+            set -eux
+            
+            if [ -e /etc/kernel/cmdline ]; then
+              echo 'Updating /etc/kernel/cmdline'
+              sed -i -e "s/^\(.*\)net\.ifnames=0\s*\(.*\)/\1\2/" /etc/kernel/cmdline
+            fi
+            
+            source /etc/default/grub
+            
+            if grep -q "net.ifnames=0" <<< "$GRUB_CMDLINE_LINUX"; then
+              echo 'Updating /etc/default/grub'
+              sed -i -e "s/^\(GRUB_CMDLINE_LINUX=.*\)net\.ifnames=0\s*\(.*\)/\1\2/" /etc/default/grub
+            fi
+            
+            if [ "$GRUB_ENABLE_BLSCFG" == "true" ]; then
+              echo 'Fixing BLS entries'
+              find /boot/loader/entries -type f -exec sed -i -e "s/^\(.*\)net\.ifnames=0\s*\(.*\)/\1\2/" {} \;
+            fi
+            
+            # Always do this, on RHEL8 with BLS we still need it as the BLS entry uses $kernelopts from grubenv
+            echo 'Running grub2-mkconfig'
+            grub2-mkconfig -o /etc/grub2.cfg
+            grub2-mkconfig -o /etc/grub2-efi.cfg
+            
+            rm -f /etc/sysconfig/network-scripts/ifcfg-ens* /etc/sysconfig/network-scripts/ifcfg-eth*
+
+      - name: Run virt-customize
+        command: virt-customize -a "{{ osp_base_image_url_path }}" --run "{{ osp_base_image_url_path }}_customize.sh"
         environment:
           LIBGUESTFS_BACKEND: direct
 


### PR DESCRIPTION
Altering the kernel cmdline is completely different in RHEL8 and RHEL9 and AFAICT half-broken in both cases.

This logic seems to work on the RHEL and CentOS guest images we currently use.