### PR TITLE
Prerequisite fixes for DCN support patches

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -134,12 +134,12 @@ git: hosts local-deps local-defaults.yaml
 	git.yaml
 
 openstack:
+	$(MAKE) patch_csv
 	$(MAKE) datavolume
 	$(MAKE) networks
 	$(MAKE) git
 	$(MAKE) ctlplane
 	$(MAKE) computes
-	$(MAKE) patch_csv
 	$(MAKE) osp_deploy
 	$(MAKE) must_gather
 

--- a/ansible/config_generator.yaml
+++ b/ansible/config_generator.yaml
@@ -36,24 +36,35 @@
     with_items:
     - "openstackconfiggenerator.yaml"
 
+  - name: Check if config generator exists
+    environment: &oc_env
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
+    ignore_errors: true
+    command: oc get osconfiggenerator -n openstack {{ config_generator_name|default('default') }} -o name
+    register: osconfiggen_check_exists
+
+  - set_fact:
+      osconfiggen_exists: "{{ osconfiggen_check_exists.rc == 0 }}"
+
   - name: Start config generator
     shell: |
       set -e
       oc apply -n openstack -f "{{ config_generator_yaml_dir }}/openstackconfiggenerator.yaml"
-    environment: &oc_env
-      PATH: "{{ oc_env_path }}"
-      KUBECONFIG: "{{ kubeconfig }}"
+    environment:
+      <<: *oc_env
+    when: osconfiggen_exists|bool == false
 
   - name: Refresh config generator image
     shell: |
-      set -e
-      oc get -n openstack osconfiggenerator {{ config_generator_name|default('default') }} -o json \
-        | jq 'del( .spec.imageURL )' \
-        | oc replace -f -
+      oc patch osconfiggenerator -n openstack {{ config_generator_name|default('default') }} --type=json -p="[
+        {'op': 'remove', 'path': '/spec/imageURL'}
+      ]"
     environment:
       <<: *oc_env
     when:
       - config_generator_update_image|default(False)
+      - osconfiggen_exists|bool
 
   - name: wait for config generator to finish
     shell: |

--- a/ansible/datavolume.yaml
+++ b/ansible/datavolume.yaml
@@ -37,7 +37,7 @@
       - name: Download RHEL/CentOS guest image {{ osp.base_image_url }}
         get_url:
           url: "{{ osp.base_image_url }}"
-          dest: "{{ osp_base_image_url_path }}"
+          dest: "{{ osp_base_image_url_path }}.tmp"
           owner: ocp
           group: ocp
           mode: '0644'
@@ -77,9 +77,12 @@
             rm -f /etc/sysconfig/network-scripts/ifcfg-ens* /etc/sysconfig/network-scripts/ifcfg-eth*
 
       - name: Run virt-customize
-        command: virt-customize -a "{{ osp_base_image_url_path }}" --run "{{ osp_base_image_url_path }}_customize.sh" --truncate /etc/machine-id
+        command: virt-customize -a "{{ osp_base_image_url_path }}.tmp" --run "{{ osp_base_image_url_path }}_customize.sh" --truncate /etc/machine-id
         environment:
           LIBGUESTFS_BACKEND: direct
+
+      - name: Rename guest image to final path
+        command: mv "{{ osp_base_image_url_path }}.tmp" "{{ osp_base_image_url_path }}"
 
   - name: create datavolume for vmset roles
     include_tasks: datavolume_tasks.yaml

--- a/ansible/extrafeature_tarball_config.yaml
+++ b/ansible/extrafeature_tarball_config.yaml
@@ -7,15 +7,13 @@
 - name: copy feature files if directory exists
   when: p.stat.exists
   block:
-  - name: Find template files in feature dir
+  - name: Find files in feature dir
     delegate_to: localhost
     find:
       paths: "{{ feature_dir }}"
-      patterns: "^.*\\.yaml"
-      use_regex: yes
     register: f
   - name: copy feature {{ feature }} files to custom tripleo tarball dir
-    template:
+    copy:
       src: "{{ item.path }}"
       dest: "{{ ooo_tarball_dir }}/{{ item.path | basename }}"
       mode: '0644'

--- a/ansible/install_computes.yaml
+++ b/ansible/install_computes.yaml
@@ -99,21 +99,13 @@
       dest: "{{ compute_yaml_dir }}/openstackprovisionserver.yaml"
       mode: '0644'
 
-  - name: does the provisionserver already exist
-    shell: >
-      oc get -n {{ namespace }} osprovserver openstack -o json --ignore-not-found
-    environment: &oc_env
-      PATH: "{{ oc_env_path }}"
-      KUBECONFIG: "{{ kubeconfig }}"
-    register: provisionserver_switch
-
   - name: Start provisionserver
     shell: |
       set -e
       oc apply -n {{ namespace }} -f "{{ compute_yaml_dir }}/openstackprovisionserver.yaml"
-    environment:
-      <<: *oc_env
-    when: provisionserver_switch.stdout | length == 0
+    environment: &oc_env
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
 
   - name: Start all baremetalsets
     shell: |

--- a/ansible/osp_custom_config.yaml
+++ b/ansible/osp_custom_config.yaml
@@ -50,6 +50,14 @@
     - "templates/osp/tripleo_heat_envs/{{ osp.release }}/*.j2"
 
   # enable osp extra features parameters
+
+  - include_tasks: extrafeature_heat_env.yaml
+    vars:
+      feature_dir: "{{ playbook_dir }}/templates/osp/tripleo_heat_envs/features/common/{{ feature }}"
+    loop: "{{ osp.extrafeatures }}"
+    loop_control:
+      loop_var: feature
+
   - include_tasks: extrafeature_heat_env.yaml
     vars:
       feature_dir: "{{ playbook_dir }}/templates/osp/tripleo_heat_envs/features/{{ osp.release }}/{{ feature }}"
@@ -71,6 +79,14 @@
       mode: '0644'
 
   # enable osp tarball extra features
+
+  - include_tasks: extrafeature_tarball_config.yaml
+    vars:
+      feature_dir: "{{ playbook_dir }}/files/osp/features/common/{{ feature }}"
+    loop: "{{ osp.extrafeatures }}"
+    loop_control:
+      loop_var: feature
+
   - include_tasks: extrafeature_tarball_config.yaml
     vars:
       feature_dir: "{{ playbook_dir }}/files/osp/features/{{ osp.release }}/{{ feature }}"

--- a/ansible/patch_csv.yaml
+++ b/ansible/patch_csv.yaml
@@ -9,6 +9,10 @@
     set_fact:
       osp: "{{ osp_defaults | combine((osp_release_defaults | default({})), recursive=True) | combine((osp_local | default({})), recursive=True) }}"
 
+  # FIXME: need to delete/recreate or use patch for existing objects.
+  # In spite of what oc replace --help says, it's not safe to run oc get -o yaml, modify yaml, and then oc replace.
+  # This can cause "metadata.resourceVersion: Invalid value: 0x0: must be specified for an update" as it tries to
+  # apply the kubectl.kubernetes.io/last-applied-configuration annotation.
   - name: Update CSV
     environment: &oc_env
       PATH: "{{ oc_env_path }}"
@@ -68,18 +72,20 @@
     environment:
       <<: *oc_env
     shell: |
-      oc get openstackclient -n openstack openstackclient -o json \
-        | jq 'del( .spec.imageURL )' \
-        | oc replace -f -
+      oc patch openstackclient -n openstack openstackclient --type=json -p="[
+        {'op': 'remove', 'path': '/spec/imageURL'}
+      ]"
     when: osclient_exists|bool
 
   - name: Update provisionserver CR
     environment:
       <<: *oc_env
     shell: |
-      oc get openstackprovisionserver -n openstack openstack -o json \
-          | jq 'del( .spec.agentImageUrl, .spec.apacheImageUrl, .spec.downloaderImageUrl)' \
-          | oc replace -f -
+      oc patch openstackprovisionserver -n openstack openstack --type=json -p="[
+            {'op': 'remove', 'path': '/spec/agentImageUrl'},
+            {'op': 'remove', 'path': '/spec/apacheImageUrl'},
+            {'op': 'remove', 'path': '/spec/downloaderImageUrl'}
+          ]"
     when: osprovsrv_exists|bool
 
   - name: Wait for openstackclient to reconcile


### PR DESCRIPTION
Fixes various issue found while developing DCN support:

The virt-customize task was not atomic, and can result in obscure issues when ansible is interrupted and re-run.
The extrafeatures task were not including the "common" dir, also are not templates when they are in `files/` so should be copied verbatim instead of jinja2 rending.
Switch from `oc replace` (unsafe) to `oc patch`.
Ensures the provision server yaml is also up to date when it already exists as the target version (and therefor the provisioning image) may have changed.