### PR TITLE
Workaround BZ2087231 for 16.2.3

### DIFF
--- a/ansible/templates/osp/tripleo_heat_envs/16.2/workarounds.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/16.2/workarounds.yaml.j2
@@ -1,1 +1,4 @@
-#parameter_defaults:
+{%- if workaround_BZ2087231|default(false) %}
+parameter_defaults:
+    ValidateGatewaysIcmp: false
+{%- endif %}

--- a/ansible/vars/16.2.3_fencing.yaml
+++ b/ansible/vars/16.2.3_fencing.yaml
@@ -3,6 +3,8 @@ osp_release_auto_compose: z3
 
 enable_fencing: true
 
+workaround_BZ2087231: true
+
 osp_release_defaults:
   vmset:
     Controller:


### PR DESCRIPTION
IIRC we previously had this workaround in dev tools but removed it when we switched to 16.2.4 composes. Re-enable it just for the 16.2.3 environment.