### PR TITLE
Update sushy-tools and crucible to latest versions

### DIFF
--- a/ansible/host_prep.yaml
+++ b/ansible/host_prep.yaml
@@ -191,6 +191,10 @@
           # required to customize the guest-image to remove net.ifnames=0 kernel param
           - libguestfs-tools-c
 
+          # required to run recent sushy-tools
+          - python39
+          - python3-virtualenv
+
     - name: Enable helpful services
       service: name={{ item }} enabled=yes state=started
       with_items:

--- a/ansible/host_prep.yaml
+++ b/ansible/host_prep.yaml
@@ -193,6 +193,7 @@
 
           # required to run recent sushy-tools
           - python39
+          - python39-devel
           - python3-virtualenv
 
     - name: Enable helpful services

--- a/ansible/ocp_ai_destroy.yaml
+++ b/ansible/ocp_ai_destroy.yaml
@@ -77,6 +77,10 @@
     systemd:
       daemon_reload: yes
 
+  - name: Remove sushy-tools
+    file:
+      path: /opt/sushy-tools
+      state: absent
 
   ### HTTP STORE
 

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -612,7 +612,7 @@
         repo: "{{ ocp_ai_ansible_repo | default('https://github.com/redhat-partner-solutions/crucible.git', true) }}"
         dest: "{{ base_path }}/crucible"
         force: true
-        version: "{{ ocp_ai_ansible_branch | default('380937382a9929bc3af76724e4a9186cf1d61f50', true) }}"
+        version: "{{ ocp_ai_ansible_branch | default('863559ed9fdf61b650633922f4c29694b604ff09', true) }}"
 
     - name: Get BMC-network-connected interface's IP for baremetal deployments
       when: ocp_cluster_has_bm|bool
@@ -723,21 +723,6 @@
           path: "{{ base_path }}/crucible/roles/get_image_hash/defaults/main.yml"
           regexp: 'version:\s"{{ ocp_version | replace(".", "") }}\.\d+.+'
           replace: 'version: "{{ rhcos_image_version if rhcos_image_version != "" else rhcos_image_version_alt }}"'
-
-    - name: Force linear execution of boot_iso role when KVM nodes present
-      when: ocp_num_masters > 0 or ocp_num_workers > 0
-      block:
-      - name: Force linear execution
-        replace:
-          path: "{{ base_path }}/crucible/playbooks/boot_iso.yml"
-          regexp: 'strategy:\s.+'
-          replace: 'strategy: linear'
-
-      - name: Force linear execution, part 2
-        replace:
-          path: "{{ base_path }}/crucible/playbooks/boot_iso.yml"
-          regexp: 'serial:\s.+'
-          replace: 'serial: 1'
 
     - name: Remove NTP validation due to prevelance of random false-negatives
       replace:

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -556,23 +556,18 @@
     become: true
     become_user: root
     block:
-    # latest 4.0.1 fails with: ModuleNotFoundError: No module named 'setuptools_rust'
-    - name: Install bcrypt < 4.0.0
-      pip:
-        name: ['bcrypt']
-        version: "<4.0.0"
-        executable: /usr/bin/pip-3
-
-    - name: Install sushy-tools via pip3
-      pip:
-        name: ['sushy-tools', 'libvirt-python']
-        executable: /usr/bin/pip-3
-
     - name: Create sushy-tools conf directory
       file:
         path: /opt/sushy-tools
         state: directory
         mode: '0755'
+
+    - name: Install sushy-tools in virtualenv
+      pip:
+        name: ['sushy-tools!=0.21.1', 'libvirt-python']
+        virtualenv: /opt/sushy-tools/venv
+        virtualenv_python: python3.9
+        state: latest
 
     - name: Create sushy-tools conf
       template:

--- a/ansible/templates/ai/crucible/inventory.ospd.yml.j2
+++ b/ansible/templates/ai/crucible/inventory.ospd.yml.j2
@@ -155,7 +155,7 @@ all:
     kubeconfig_dest_filename: "{{ ocp_cluster_name }}-kubeconfig"
 
     # Prevent sushy-tools from being overwhelmed
-    use_boot_iso_strategy_free: false
+    #use_boot_iso_strategy_free: false
 
     ############################
     #    LOGIC: DO NOT TOUCH   #

--- a/ansible/templates/ai/crucible/inventory.ospd.yml.j2
+++ b/ansible/templates/ai/crucible/inventory.ospd.yml.j2
@@ -134,20 +134,20 @@ all:
     # Extra manifests to apply against the cluster during install
     manifest_templates_for_mode:
       none:
-        - 50-worker-nm-fix-ipv6.yml
-        - 50-worker-remove-ipi-leftovers.yml
-        # - 02-fix-ingress-config.yml     # Applying this fix breaks the ingress controller on SNO.
-        # - 01-master-node-scheduler.yml  # The master node on SNO is automatically marked as schedulable.
+        - template: 50-worker-nm-fix-ipv6.yml.j2
+        - template: 50-worker-remove-ipi-leftovers.yml.j2
+        # - template: 02-fix-ingress-config.yml.j2     # Applying this fix breaks the ingress controller on SNO.
+        # - template: 01-master-node-scheduler.yml.j2  # The master node on SNO is automatically marked as schedulable.
       full:
 {% for ocp_node_role in ocp_node_roles %}
-        - 50-{{ ocp_node_role }}-RH-Root-CA.yml
+        - template: 50-{{ ocp_node_role }}-RH-Root-CA.yml.j2
 {% endfor %}
-        - 50-worker-nm-fix-ipv6.yml
-        - 50-worker-remove-ipi-leftovers.yml
-        - 02-fix-ingress-config.yml
+        - template: 50-worker-nm-fix-ipv6.yml.j2
+        - template: 50-worker-remove-ipi-leftovers.yml.j2
+        - template: 02-fix-ingress-config.yml.j2
 {# Needed for 4.12 until the fix for https://issues.redhat.com/browse/OCPBUGS-1482 appears in that version #}
 {% if ocp_version != '4.12' %}
-        - 01-master-node-scheduler.yml
+        - template: 01-master-node-scheduler.yml.j2
 {% endif %}
 
     # The retrieved cluster kubeconfig will be placed on the bastion host at the following location

--- a/ansible/templates/ai/sushy-tools/sushy-tools.service.j2
+++ b/ansible/templates/ai/sushy-tools/sushy-tools.service.j2
@@ -7,7 +7,7 @@ Type=simple
 TimeoutStartSec=5m
 #User=<your-user>
 WorkingDirectory=/opt/sushy-tools
-ExecStart=/usr/local/bin/sushy-emulator --config /opt/sushy-tools/sushy-emulator.conf
+ExecStart=/opt/sushy-tools/venv/bin/sushy-emulator --config /opt/sushy-tools/sushy-emulator.conf
 Restart=always
 
 [Install]

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -3,7 +3,7 @@
 ocp_ai_discovery_iso_server: 192.168.111.1
 
 # ocp_ai_ansible_repo: defaults to "https://github.com/redhat-partner-solutions/crucible.git"
-# ocp_ai_ansible_branch: defaults to "380937382a9929bc3af76724e4a9186cf1d61f50"
+# ocp_ai_ansible_branch: defaults to "863559ed9fdf61b650633922f4c29694b604ff09"
 
 ocp_ai_bm_bridge_master_mac_prefix: 3c:fd:fe:78:ab:0
 ocp_ai_bm_bridge_worker_mac_prefix: 3c:fd:fe:78:ab:1


### PR DESCRIPTION
sushy-tools 0.20.0 fixes a caching issue which could result in requested
actions not occurring.

I expect this is the root cause of OCP installs failing intermittently while
waiting for a node to reboot.

0.20.0 and later require at least python 3.8 so jump to 3.9
Also run this in a virtualenv.

0.21.1 is broken so skip this version. I've landed a fix so should be in the next tag.

Latest commit on crucible repo is working with a minor change to the inventory. Now that the sushy-tools caching issue is fixed we can drop the workarounds.