### PR TITLE
Use latest osconfigversion for osdeploy

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,11 @@
 approvers:
   - abays
   - dprince
-  - mpryc
   - stuggi
   - olliewalsh
 
 reviewers:
   - abays
   - dprince
-  - mpryc
   - stuggi
   - olliewalsh

--- a/ansible/osp_deployment.yaml
+++ b/ansible/osp_deployment.yaml
@@ -31,7 +31,7 @@
   # TODO: filter by configGeneratorName
   - name: Lookup configVersion
     shell: >
-      oc get -n openstack --sort-by {.metadata.creationTimestamp} osconfigversions -o json | jq -e '.items[0].spec | {hash,configGeneratorName}'
+      oc get -n openstack --sort-by {.metadata.creationTimestamp} osconfigversions -o json | jq -e '.items[-1].spec | {hash,configGeneratorName}'
     register: config_version_cmd
     environment: &oc_env
       PATH: "{{ oc_env_path }}"


### PR DESCRIPTION
osconfigversions get sorted by date in [1] and first element of the configversions used to get the hash for the osdeploy. While this works for a fresh deployment where there is only a single osconfigversion, when an update is performed, the latest osconfigversion is the last element of the array.

[1] https://github.com/openstack-k8s-operators/osp-director-dev-tools/blob/master/ansible/osp_deployment.yaml#L34