### PR TITLE
Ignore errors from nmcli module when deleting bridges

### DIFF
--- a/ansible/ocp_ai_destroy.yaml
+++ b/ansible/ocp_ai_destroy.yaml
@@ -113,6 +113,7 @@
       - "{{ ocp_cluster_name }}pr"
       - "ospnetwork"
       - "external"
+    ignore_errors: yes
 
   - name: Make sure bridge ifcfg files are removed
     file:


### PR DESCRIPTION
This is failing on my dev host causing destroy_ocp to bail out early. Looks like an issue in the nmcli module or the nm command. For now just ignore errors.