### PR TITLE
Update wallaby centos base image

### DIFF
--- a/ansible/vars/wallaby.yaml
+++ b/ansible/vars/wallaby.yaml
@@ -3,7 +3,7 @@ openstackclient_image: quay.io/tripleowallaby/openstack-tripleoclient:current-tr
 osp_release_defaults:
   release: wallaby
   container_tag: current-tripleo
-  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220919.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230307.0.x86_64.qcow2
   #TODO: which ceph images tag to use for upstream train?
   #ceph_tag: 5-12
   #ceph_image: daemon

--- a/ansible/vars/wallaby_ipv6.yaml
+++ b/ansible/vars/wallaby_ipv6.yaml
@@ -6,7 +6,7 @@ osp_release_defaults:
   #TODO: which ceph images tag to use for upstream wallaby?
   #ceph_tag: 5-12
   #ceph_image: daemon
-  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220919.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230307.0.x86_64.qcow2
   networks: ipv6
   extrafeatures:
     - ipv6

--- a/ansible/vars/wallaby_ipv6_subnet.yaml
+++ b/ansible/vars/wallaby_ipv6_subnet.yaml
@@ -16,7 +16,7 @@ ephemeral_heat:
 osp_release_defaults:
   release: wallaby
   container_tag: current-tripleo
-  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220919.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230307.0.x86_64.qcow2
   #TODO: which ceph images tag to use for upstream train?
   #ceph_tag: 5-12
   #ceph_image: daemon

--- a/ansible/vars/wallaby_subnet.yaml
+++ b/ansible/vars/wallaby_subnet.yaml
@@ -17,7 +17,7 @@ openstackclient_networks:
 osp_release_defaults:
   release: wallaby
   container_tag: current-tripleo
-  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220919.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230307.0.x86_64.qcow2
   ceph_tag: 5-12
   networks: ipv4_subnet
   vmset:


### PR DESCRIPTION
Wallaby overcloud deployment it failing when installing openstack-selinux. Updating the CentOS base image to the version currently used in upsteam tripleo CI resolves this.