### PR TITLE
Use passed_phase2 for 17.0 RHEL9 jobs

### DIFF
--- a/ansible/vars/17.0.yaml
+++ b/ansible/vars/17.0.yaml
@@ -1,6 +1,7 @@
 ---
 csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
+osp_release_auto_compose: passed_phase2
 
 osp_release_defaults:
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2

--- a/ansible/vars/17.0_external_ceph.yaml
+++ b/ansible/vars/17.0_external_ceph.yaml
@@ -1,6 +1,7 @@
 ---
 csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
+osp_release_auto_compose: passed_phase2
 
 osp_release_defaults:
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2

--- a/ansible/vars/17.0_fencing.yaml
+++ b/ansible/vars/17.0_fencing.yaml
@@ -2,6 +2,7 @@
 enable_fencing: true
 csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
+osp_release_auto_compose: passed_phase2
 
 osp_release_defaults:
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2

--- a/ansible/vars/17.0_hci.yaml
+++ b/ansible/vars/17.0_hci.yaml
@@ -1,6 +1,7 @@
 ---
 csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
+osp_release_auto_compose: passed_phase2
 osp_release_defaults:
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2
   bmset:

--- a/ansible/vars/17.0_hci_subnet.yaml
+++ b/ansible/vars/17.0_hci_subnet.yaml
@@ -1,6 +1,7 @@
 ---
 csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
+osp_release_auto_compose: passed_phase2
 
 openstackclient_networks:
   - ctlplane

--- a/ansible/vars/17.0_ipv6.yaml
+++ b/ansible/vars/17.0_ipv6.yaml
@@ -1,6 +1,7 @@
 ---
 csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
+osp_release_auto_compose: passed_phase2
 
 osp_release_defaults:
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2

--- a/ansible/vars/17.0_ipv6_subnet.yaml
+++ b/ansible/vars/17.0_ipv6_subnet.yaml
@@ -1,6 +1,7 @@
 ---
 csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
+osp_release_auto_compose: passed_phase2
 
 osp_release_defaults:
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.0/20221216.0/images/rhel-guest-image-9.0-20221216.0.x86_64.qcow2

--- a/ansible/vars/17.0_subnet.yaml
+++ b/ansible/vars/17.0_subnet.yaml
@@ -1,6 +1,7 @@
 ---
 csv_version: latest-17.0
 osp_release_auto_version: 17.0-RHEL-9
+osp_release_auto_compose: passed_phase2
 
 openstackclient_networks:
   - ctlplane


### PR DESCRIPTION
rhos-release is installing cephadm 5.3 so we need to use 5.3 ceph containers. The latest_cdn ceph container tag is 5.2.
(https://bugzilla.redhat.com/show_bug.cgi?id=2160392)