### PR TITLE
Update centos-stream 8 and 9 images

### DIFF
--- a/ansible/vars/train.yaml
+++ b/ansible/vars/train.yaml
@@ -3,7 +3,7 @@ openstackclient_image: quay.io/tripleotraincentos8/centos-binary-tripleoclient:c
 osp_release_defaults:
   release: train
   container_tag: current-tripleo
-  base_image_url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20230404.0.x86_64.qcow2
   #TODO: which ceph images tag to use for upstream train?
   #ceph_tag: 5-12
   #ceph_image: daemon

--- a/ansible/vars/train_ipv6.yaml
+++ b/ansible/vars/train_ipv6.yaml
@@ -6,7 +6,7 @@ osp_release_defaults:
   #TODO: which ceph images tag to use for upstream train?
   #ceph_tag: 5-12
   #ceph_image: daemon
-  base_image_url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20230404.0.x86_64.qcow2
   networks: ipv6
   extrafeatures:
     - ipv6

--- a/ansible/vars/train_ipv6_subnet.yaml
+++ b/ansible/vars/train_ipv6_subnet.yaml
@@ -18,7 +18,7 @@ osp_release_defaults:
   #TODO: which ceph images tag to use for upstream train?
   #ceph_tag: 5-12
   #ceph_image: daemon
-  base_image_url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20230404.0.x86_64.qcow2
   networks: ipv6_subnet
   vmset:
     Controller:

--- a/ansible/vars/train_subnet.yaml
+++ b/ansible/vars/train_subnet.yaml
@@ -15,7 +15,7 @@ ephemeral_heat:
 osp_release_defaults:
   release: train
   container_tag: current-tripleo
-  base_image_url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20230404.0.x86_64.qcow2
   #TODO: which ceph images tag to use for upstream train?
   #ceph_tag: 5-12
   #ceph_image: daemon

--- a/ansible/vars/wallaby.yaml
+++ b/ansible/vars/wallaby.yaml
@@ -3,7 +3,7 @@ openstackclient_image: quay.io/tripleowallaby/openstack-tripleoclient:current-tr
 osp_release_defaults:
   release: wallaby
   container_tag: current-tripleo
-  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230307.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230410.0.x86_64.qcow2
   #TODO: which ceph images tag to use for upstream train?
   #ceph_tag: 5-12
   #ceph_image: daemon

--- a/ansible/vars/wallaby_ipv6.yaml
+++ b/ansible/vars/wallaby_ipv6.yaml
@@ -6,7 +6,7 @@ osp_release_defaults:
   #TODO: which ceph images tag to use for upstream wallaby?
   #ceph_tag: 5-12
   #ceph_image: daemon
-  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230307.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230410.0.x86_64.qcow2
   networks: ipv6
   extrafeatures:
     - ipv6

--- a/ansible/vars/wallaby_ipv6_subnet.yaml
+++ b/ansible/vars/wallaby_ipv6_subnet.yaml
@@ -16,7 +16,7 @@ ephemeral_heat:
 osp_release_defaults:
   release: wallaby
   container_tag: current-tripleo
-  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230307.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230410.0.x86_64.qcow2
   #TODO: which ceph images tag to use for upstream train?
   #ceph_tag: 5-12
   #ceph_image: daemon

--- a/ansible/vars/wallaby_subnet.yaml
+++ b/ansible/vars/wallaby_subnet.yaml
@@ -17,7 +17,7 @@ openstackclient_networks:
 osp_release_defaults:
   release: wallaby
   container_tag: current-tripleo
-  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230307.0.x86_64.qcow2
+  base_image_url: https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230410.0.x86_64.qcow2
   ceph_tag: 5-12
   networks: ipv4_subnet
   vmset:


### PR DESCRIPTION
    Image download fails right now with

```
    TASK [Download RHEL/CentOS guest image https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230307.0.x86_64.qcow2] ***
    Friday 14 April 2023  14:31:20 +0000 (0:00:00.309)       0:00:07.597 **********
    [0;31mfatal: [localhost]: FAILED! => {[0m
    [0;31m    "changed": false,[0m
    [0;31m    "dest": "/opt/http_store/data/images/CentOS-Stream-GenericCloud-9-20230307.0.x86_64.qcow2.tmp",[0m
    [0;31m    "elapsed": 0,[0m
    [0;31m    "response": "HTTP Error 404: Not Found",[0m
    [0;31m    "status_code": 404,[0m
    [0;31m    "url": "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230307.0.x86_64.qcow2"[0m
    [0;31m}[0m
    [0;31m[0m
    [0;31mMSG:[0m
    [0;31m[0m
    [0;31mRequest failed[0m
```
