### PR TITLE
remove workaround for BZ2087231

### DIFF
--- a/ansible/templates/osp/tripleo_heat_envs/16.2/workarounds.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/16.2/workarounds.yaml.j2
@@ -1,3 +1,1 @@
-parameter_defaults:
-  # https://bugzilla.redhat.com/show_bug.cgi?id=2087231
-  ValidateGatewaysIcmp: false
+#parameter_defaults:

--- a/ansible/vars/wallaby.yaml
+++ b/ansible/vars/wallaby.yaml
@@ -3,7 +3,7 @@ openstackclient_image: quay.io/tripleowallaby/openstack-tripleoclient:current-tr
 osp_release_defaults:
   release: wallaby
   container_tag: current-tripleo
-  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220509.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220919.0.x86_64.qcow2
   #TODO: which ceph images tag to use for upstream train?
   #ceph_tag: 5-12
   #ceph_image: daemon

--- a/ansible/vars/wallaby_ipv6.yaml
+++ b/ansible/vars/wallaby_ipv6.yaml
@@ -6,7 +6,7 @@ osp_release_defaults:
   #TODO: which ceph images tag to use for upstream wallaby?
   #ceph_tag: 5-12
   #ceph_image: daemon
-  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220509.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220919.0.x86_64.qcow2
   networks: ipv6
   extrafeatures:
     - ipv6

--- a/ansible/vars/wallaby_ipv6_subnet.yaml
+++ b/ansible/vars/wallaby_ipv6_subnet.yaml
@@ -16,7 +16,7 @@ ephemeral_heat:
 osp_release_defaults:
   release: wallaby
   container_tag: current-tripleo
-  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220509.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220919.0.x86_64.qcow2
   #TODO: which ceph images tag to use for upstream train?
   #ceph_tag: 5-12
   #ceph_image: daemon

--- a/ansible/vars/wallaby_subnet.yaml
+++ b/ansible/vars/wallaby_subnet.yaml
@@ -17,7 +17,7 @@ openstackclient_networks:
 osp_release_defaults:
   release: wallaby
   container_tag: current-tripleo
-  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220509.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220919.0.x86_64.qcow2
   ceph_tag: 5-12
   networks: ipv4_subnet
   vmset:


### PR DESCRIPTION
- removes workaround for BZ2087231]
- updates centos 9 image for wallaby configs for - `Deployment of upstream wallaby fails with` :
~~~
2022-09-26 06:25:20.729453 | 0a580a82-0028-6b26-f910-000000001a2f |       TASK | Enable os_enable_vtpm SELinux boolean for vTPM
2022-09-26 06:25:21.083708 | 0a580a82-0028-6b26-f910-000000001a2f |      FATAL | Enable os_enable_vtpm SELinux boolean for vTPM | computeleaf1-0 | error={"changed": false, "msg": "SELinux boolean os_enable_vtpm does not exist."}
2022-09-26 06:25:21.084648 | 0a580a82-0028-6b26-f910-000000001a2f |     TIMING | Enable os_enable_vtpm SELinux boolean for vTPM | computeleaf1-0 | 0:06:54.191964 | 0.35s
2022-09-26 06:25:21.094984 | 0a580a82-0028-6b26-f910-000000001b6d |      FATAL | Enable os_enable_vtpm SELinux boolean for vTPM | computeleaf2-0 | error={"changed": false, "msg": "SELinux boolean os_enable_vtpm does not exist."}
~~~

Root cause is https://bugzilla.redhat.com/show_bug.cgi?id=2094683 ,
where the fix is to use libselinux-3.4-2.el9.x86_64.rpm. This is in
later CentOS image versions.

Lets update to use https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220919.0.x86_64.qcow2