### PR TITLE
Add DMBS deployment

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -234,6 +234,26 @@ osp_cell_v2_discover_hosts: hosts local-defaults.yaml
 	-e @local-defaults.yaml \
 	osp_cell_v2_discover_hosts.yaml
 
+openstack_scenario_dmbs:
+	$(MAKE) patch_csv
+	$(MAKE) datavolume
+	$(MAKE) networks
+	$(MAKE) git
+	$(MAKE) ctlplane
+	$(MAKE) computes
+	$(MAKE) osp_deploy_dcn_central
+	$(MAKE) osp_deploy_dcn_1
+	$(MAKE) osp_redeploy_dcn_central
+	$(MAKE) osp_cell_v2_discover_hosts
+	$(MAKE) must_gather
+
+osp_redeploy_dcn_central: hosts local-defaults.yaml
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-i hosts \
+	-e @vars/${OSP_RELEASE}.yaml \
+	-e @local-defaults.yaml \
+	osp_redeploy_dcn_central.yaml
+
 .PHONY: openstack_update
 openstack_update: ## perform an overcloud minor update bu patching the csv for the new version and perform the update.
 	$(MAKE) patch_csv

--- a/ansible/osp_deploy_dcn_1.yaml
+++ b/ansible/osp_deploy_dcn_1.yaml
@@ -5,6 +5,7 @@
   vars:
     custom_config_name: dcn1
     custom_config_ceph_cluster_name: dcn1
+    custom_config_dmbs_remote_site: "{{ 'dmbs' in osp.extrafeatures }}"
     custom_config_imports:
       - deploy: central
         src: ctlplane-export.yaml
@@ -18,6 +19,7 @@
   vars:
     custom_config_name: dcn1
     config_generator_name: dcn1
+    custom_config_dmbs_remote_site: "{{ 'dmbs' in osp.extrafeatures }}"
     config_generator_roles:
       - DistributedComputeHCILeaf1
 

--- a/ansible/osp_redeploy_dcn_central.yaml
+++ b/ansible/osp_redeploy_dcn_central.yaml
@@ -1,0 +1,35 @@
+---
+
+- name: Generate redeploy custom config
+  import_playbook: osp_custom_config.yaml
+  vars:
+    custom_config_name: central
+    custom_config_action: redeploy
+    custom_config_ceph_cluster_name: central
+    custom_config_extrafeatures: ["dmbs_store_dcn1"]
+    custom_config_imports:
+      - deploy: dcn1
+        src: ceph-export.yaml
+        dest: ceph-export-dcn1.yaml
+
+- name: Config generate
+  import_playbook: config_generator.yaml
+  vars:
+    custom_config_name: central
+    config_generator_name: redeploy-central
+    config_generator_roles:
+      - Controller
+      - ComputeHCI
+
+- name: Overcloud node repo setup
+  import_playbook: osp_register_overcloud_nodes.yaml
+  vars:
+    config_generator_roles:
+      - Controller
+      - ComputeHCI
+
+- name: Overcloud redeployment
+  import_playbook: osp_deployment.yaml
+  vars:
+    config_generator_name: redeploy-central
+    deploy_name: redeploy-central

--- a/ansible/osp_tempest.yaml
+++ b/ansible/osp_tempest.yaml
@@ -109,6 +109,15 @@
       environment:
         <<: *oc_env
 
+    - name: download cirros and convert the image to raw format
+      shell: |
+        #!/bin/bash
+        curl --location --insecure --output /tmp/cirros-0.4.0-x86_64-disk.img https://github.com/cirros-dev/cirros/releases/download/0.4.0/cirros-0.4.0-x86_64-disk.img
+        qemu-img convert -f qcow2 -O raw /tmp/cirros-0.4.0-x86_64-disk.img /tmp/cirros-0.4.0-x86_64-disk.raw
+        oc cp -n openstack /tmp/cirros-0.4.0-x86_64-disk.raw tempest:/var/lib/tempest/.config/openstack/cirros-0.4.0-x86_64-disk.raw
+      environment:
+        <<: *oc_env
+
     - name: copy rendered tempest config
       shell: |
         #!/bin/bash

--- a/ansible/templates/osp/config_generator/openstackconfiggenerator.yaml.j2
+++ b/ansible/templates/osp/config_generator/openstackconfiggenerator.yaml.j2
@@ -27,6 +27,9 @@ spec:
 {%- if "dcn" in osp.extrafeatures %}
     - nova-az-config.yaml
 {%- endif %}
+{%- if custom_config_dmbs_remote_site|default(false) %}
+    - dcn-storage.yaml
+{%- endif %}
 {%- for envfile in osp_extra_env_files|default([]) %}
     - {{ envfile }}
 {%- endfor %}

--- a/ansible/templates/osp/tripleo_heat_envs/common/storage-backend.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/common/storage-backend.yaml.j2
@@ -65,6 +65,12 @@ parameter_defaults:
 {% if custom_config_ceph_cluster_name|default(False) %}
   CephClusterName: {{ custom_config_ceph_cluster_name }}
 {% endif %}
+{% if "dmbs" in osp.extrafeatures %}
+  CinderStorageAvailabilityZone: az-{{ custom_config_ceph_cluster_name|default('volume') }}
+{% if custom_config_dmbs_remote_site|default(false)  %}
+  CinderVolumeCluster: az-{{ custom_config_ceph_cluster_name }}
+{% endif %}
+{% endif %}
 {% elif "external_ceph" in osp.extrafeatures %}
   CinderEnableIscsiBackend: false
   CinderEnableRbdBackend: true

--- a/ansible/templates/osp/tripleo_heat_envs/features/common/dmbs/glance.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/features/common/dmbs/glance.yaml.j2
@@ -1,0 +1,14 @@
+parameter_defaults:
+  GlanceShowMultipleLocations: true
+  GlanceEnabledImportMethods: web-download,copy-image
+  GlanceBackend: rbd
+  GlanceStoreDescription: '{{ custom_config_ceph_cluster_name }} rbd glance store'
+  GlanceBackendID: {{ custom_config_ceph_cluster_name }}
+{% if custom_config_dmbs_remote_site|default(false)  %}
+  GlanceMultistoreConfig:
+    central:
+      GlanceBackend: rbd
+      GlanceStoreDescription: 'central rbd glance store'
+      CephClientUserName: 'openstack'
+      CephClusterName: central
+{% endif %}

--- a/ansible/templates/osp/tripleo_heat_envs/features/common/dmbs_store_dcn1/dcn1_glance_store.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/features/common/dmbs_store_dcn1/dcn1_glance_store.yaml.j2
@@ -1,0 +1,7 @@
+parameter_defaults:
+  GlanceMultistoreConfig:
+    dcn1:
+      GlanceBackend: rbd
+      GlanceStoreDescription: 'dcn1 rbd glance store'
+      CephClientUserName: 'openstack'
+      CephClusterName: dcn1

--- a/ansible/templates/tempest/tempest_script.sh.j2
+++ b/ansible/templates/tempest/tempest_script.sh.j2
@@ -21,6 +21,21 @@ if [ -z "$PUB_NETWORK_ID" ]; then
   PUB_NETWORK_ID=$(openstack --os-cloud overcloud network list -f value -c ID --name public)
 fi
 
+# DMBS scenario: Create images in all glance stores (which is not supported by openstack client)
+# Glance client on the other hand does not support clouds.yaml
+{% if "dmbs" in osp.extrafeatures %}
+  export OS_AUTH_URL=https://overcloud.osptest.test.metalkube.org:13000
+  export OS_PASSWORD=$(grep password ~/.config/openstack/clouds.yaml | awk '{print $NF}')
+  export OS_PROJECT_DOMAIN_NAME=Default
+  export OS_PROJECT_NAME=admin
+  export OS_USER_DOMAIN_NAME=Default
+  export OS_USERNAME=admin
+  glance image-create --disk-format raw --container-format bare --id 12345678-aaaa-bbbb-cccc-0123456789ab --visibility public --name cirros-0.4.0-x86_64-disk.img --file /var/lib/tempest/.config/openstack/cirros-0.4.0-x86_64-disk.raw --store central
+  glance image-import 12345678-aaaa-bbbb-cccc-0123456789ab --stores dcn1 --import-method copy-image
+  glance image-create --disk-format raw --container-format bare --id 87654321-aaaa-bbbb-cccc-0123456789ab --visibility public --name cirros-0.4.0-x86_64-disk.img_alt --file /var/lib/tempest/.config/openstack/cirros-0.4.0-x86_64-disk.raw --store central
+  glance image-import 87654321-aaaa-bbbb-cccc-0123456789ab --stores dcn1 --import-method copy-image
+{% endif %}
+
 # Create a tempest workspace, use the shared directory so that the files
 # in it are accessible from the host as well.
 mkdir -p /var/lib/tempest/tempest_workspace

--- a/ansible/vars/16.2_dcn_dmbs.yaml
+++ b/ansible/vars/16.2_dcn_dmbs.yaml
@@ -1,0 +1,78 @@
+ocp_num_workers: 2
+ocp_num_extra_workers: 5
+ocp_ai_bmc_protocol: redfish-virtualmedia+http
+
+osp_release_defaults:
+  networks: ipv4_dcn
+  vmset:
+    Controller:
+      count: 1
+      cores: 6
+      memory: 20
+      networks:
+        - ctlplane
+        - internal_api
+        - external
+        - tenant
+        - storage
+        - storage_mgmt
+      root_disk:
+        disk_size: 40
+        storage_class: host-nfs-storageclass
+        storage_access_mode: ReadWriteMany
+        storage_volume_mode: Filesystem
+  bmset:
+    Compute:
+      count: 0
+    ComputeHCI:
+      count: 2
+      ctlplane_interface: enp1s0
+      networks:
+        - ctlplane
+        - internal_api
+        - tenant
+        - storage
+        - storage_mgmt
+    DistributedComputeHCILeaf1:
+      count: 3
+      ctlplane_interface: enp1s0
+      networks:
+        - ctlplane_leaf1
+        - internal_api_leaf1
+        - storage_leaf1
+        - storage_mgmt_leaf1
+        - tenant_leaf1
+  extrafeatures:
+    - hci
+    - dcn
+    - dmbs
+
+tempest_test_dict:
+  regex: '(?!.*\[.*\bslow\b.*\])(^tempest\.(api|scenario))'
+  includelist: []
+  # per default with OVN there is no DHCPAgent, disable the tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON tests
+  excludelist:
+      - "^tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_multi_create_auto_allocate"
+      - "^tempest.api.compute.admin.test_live_migration.LiveMigrationTest.test_live_block_migration_paused"
+      - "^tempest.api.compute.admin.test_live_migration.LiveAutoBlockMigrationV225Test.test_live_block_migration_paused"
+      - "^tempest.api.compute.admin.test_live_migration.LiveMigrationRemoteConsolesV26Test.test_live_block_migration_paused"
+      - "^tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON.test_add_remove_network_from_dhcp_agent"
+      - "^tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON.test_list_networks_hosted_by_one_dhcp"
+      # The scenario/tests create an image which is not in raw format and/or not in DCN site's store which causes the test to fail
+      - "^tempest.scenario.test_minimum_basic.TestMinimumBasicScenario.test_minimum_basic_scenario"
+      - "^tempest.api.compute.admin.test_volume.AttachSCSIVolumeTestJSON.test_attach_scsi_disk_with_config_drive"
+      - "^tempest.api.volume.admin.test_volume_types.VolumeTypesTest.test_volume_crud_with_volume_type_and_extra_specs"
+      - "^tempest.api.volume.test_volume_delete_cascade.VolumesDeleteCascade.test_volume_from_snapshot_cascade_delete"
+      - "^tempest.api.volume.admin.test_volume_retype.VolumeRetypeWithoutMigrationTest.test_available_volume_retype"
+
+# disble block_migration_for_live_migration: false
+tempest_enable_feature_dict:
+  compute-feature-enabled:
+    vnc_console: true
+    live_migration: true
+    block_migration_for_live_migration: false
+    volume_backed_live_migration: true
+    console_output: true
+# Create nova/volume resources in the AZ of the DCN's site
+  compute:
+    compute_volume_common_az: az-dcn1

--- a/ansible/vars/17.1_dcn_dmbs.yaml
+++ b/ansible/vars/17.1_dcn_dmbs.yaml
@@ -1,0 +1,98 @@
+---
+csv_version: latest-17.1
+osp_release_auto_version: 17.1-RHEL-9
+osp_release_auto_compose: passed_phase1
+
+ocp_num_workers: 3
+ocp_num_extra_workers: 5
+ocp_ai_bmc_protocol: redfish-virtualmedia+http
+
+osp_release_defaults:
+  base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.2/20230414.43/images/rhel-guest-image-9.2-20230414.43.x86_64.qcow2
+  networks: ipv4_dcn
+  vmset:
+    Controller:
+      count: 3
+      cores: 6
+      memory: 20
+      networks:
+        - ctlplane
+        - internal_api
+        - external
+        - tenant
+        - storage
+        - storage_mgmt
+      root_disk:
+        disk_size: 40
+        storage_class: host-nfs-storageclass
+        storage_access_mode: ReadWriteMany
+        storage_volume_mode: Filesystem
+  bmset:
+    Compute:
+      count: 0
+    ComputeHCI:
+      count: 2
+      ctlplane_interface: enp1s0
+      networks:
+        - ctlplane
+        - internal_api
+        - tenant
+        - storage
+        - storage_mgmt
+    DistributedComputeHCILeaf1:
+      count: 3
+      ctlplane_interface: enp1s0
+      networks:
+        - ctlplane_leaf1
+        - internal_api_leaf1
+        - storage_leaf1
+        - storage_mgmt_leaf1
+        - tenant_leaf1
+  extrafeatures:
+    - hci
+    - ssh_firewall_allow_all # Required for ceph-adm
+    - BZ2170021
+    - dcn
+    - dmbs
+
+tempest_test_dict:
+  regex: '(?!.*\[.*\bslow\b.*\])(^tempest\.(api|scenario))'
+  includelist: []
+  # per default with OVN there is no DHCPAgent, disable the tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON tests
+  excludelist:
+      - "^tempest.api.compute.admin.test_auto_allocate_network.AutoAllocateNetworkTest.test_server_multi_create_auto_allocate"
+      - "^tempest.api.compute.admin.test_live_migration.LiveMigrationTest.test_live_block_migration_paused"
+      - "^tempest.api.compute.admin.test_live_migration.LiveAutoBlockMigrationV225Test.test_live_block_migration_paused"
+      - "^tempest.api.compute.admin.test_live_migration.LiveMigrationRemoteConsolesV26Test.test_live_block_migration_paused"
+      - "^tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON.test_add_remove_network_from_dhcp_agent"
+      - "^tempest.api.network.admin.test_dhcp_agent_scheduler.DHCPAgentSchedulersTestJSON.test_list_networks_hosted_by_one_dhcp"
+      # The scenario/tests create an image which is not in raw format and/or not in DCN site's store which causes the test to fail
+      - "^tempest.scenario.test_minimum_basic.TestMinimumBasicScenario.test_minimum_basic_scenario"
+      - "^tempest.scenario.test_minimum_basic.TestMinimumBasicScenario.test_minimum_basic_instance_hard_reboot_after_vol_snap_deletion"
+      - "^tempest.api.compute.admin.test_volume.AttachSCSIVolumeTestJSON.test_attach_scsi_disk_with_config_drive"
+      - "^tempest.api.volume.admin.test_volume_types.VolumeTypesTest.test_volume_crud_with_volume_type_and_extra_specs"
+      - "^tempest.api.volume.test_volume_delete_cascade.VolumesDeleteCascade.test_volume_from_snapshot_cascade_delete"
+      - "^tempest.api.volume.admin.test_volume_retype.VolumeRetypeWithoutMigrationTest.test_available_volume_retype"
+
+# disble block_migration_for_live_migration: false
+tempest_enable_feature_dict:
+  compute-feature-enabled:
+    vnc_console: true
+    live_migration: true
+    block_migration_for_live_migration: false
+    volume_backed_live_migration: true
+    console_output: true
+# Create nova/volume resources in the AZ of the DCN's site
+  compute:
+    compute_volume_common_az: az-dcn1
+  image:
+    image_path: https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
+
+# (mschuppert) can be deleted when released
+openstackclient_image: "rhos-qe-mirror-rdu2.usersys.redhat.com:5002/rh-osbs/rhosp17-openstack-tripleoclient:{{ osp_release_auto.tag }}"
+
+ephemeral_heat:
+  heat_api_image: "rhos-qe-mirror-rdu2.usersys.redhat.com:5002/rh-osbs/rhosp17-openstack-heat-api:{{ osp_release_auto.tag }}"
+  heat_engine_image: "rhos-qe-mirror-rdu2.usersys.redhat.com:5002/rh-osbs/rhosp17-openstack-heat-engine:{{ osp_release_auto.tag }}"
+  mariadb_image: "rhos-qe-mirror-rdu2.usersys.redhat.com:5002/rh-osbs/rhosp17-openstack-mariadb:{{ osp_release_auto.tag }}"
+  rabbit_image: "rhos-qe-mirror-rdu2.usersys.redhat.com:5002/rh-osbs/rhosp17-openstack-rabbitmq:{{ osp_release_auto.tag }}"


### PR DESCRIPTION
The PR adds Cinder in A/A on the Edge site and Glance multistore. The central site redeploy with updated configuration for ceph cluster on the site and glance multistore is required. It's needed to create an raw image in all the glance stores to test such deployment with tempest. Unfortunately openstack client does not support that and tempest image does not include qemu-img to covert the image to raw format directly on the tempest pod.
