### PR TITLE
truncate /etc/machine-id in golden image

### DIFF
--- a/ansible/datavolume.yaml
+++ b/ansible/datavolume.yaml
@@ -77,7 +77,7 @@
             rm -f /etc/sysconfig/network-scripts/ifcfg-ens* /etc/sysconfig/network-scripts/ifcfg-eth*
 
       - name: Run virt-customize
-        command: virt-customize -a "{{ osp_base_image_url_path }}" --run "{{ osp_base_image_url_path }}_customize.sh"
+        command: virt-customize -a "{{ osp_base_image_url_path }}" --run "{{ osp_base_image_url_path }}_customize.sh" --truncate /etc/machine-id
         environment:
           LIBGUESTFS_BACKEND: direct
 


### PR DESCRIPTION
virt-customize will create /etc/machine-id when customize the image used to provision the overcloud nodes. Make sure to use --truncate /etc/machine-id to clean /etc/machine-id so that a new machine-id gets created during provisioning