### PR TITLE
Rebase AI installs against latest Crucible

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -614,10 +614,10 @@
 
     - name: Clone the assisted installer playbooks repo
       git:
-        repo: "{{ ocp_ai_ansible_repo | default('https://github.com/openstack-k8s-operators/crucible.git', true) }}"
+        repo: "{{ ocp_ai_ansible_repo | default('https://github.com/redhat-partner-solutions/crucible.git', true) }}"
         dest: "{{ base_path }}/crucible"
         force: true
-        version: "{{ ocp_ai_ansible_branch | default('apiV2', true) }}"
+        version: "{{ ocp_ai_ansible_branch | default('380937382a9929bc3af76724e4a9186cf1d61f50', true) }}"
 
     - name: Get BMC-network-connected interface's IP for baremetal deployments
       when: ocp_cluster_has_bm|bool
@@ -654,27 +654,9 @@
         regexp: 'openshift_full_version in supported_ocp_versions'
         replace: 'openshift_full_version is defined'
 
-    - name: Override/inject OCP live ISO version
-      replace:
-        path: "{{ base_path }}/crucible/roles/setup_assisted_installer/defaults/main.yml"
-        after: "assisted_installer_os_images_defualts:"
-        before: "assisted_installer_release_images_defaults:"
-        regexp: 'dependencies/rhcos/{{ ocp_version | replace(".", "\.") }}/.*iso'
-        replace: 'dependencies/rhcos/{{ ocp_version }}/latest/rhcos-live.x86_64.iso'
-
-    - name: Override/inject OCP live rootfs version
-      replace:
-        path: "{{ base_path }}/crucible/roles/setup_assisted_installer/defaults/main.yml"
-        after: "assisted_installer_os_images_defualts:"
-        before: "assisted_installer_release_images_defaults:"
-        regexp: 'dependencies/rhcos/{{ ocp_version | replace(".", "\.") }}/.*img'
-        replace: 'dependencies/rhcos/{{ ocp_version }}/latest/rhcos-live-rootfs.x86_64.img'
-
     - name: Override/inject desired OCP version (display_name/release_version)
       replace:
-        path: "{{ base_path }}/crucible/roles/setup_assisted_installer/defaults/main.yml"
-        after: "assisted_installer_release_images_defaults:"
-        before: "assisted_installer_hardware_validation:"
+        path: "{{ base_path }}/crucible/roles/get_image_hash/defaults/main.yml"
         regexp: '{{ ocp_version | replace(".", "\.") }}\.\d+'
         replace: '{{ ocp_version }}.{{ ocp_minor_version }}'
 
@@ -691,7 +673,7 @@
       - name: Get RHCOS image version for {{ ocp_version }}.{{ ocp_minor_version }}
         set_fact:
           rhcos_image_version: "{{ rhcos_image_version_raw_data.content | regex_search('second_release=([^&]+)', '\\1') | default ([''], true) | first }}"
-          rhcos_image_version_alt: "{{ rhcos_image_version_raw_data.content | regex_search('/\\?release=([^&]+)', '\\1') | default ([''], true) | first }}"
+          rhcos_image_version_alt: "{{ rhcos_image_version_raw_data.content | regex_search('\\/\\?release=([^&]+)', '\\1') | default ([''], true) | first }}"
 
       - name: Fail when an RHCOS version cannot be determined
         fail:
@@ -700,19 +682,9 @@
 
       - name: Inject RHCOS image version
         replace:
-          path: "{{ base_path }}/crucible/roles/setup_assisted_installer/defaults/main.yml"
-          after: "assisted_installer_os_images_defualts:"
-          before: "assisted_installer_release_images_defaults:"
-          regexp: 'version:\s"{{ ocp_version | replace(".", "") }}\..+'
+          path: "{{ base_path }}/crucible/roles/get_image_hash/defaults/main.yml"
+          regexp: 'version:\s"{{ ocp_version | replace(".", "") }}\.\d+.+'
           replace: 'version: "{{ rhcos_image_version if rhcos_image_version != "" else rhcos_image_version_alt }}"'
-
-      - name: Override release image URL
-        replace:
-          path: "{{ base_path }}/crucible/roles/setup_assisted_installer/defaults/main.yml"
-          after: 'cpu_architecture: "x86_64"'
-          before: 'version: "{{ ocp_version }}.{{ ocp_minor_version }}"'
-          regexp: 'url:\s"quay.io/openshift-release-dev/ocp-release{\%\sif\s''release_{{ ocp_version }}.*'
-          replace: 'url: "quay.io/openshift-release-dev/ocp-release:{{ ocp_version }}.{{ ocp_minor_version }}-x86_64"'
 
     - name: Force linear execution of boot_iso role when KVM nodes present
       when: ocp_num_masters > 0 or ocp_num_workers > 0

--- a/ansible/templates/ai/crucible/inventory.ospd.yml.j2
+++ b/ansible/templates/ai/crucible/inventory.ospd.yml.j2
@@ -311,25 +311,25 @@ all:
             {{ ocp_cluster_name }}-{{ name }}:
               vendor: {{ master.vendor }}
               ansible_host: {{ ocp_ai_bm_cidr_prefix }}.1{{ loop.index0 }}
-              mac: "{{ master.bm_mac }}"
+              mac: "{{ master.bm_mac | upper }}"
               bmc_address: {{ master.bmc_address }}
               bmc_user: {{ master.bmc_username }}
               bmc_password: {{ master.bmc_password }}
               installation_disk_path: {{ master.root_device | default ("/dev/sda") }}
               mac_interface_map:
               - logical_nic_name: {{ master.bm_interface }}
-                mac_address: "{{ master.bm_mac }}"
+                mac_address: "{{ master.bm_mac | upper }}"
 {% if master.disabled_interfaces is defined and master.disabled_interfaces | length > 0 %}
 {% for interface in master.disabled_interfaces %}
               - logical_nic_name: {{ interface.name }}
-                mac_address: "{{ interface.mac }}"
+                mac_address: "{{ interface.mac | upper }}"
 {% endfor %}
 {% endif %}
               network_config:
                 raw:
                   interfaces:
                     - name: {{ master.bm_interface }}
-                      mac: "{{ master.bm_mac }}"
+                      mac: "{{ master.bm_mac | upper }}"
                       state: up
                       ipv4:
                         enabled: true
@@ -340,7 +340,7 @@ all:
 {% if master.disabled_interfaces is defined and master.disabled_interfaces | length > 0 %}
 {% for interface in master.disabled_interfaces %}
                     - name: {{ interface.name }}
-                      mac: "{{ interface.mac }}"
+                      mac: "{{ interface.mac | upper }}"
                       state: up
                       ipv4:
                         enabled: false
@@ -363,7 +363,7 @@ all:
 {% for i in range(0, ocp_num_masters) %}
             {{ ocp_cluster_name }}-master-{{ i }}:
               ansible_host: {{ ocp_ai_bm_cidr_prefix }}.1{{ i }}
-              mac: "{{ ocp_ai_bm_bridge_master_mac_prefix }}{{ i }}"
+              mac: "{{ ocp_ai_bm_bridge_master_mac_prefix | upper }}{{ i }}"
 {% endfor %}
 {% endif %}
 
@@ -376,25 +376,25 @@ all:
             {{ ocp_cluster_name }}-{{ name }}:
               vendor: {{ worker.vendor }}
               ansible_host: {{ ocp_ai_bm_cidr_prefix }}.2{{ loop.index0 }}
-              mac: "{{ worker.bm_mac }}"
+              mac: "{{ worker.bm_mac | upper }}"
               bmc_address: {{ worker.bmc_address }}
               bmc_user: {{ worker.bmc_username }}
               bmc_password: {{ worker.bmc_password }}
               installation_disk_path: {{ worker.root_device | default ("/dev/sda") }}
               mac_interface_map:
               - logical_nic_name: {{ worker.bm_interface }}
-                mac_address: "{{ worker.bm_mac }}"
+                mac_address: "{{ worker.bm_mac | upper }}"
 {% if worker.disabled_interfaces is defined and worker.disabled_interfaces | length > 0 %}
 {% for interface in worker.disabled_interfaces %}
               - logical_nic_name: {{ interface.name }}
-                mac_address: "{{ interface.mac }}"
+                mac_address: "{{ interface.mac | upper }}"
 {% endfor %}
 {% endif %}
               network_config:
                 raw:
                   interfaces:
                     - name: {{ worker.bm_interface }}
-                      mac: "{{ worker.bm_mac }}"
+                      mac: "{{ worker.bm_mac | upper }}"
                       state: up
                       ipv4:
                         enabled: true
@@ -405,7 +405,7 @@ all:
 {% if worker.disabled_interfaces is defined and worker.disabled_interfaces | length > 0 %}
 {% for interface in worker.disabled_interfaces %}
                     - name: {{ interface.name }}
-                      mac: "{{ interface.mac }}"
+                      mac: "{{ interface.mac | upper }}"
                       state: up
                       ipv4:
                         enabled: false
@@ -428,6 +428,6 @@ all:
 {% for i in range(0, ocp_num_workers) %}
             {{ ocp_cluster_name }}-worker-{{ i }}:
               ansible_host: {{ ocp_ai_bm_cidr_prefix }}.2{{ i }}
-              mac: "{{ ocp_ai_bm_bridge_worker_mac_prefix }}{{ i }}"
+              mac: "{{ ocp_ai_bm_bridge_worker_mac_prefix | upper }}{{ i }}"
 {% endfor %}
 {% endif %}

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -14,7 +14,7 @@ podman_insecure_registries:
 
 # To set a specific release to install.
 ocp_version: "4.10"
-ocp_minor_version: 27
+ocp_minor_version: 37
 ocp_release_image: "quay.io/openshift-release-dev/ocp-release:{{ ocp_version }}.{{ ocp_minor_version }}-x86_64"
 ocp_release_data_url: "https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/{{ ocp_version }}.{{ ocp_minor_version }}"
 ocp_release_type: ga

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -2,8 +2,8 @@
 # this address needs to be reachable from IPMI/iDRAC if BM worker is used 
 ocp_ai_discovery_iso_server: 192.168.111.1
 
-# ocp_ai_ansible_repo: defaults to "https://github.com/openstack-k8s-operators/crucible.git"
-# ocp_ai_ansible_branch: defaults to "apiV2"
+# ocp_ai_ansible_repo: defaults to "https://github.com/redhat-partner-solutions/crucible.git"
+# ocp_ai_ansible_branch: defaults to "380937382a9929bc3af76724e4a9186cf1d61f50"
 
 ocp_ai_bm_bridge_master_mac_prefix: 3c:fd:fe:78:ab:0
 ocp_ai_bm_bridge_worker_mac_prefix: 3c:fd:fe:78:ab:1


### PR DESCRIPTION
Update AI installs to use latest Crucible upstream bits.

Tested on new RHEL 4.6 machine with `ocp_version` set to `4.10` and `ocp_minor_version` set to `37`.