### PR TITLE
[1.2.x backport] bump OCP to 4.10.27 and CNV 4.10 (#405)

### DIFF
--- a/ansible/datavolume_tasks.yaml
+++ b/ansible/datavolume_tasks.yaml
@@ -24,7 +24,7 @@
   block:
     - name: Upload OSP Controller base image
       shell: |
-        virtctl image-upload dv {{ _datavolume }} -n {{ namespace }} --size={{ osp.vmset[_role].disk_size }}G --image-path={{ osp_base_image_url_path }} --insecure
+        virtctl image-upload dv {{ _datavolume }} -n {{ namespace }} --size={{ osp.vmset[_role].disk_size }}G --image-path={{ osp_base_image_url_path }} --insecure --access-mode ReadWriteOnce
   rescue:
     - name: Remove datavolume {{ _datavolume }} from failed upload
       command: oc delete datavolume {{ _datavolume }} -n {{ namespace }}
@@ -32,7 +32,7 @@
 
     - name: Re-Upload base image {{ _datavolume }}
       shell: |
-        virtctl image-upload dv {{ _datavolume }} -n {{ namespace }} --size={{ osp.vmset[_role].disk_size }}G --image-path={{ osp_base_image_url_path }} --insecure
+        virtctl image-upload dv {{ _datavolume }} -n {{ namespace }} --size={{ osp.vmset[_role].disk_size }}G --image-path={{ osp_base_image_url_path }} --insecure --access-mode ReadWriteOnce
 
 - name: Wait for the datavolume {{ _datavolume }} to be ready
   retries: 5

--- a/ansible/host_prep.yaml
+++ b/ansible/host_prep.yaml
@@ -36,7 +36,7 @@
     - name: fail if OCP version <= 4.6
       fail:
         msg: "OCP version {{ ocp_version }} is not allowed.  Only OCP greater than 4.6 is currently supported for assisted installer deployments."
-      when: ocp_version <= 4.6
+      when: ocp_version is version('4.6', 'le', strict=True )
     when: ocp_ai|bool
 
   - name: OCS validation checks

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -9,8 +9,8 @@ dev_scripts_branch: b8c619c1515d03f162adf08cbb89f9ba5c6d5cf1
 base_domain_name: test.metalkube.org
 
 # To set a specific release to install.
-ocp_version: 4.8
-ocp_minor_version: 35
+ocp_version: "4.10"
+ocp_minor_version: 27
 ocp_release_image: "quay.io/openshift-release-dev/ocp-release:{{ ocp_version }}.{{ ocp_minor_version }}-x86_64"
 ocp_release_data_url: "https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/{{ ocp_version }}.{{ ocp_minor_version }}"
 ocp_release_type: ga
@@ -189,7 +189,7 @@ sriov_version: "{{ ocp_version }}"
 perf_version: "{{ ocp_version }}"
 
 # CNV addon operator version (usually should correspond to X.X release)
-cnv_hyperconverged_operator_version: "{{ {'4.10':'4.10.1', '4.9':'4.9.4', '4.8':'4.8.6'}.get(ocp_version|string) }}"
+cnv_hyperconverged_operator_version: "{{ {'4.10':'4.10.4', '4.9':'4.9.4', '4.8':'4.8.6'}.get(ocp_version|string) }}"
 
 # namespace to deploy the operator to
 # Note: right now only openstack is supported as it is hardcoded in the Dockerfile
@@ -414,7 +414,7 @@ osp_rhel_subscription_repos:
 # NOTE: Only AI deployments currently support OCS, so even if "enable_ocs" is set to true for
 #       a dev-scripts deployment, it will not be honored
 enable_ocs: false
-ocs_version: "{{ 4.8 if ocp_version >= 4.8 else ocp_version }}"
+ocs_version: "{{ 4.10 if ocp_version >= 4.10 else ocp_version }}"
 
 # Virtualized SRIOV (for dev/test)
 enable_virt_sriov: false


### PR DESCRIPTION
* bump OCP to 4.10.27 and CNV 4.10

* fix OCP version check

* set ocs to 4.10

* make sure ocp_version is string

* Set access-mode on datavolume create

DV create fails right now with the following error since there is no access-mode set in the auto created host-nfs-storageclass StorageProfile.

2022-08-19T10:30:41.735952853Z {"level":"error","ts":1660905041.735828,"logger":"controller.datavolume-controller","msg":"Reconciler error","name":"controller-base-img","namespace":"openstack","error":"no accessMode defined DV nor on StorageProfile for host-nfs-storageclass StorageClass","errorVerbose":"no accessMode defined DV nor on StorageProfile for host-nfs-storageclass StorageClass

For now just set the access-mode on the upload command.

(cherry picked from commit 19bbbf68a999ed3c4eaa0b38e04c11b701bf1973)