### PR TITLE
Some fixes

### DIFF
--- a/ansible/vars/17.0.yaml
+++ b/ansible/vars/17.0.yaml
@@ -1,11 +1,7 @@
 ---
+csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
 osp_release_auto_compose: passed_phase2
-ephemeral_heat:
-  heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
-  heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo
-  mariadb_image: quay.io/tripleowallaby/openstack-mariadb:current-tripleo
-  rabbit_image: quay.io/tripleowallaby/openstack-rabbitmq:current-tripleo
 
 osp_release_defaults:
-  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20220428.0/images/rhel-guest-image-9.0-20220428.0.x86_64.qcow2
+  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2

--- a/ansible/vars/17.0.yaml
+++ b/ansible/vars/17.0.yaml
@@ -1,7 +1,6 @@
 ---
 csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
-osp_release_auto_compose: passed_phase2
 
 osp_release_defaults:
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2

--- a/ansible/vars/17.0_external_ceph.yaml
+++ b/ansible/vars/17.0_external_ceph.yaml
@@ -1,7 +1,6 @@
 ---
 csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
-osp_release_auto_compose: passed_phase2
 
 osp_release_defaults:
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2

--- a/ansible/vars/17.0_external_ceph.yaml
+++ b/ansible/vars/17.0_external_ceph.yaml
@@ -1,14 +1,10 @@
 ---
+csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
 osp_release_auto_compose: passed_phase2
-ephemeral_heat:
-  heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
-  heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo
-  mariadb_image: quay.io/tripleowallaby/openstack-mariadb:current-tripleo
-  rabbit_image: quay.io/tripleowallaby/openstack-rabbitmq:current-tripleo
 
 osp_release_defaults:
-  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20220428.0/images/rhel-guest-image-9.0-20220428.0.x86_64.qcow2
+  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2
   extrafeatures:
     - external_ceph
 

--- a/ansible/vars/17.0_hci.yaml
+++ b/ansible/vars/17.0_hci.yaml
@@ -1,8 +1,9 @@
 ---
+csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
 osp_release_auto_compose: passed_phase2
 osp_release_defaults:
-  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20220428.0/images/rhel-guest-image-9.0-20220428.0.x86_64.qcow2
+  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2
   bmset:
     Compute:
       count: 0
@@ -17,8 +18,3 @@ osp_release_defaults:
         - storage_mgmt
   extrafeatures:
     - hci
-ephemeral_heat:
-  heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
-  heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo
-  mariadb_image: quay.io/tripleowallaby/openstack-mariadb:current-tripleo
-  rabbit_image: quay.io/tripleowallaby/openstack-rabbitmq:current-tripleo

--- a/ansible/vars/17.0_hci.yaml
+++ b/ansible/vars/17.0_hci.yaml
@@ -1,7 +1,6 @@
 ---
 csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
-osp_release_auto_compose: passed_phase2
 osp_release_defaults:
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2
   bmset:

--- a/ansible/vars/17.0_hci_subnet.yaml
+++ b/ansible/vars/17.0_hci_subnet.yaml
@@ -1,7 +1,6 @@
 ---
 csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
-osp_release_auto_compose: passed_phase2
 
 openstackclient_networks:
   - ctlplane

--- a/ansible/vars/17.0_hci_subnet.yaml
+++ b/ansible/vars/17.0_hci_subnet.yaml
@@ -1,12 +1,7 @@
 ---
+csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
 osp_release_auto_compose: passed_phase2
-
-ephemeral_heat:
-  heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
-  heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo
-  mariadb_image: quay.io/tripleowallaby/openstack-mariadb:current-tripleo
-  rabbit_image: quay.io/tripleowallaby/openstack-rabbitmq:current-tripleo
 
 openstackclient_networks:
   - ctlplane
@@ -15,7 +10,7 @@ openstackclient_networks:
   - internal_api_leaf1
 
 osp_release_defaults:
-  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20220428.0/images/rhel-guest-image-9.0-20220428.0.x86_64.qcow2
+  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2
   networks: ipv4_subnet
   vmset:
     Controller:

--- a/ansible/vars/17.0_ipv6.yaml
+++ b/ansible/vars/17.0_ipv6.yaml
@@ -1,18 +1,13 @@
 ---
+csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
 osp_release_auto_compose: passed_phase2
 
 osp_release_defaults:
-  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20220428.0/images/rhel-guest-image-9.0-20220428.0.x86_64.qcow2
+  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2
   networks: ipv6
   extrafeatures:
     - ipv6
-
-ephemeral_heat:
-  heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
-  heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo
-  mariadb_image: quay.io/tripleowallaby/openstack-mariadb:current-tripleo
-  rabbit_image: quay.io/tripleowallaby/openstack-rabbitmq:current-tripleo
 
 # TODO: create good set of ipv6 tempest tests, right now disabled those which create floating IP, which is not the case in IPv6
 tempest_test_dict:

--- a/ansible/vars/17.0_ipv6.yaml
+++ b/ansible/vars/17.0_ipv6.yaml
@@ -1,7 +1,6 @@
 ---
 csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
-osp_release_auto_compose: passed_phase2
 
 osp_release_defaults:
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2

--- a/ansible/vars/17.0_ipv6_subnet.yaml
+++ b/ansible/vars/17.0_ipv6_subnet.yaml
@@ -1,7 +1,6 @@
 ---
 csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
-osp_release_auto_compose: passed_phase2
 
 osp_release_defaults:
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2

--- a/ansible/vars/17.0_ipv6_subnet.yaml
+++ b/ansible/vars/17.0_ipv6_subnet.yaml
@@ -1,9 +1,10 @@
 ---
+csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
 osp_release_auto_compose: passed_phase2
 
 osp_release_defaults:
-  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20220428.0/images/rhel-guest-image-9.0-20220428.0.x86_64.qcow2
+  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2
   networks: ipv6_subnet
   vmset:
     Controller:
@@ -43,13 +44,6 @@ osp_release_defaults:
         - storage_leaf2
   extrafeatures:
     - ipv6
-
-
-ephemeral_heat:
-  heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
-  heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo
-  mariadb_image: quay.io/tripleowallaby/openstack-mariadb:current-tripleo
-  rabbit_image: quay.io/tripleowallaby/openstack-rabbitmq:current-tripleo
 
 # phase2 tempest tests
 tempest_test_dict:

--- a/ansible/vars/17.0_subnet.yaml
+++ b/ansible/vars/17.0_subnet.yaml
@@ -1,7 +1,6 @@
 ---
 csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
-osp_release_auto_compose: passed_phase2
 
 openstackclient_networks:
   - ctlplane

--- a/ansible/vars/17.0_subnet.yaml
+++ b/ansible/vars/17.0_subnet.yaml
@@ -1,12 +1,7 @@
 ---
+csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
 osp_release_auto_compose: passed_phase2
-
-ephemeral_heat:
-  heat_api_image: quay.io/tripleowallaby/openstack-heat-api:current-tripleo
-  heat_engine_image: quay.io/tripleowallaby/openstack-heat-engine:current-tripleo
-  mariadb_image: quay.io/tripleowallaby/openstack-mariadb:current-tripleo
-  rabbit_image: quay.io/tripleowallaby/openstack-rabbitmq:current-tripleo
 
 openstackclient_networks:
   - ctlplane
@@ -15,7 +10,7 @@ openstackclient_networks:
   - internal_api_leaf1
 
 osp_release_defaults:
-  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20220428.0/images/rhel-guest-image-9.0-20220428.0.x86_64.qcow2
+  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2
   networks: ipv4_subnet
   vmset:
     Controller:

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -469,7 +469,7 @@ freeipa_directory_manager_password: dcba1234
 freeipa_image_url: quay.io/freeipa/freeipa-server:centos-8-stream
 
 # must-gather image
-must_gather_image: quay.io/openstack-k8s-operators/must-gather:0.0.2
+must_gather_image: quay.io/openstack-k8s-operators/must-gather:latest
 # Optional directory to save must-gather information, defaults to "{{ working_log_dir }}"
 # must_gather_directory: "{{ working_log_dir }}"
 must_gather_compress_logs: false

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -25,9 +25,7 @@ ocp_release_type: ga
 # - ocp_release_type is ignored
 # - ocp_version must be 4.6+
 # - Other OCP AI variables are stored in vars/ocp_ai.yaml to reduce clutter in this file
-# NOTE: This variable should be set to true in local-defaults.yaml as opposed to changing it here,
-#       otherwise our playbooks seem to be flaky with executing the AI logic
-#ocp_ai: false
+ocp_ai: true
 
 # private repo to read required secret files from
 # The playbooks expect secret files which can be placed in a private repo
@@ -185,7 +183,7 @@ sdk_version: v1.20.0
 kuttl_version: 0.12.1
 
 # golang version
-go_version: 1.17.9
+go_version: 1.18.9
 
 # kustomize version to use (must be specific version)
 kustomize_version: v4.0.1

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -209,7 +209,7 @@ watch_namespace: openstack,openshift-machine-api,openshift-sriov-network-operato
 # osp-director-operator image and tag to use
 director_operator_image: quay.io/openstack-k8s-operators/osp-director-operator
 # CSV version is used for both the CSV version and container image tag
-csv_version: latest
+csv_version: latest-16.2
 
 #ocp_network_type: OVNKubernetes
 ocp_network_type: OpenShiftSDN

--- a/ansible/vars/ocp4.8_16.2.yaml
+++ b/ansible/vars/ocp4.8_16.2.yaml
@@ -1,0 +1,10 @@
+ocp_version: "4.8"
+ocp_minor_version: 53
+
+ocp_master_disk: 130
+ocp_worker_disk: 130
+
+#osp_release_auto_compose: z3
+#workaround_BZ2087231: true
+
+osp_release_defaults: {}


### PR DESCRIPTION
* set ai as default and go_version to 1.18.9
* add ocp4.8 16.2 config
* use csv defaults for ephemeral_heat images

Depends-On: https://github.com/openstack-k8s-operators/osp-director-operator/pull/729