### PR TITLE
Allow pool_ids or pool regex to be used for rhsm

### DIFF
--- a/ansible/host_prep.yaml
+++ b/ansible/host_prep.yaml
@@ -146,7 +146,8 @@
         force_register: yes
         activationkey: "{{ rhel_subscription_activation_key }}"
         org_id: "{{ rhel_subscription_org_id }}"
-        pool: "{{ rhel_subscription_pool|default('^OpenShift Employee Subscription$') }}"
+        pool: "{{ rhel_subscription_pool|default(omit) }}"
+        pool_ids: "{{ rhel_subscription_pool_ids|default(omit) }}"
         server_hostname: "{{ rhel_subscription_server_hostname|default(omit) }}"
       when: manual_rhel_subscription is undefined
 


### PR DESCRIPTION
Allow either an explicit pool_id list or the existing pool regex to be used for subscription management.
Regex was not hitting the correct pools for me using the staging subscription server.