### PR TITLE
Pin bcrypt to 3.2.2

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -556,6 +556,13 @@
     become: true
     become_user: root
     block:
+    # latest 4.0.1 fails with: ModuleNotFoundError: No module named 'setuptools_rust'
+    - name: Install bcrypt < 4.0.0
+      pip:
+        name: ['bcrypt']
+        version: "<4.0.0"
+        executable: /usr/bin/pip-3
+
     - name: Install sushy-tools via pip3
       pip:
         name: ['sushy-tools', 'libvirt-python']


### PR DESCRIPTION
sushy-tools dependency installs bcrypt > 3.0.1. brcypt latest version 4.0.1 has a dependency to setuptools_rust which fails to install with:

ModuleNotFoundError: No module named 'setuptools_rust'

For now install bcrypt 3.2.2.