### PR TITLE
Fix OCP AI version selection

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -612,27 +612,13 @@
         repo: "{{ ocp_ai_ansible_repo | default('https://github.com/redhat-partner-solutions/crucible.git', true) }}"
         dest: "{{ base_path }}/crucible"
         force: true
-        version: "{{ ocp_ai_ansible_branch | default('863559ed9fdf61b650633922f4c29694b604ff09', true) }}"
+        version: "{{ ocp_ai_ansible_branch | default('3fc557583beba37fa3d084fae7c21410530f5cc6', true) }}"
 
     - name: Get BMC-network-connected interface's IP for baremetal deployments
       when: ocp_cluster_has_bm|bool
       shell: |
         /usr/bin/nmcli -g ip4.address device show {{ ocp_bmc_interface }} | cut -d '/' -f 1
       register: ocp_bmc_interface_ip
-
-    - name: Configure inventory variables
-      template:
-        src: ai/crucible/inventory.ospd.yml.j2
-        dest: "{{ base_path }}/crucible/inventory.ospd.yml"
-        mode: '0664'
-      vars:
-        ssh_pub_key: "{{ ssh_root_pub_key.stdout }}"
-
-    - name: Configure inventory vault variables
-      template:
-        src: ai/crucible/inventory.vault.ospd.yml.j2
-        dest: "{{ base_path }}/crucible/inventory.vault.ospd.yml"
-        mode: '0664'
 
     - name: Add Crucible template to inject Red Hat CA
       template:
@@ -657,47 +643,6 @@
         state: absent
         regexp: '^.*"schedulable_masters"'
 
-    # FIXME: Needed until upstream Crucible supports 4.11 and 4.12
-    - name: Inject Crucible support for OCP 4.11/4.12 provisioning images
-      when: ocp_version in ["4.11", "4.12"]
-      blockinfile:
-        path: "{{ base_path }}/crucible/roles/get_image_hash/defaults/main.yml"
-        insertafter: "os_images:"
-        block: |2
-            - openshift_version: '4.11'
-              cpu_architecture: x86_64
-              url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.11/4.11.9/rhcos-live.x86_64.iso
-              rootfs_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.11/4.11.9/rhcos-live-rootfs.x86_64.img
-              version: 411.86.202210072320-0
-            - openshift_version: '4.12'
-              cpu_architecture: x86_64
-              url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.12/4.12.0/rhcos-live.x86_64.iso
-              rootfs_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.12/4.12.0/rhcos-live-rootfs.x86_64.img
-              version: 412.86.202301061548-0
-
-    # FIXME: Needed until upstream Crucible supports 4.11 and 4.12
-    - name: Inject Crucible support for OCP 4.11/4.12 release images
-      when: ocp_version in ["4.11", "4.12"]
-      blockinfile:
-        path: "{{ base_path }}/crucible/roles/get_image_hash/defaults/main.yml"
-        insertafter: "release_images:"
-        marker: "#*#*#*" # workaround for https://github.com/ansible/ansible/issues/14363
-        block: |2
-            - openshift_version: '4.11'
-              cpu_architecture: x86_64
-              url: quay.io/openshift-release-dev/ocp-release:4.11.9-x86_64
-              version: 4.11.9
-            - openshift_version: '4.12'
-              cpu_architecture: x86_64
-              url: quay.io/openshift-release-dev/ocp-release:4.12.0-x86_64
-              version: 4.12.0
-
-    - name: Override/inject desired OCP version (display_name/release_version)
-      replace:
-        path: "{{ base_path }}/crucible/roles/get_image_hash/defaults/main.yml"
-        regexp: '{{ ocp_version | replace(".", "\.") }}\.\d+'
-        replace: '{{ ocp_version }}.{{ ocp_minor_version }}'
-
     - name: Inject specific RHCOS image version
       block:
       - name: Get RHCOS image version raw data for {{ ocp_version }}.{{ ocp_minor_version }}
@@ -711,24 +656,32 @@
       - name: Get RHCOS image version for {{ ocp_version }}.{{ ocp_minor_version }}
         set_fact:
           rhcos_image_version: "{{ rhcos_image_version_raw_data.content | regex_search('second_release=([^&]+)', '\\1') | default ([''], true) | first }}"
-          rhcos_image_version_alt: "{{ rhcos_image_version_raw_data.content | regex_search('\\/\\?release=([^&]+)', '\\1') | default ([''], true) | first }}"
+          rhcos_image_version_alt: "{{ rhcos_image_version_raw_data.content | regex_search('&amp;release=([^&]+)', '\\1') | default ([''], true) | first }}"
 
       - name: Fail when an RHCOS version cannot be determined
         fail:
           msg: "Unable to determine RHCOS version for OCP version {{ ocp_version }}.{{ ocp_minor_version }}"
         when: rhcos_image_version == "" and rhcos_image_version_alt == ""
 
-      - name: Inject RHCOS image version
-        replace:
-          path: "{{ base_path }}/crucible/roles/get_image_hash/defaults/main.yml"
-          regexp: 'version:\s"{{ ocp_version | replace(".", "") }}\.\d+.+'
-          replace: 'version: "{{ rhcos_image_version if rhcos_image_version != "" else rhcos_image_version_alt }}"'
-
     - name: Remove NTP validation due to prevelance of random false-negatives
       replace:
         path: "{{ base_path }}/crucible/roles/validate_inventory/tasks/network.yml"
         regexp: '\(setup_ntp_service\s\|\sdefault\(True\)\)\s!=\sTrue'
         replace: 'false'
+
+    - name: Configure inventory variables
+      template:
+        src: ai/crucible/inventory.ospd.yml.j2
+        dest: "{{ base_path }}/crucible/inventory.ospd.yml"
+        mode: '0664'
+      vars:
+        ssh_pub_key: "{{ ssh_root_pub_key.stdout }}"
+
+    - name: Configure inventory vault variables
+      template:
+        src: ai/crucible/inventory.vault.ospd.yml.j2
+        dest: "{{ base_path }}/crucible/inventory.vault.ospd.yml"
+        mode: '0664'
 
     - name: Create assisted installer service bash script
       template:

--- a/ansible/templates/ai/crucible/inventory.ospd.yml.j2
+++ b/ansible/templates/ai/crucible/inventory.ospd.yml.j2
@@ -63,6 +63,19 @@ all:
         disk_size_gb: {{ ocp_master_disk|default(120) }}
         installation_disk_speed_threshold_ms: 10
 
+    os_images:
+    - openshift_version: '{{ ocp_version }}'
+      cpu_architecture: x86_64
+      url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{{ ocp_version }}/latest/rhcos-live.x86_64.iso
+      rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{{ ocp_version }}/latest/rhcos-live-rootfs.x86_64.img
+      version: {{ rhcos_image_version if rhcos_image_version != "" else rhcos_image_version_alt }}
+
+    release_images:
+    - openshift_version: '{{ ocp_version }}'
+      cpu_architecture: x86_64
+      url: quay.io/openshift-release-dev/ocp-release:{{ ocp_version }}.{{ ocp_minor_version }}-x86_64
+      version: {{ ocp_version }}.{{ ocp_minor_version }}
+
     ######################################
     # Prerequisite Service Configuration #
     ######################################

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -3,7 +3,7 @@
 ocp_ai_discovery_iso_server: 192.168.111.1
 
 # ocp_ai_ansible_repo: defaults to "https://github.com/redhat-partner-solutions/crucible.git"
-# ocp_ai_ansible_branch: defaults to "863559ed9fdf61b650633922f4c29694b604ff09"
+# ocp_ai_ansible_branch: defaults to "3fc557583beba37fa3d084fae7c21410530f5cc6"
 
 ocp_ai_bm_bridge_master_mac_prefix: 3c:fd:fe:78:ab:0
 ocp_ai_bm_bridge_worker_mac_prefix: 3c:fd:fe:78:ab:1


### PR DESCRIPTION
While our OCP AI version selection was previously working for ISO and root filesystem images, it was not properly finding and injecting the associated RHCOS version.  This fixes that.  It also removes our hacks for OCP 4.11/4.12 support and uses a more native approach as provided by Crucible.  

Furthermore, for the ISO and root filesystem images, we now use the latest available for the particular OCP version selected.  This is necessary because not all minor versions of a particular OCP version have associated ISO and root filesystem images available in the public OpenShift mirror.  I have done some spot-testing with the latest images with early versions of 4.10 and 4.11 (i.e. 4.10.2 and 4.11.2), and they seemed to work just fine.