### PR TITLE
Disable network-feature-enabled.floating_ips for ipv6

### DIFF
--- a/ansible/vars/16.2_ipv6.yaml
+++ b/ansible/vars/16.2_ipv6.yaml
@@ -30,3 +30,5 @@ tempest_enable_feature_dict:
     block_migration_for_live_migration: true
     volume_backed_live_migration: true
     console_output: true
+  network-feature-enabled:
+    floating_ips: false

--- a/ansible/vars/16.2_ipv6_hci_subnet.yaml
+++ b/ansible/vars/16.2_ipv6_hci_subnet.yaml
@@ -43,3 +43,5 @@ tempest_enable_feature_dict:
     block_migration_for_live_migration: false
     volume_backed_live_migration: true
     console_output: true
+  network-feature-enabled:
+    floating_ips: false

--- a/ansible/vars/16.2_ipv6_hci_tlse_subnet.yaml
+++ b/ansible/vars/16.2_ipv6_hci_tlse_subnet.yaml
@@ -61,3 +61,5 @@ tempest_enable_feature_dict:
     block_migration_for_live_migration: false
     volume_backed_live_migration: true
     console_output: true
+  network-feature-enabled:
+    floating_ips: false

--- a/ansible/vars/16.2_ipv6_novacontrol_hci_tlse_subnet.yaml
+++ b/ansible/vars/16.2_ipv6_novacontrol_hci_tlse_subnet.yaml
@@ -77,3 +77,5 @@ tempest_enable_feature_dict:
     block_migration_for_live_migration: false
     volume_backed_live_migration: true
     console_output: true
+  network-feature-enabled:
+    floating_ips: false

--- a/ansible/vars/16.2_ipv6_subnet.yaml
+++ b/ansible/vars/16.2_ipv6_subnet.yaml
@@ -73,3 +73,5 @@ tempest_enable_feature_dict:
     block_migration_for_live_migration: true
     volume_backed_live_migration: true
     console_output: true
+  network-feature-enabled:
+    floating_ips: false

--- a/ansible/vars/16.2_ipv6_tlse_subnet.yaml
+++ b/ansible/vars/16.2_ipv6_tlse_subnet.yaml
@@ -110,3 +110,5 @@ tempest_enable_feature_dict:
     block_migration_for_live_migration: true
     volume_backed_live_migration: true
     console_output: true
+  network-feature-enabled:
+    floating_ips: false

--- a/ansible/vars/17.0_ipv6.yaml
+++ b/ansible/vars/17.0_ipv6.yaml
@@ -41,3 +41,5 @@ tempest_enable_feature_dict:
     block_migration_for_live_migration: true
     volume_backed_live_migration: true
     console_output: true
+  network-feature-enabled:
+    floating_ips: false

--- a/ansible/vars/17.0_ipv6_subnet.yaml
+++ b/ansible/vars/17.0_ipv6_subnet.yaml
@@ -112,3 +112,5 @@ tempest_enable_feature_dict:
     block_migration_for_live_migration: true
     volume_backed_live_migration: true
     console_output: true
+  network-feature-enabled:
+    floating_ips: false

--- a/ansible/vars/train_ipv6.yaml
+++ b/ansible/vars/train_ipv6.yaml
@@ -44,3 +44,5 @@ tempest_enable_feature_dict:
     block_migration_for_live_migration: true
     volume_backed_live_migration: true
     console_output: true
+  network-feature-enabled:
+    floating_ips: false

--- a/ansible/vars/train_ipv6_subnet.yaml
+++ b/ansible/vars/train_ipv6_subnet.yaml
@@ -69,3 +69,5 @@ tempest_enable_feature_dict:
     block_migration_for_live_migration: true
     volume_backed_live_migration: true
     console_output: true
+  network-feature-enabled:
+    floating_ips: false

--- a/ansible/vars/wallaby_ipv6.yaml
+++ b/ansible/vars/wallaby_ipv6.yaml
@@ -44,3 +44,5 @@ tempest_enable_feature_dict:
     block_migration_for_live_migration: true
     volume_backed_live_migration: true
     console_output: true
+  network-feature-enabled:
+    floating_ips: false

--- a/ansible/vars/wallaby_ipv6_subnet.yaml
+++ b/ansible/vars/wallaby_ipv6_subnet.yaml
@@ -87,3 +87,5 @@ tempest_enable_feature_dict:
     block_migration_for_live_migration: true
     volume_backed_live_migration: true
     console_output: true
+  network-feature-enabled:
+    floating_ips: false


### PR DESCRIPTION
As there is no ipv4 external network there are no floating IPs. Lets disable network-feature-enabled.floating_ips so that tests get skipped which require a floating ip and otherwise fail with

~~~
Details: {'type': 'BadRequest', 'message': 'Bad floatingip request: Network 0c2d2a84-0a4e-4cc7-9fd8-66eefa728424 does not contain any IPv4 subnet.', 'detail': ''}
~~~