### PR TITLE
install RH CA on OSP nodes

### DIFF
--- a/ansible/templates/osp/rhsm.yaml.j2
+++ b/ansible/templates/osp/rhsm.yaml.j2
@@ -3,6 +3,13 @@
   become: true
 
   tasks:
+  - name: Install RH-IT-Root-CA.crt certificate
+    ansible.builtin.shell: |
+      cd /etc/pki/ca-trust/source/anchors
+      curl -O https://password.corp.redhat.com/RH-IT-Root-CA.crt
+      update-ca-trust extract
+    args:
+      creates: "/etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt"
 {% if osp_registry_method == "rhsm" %}
   - name: Red Hat Subscription Management configuration
     import_role:


### PR DESCRIPTION
- install_RH_CA_on_OSP_nodes

issue : 
```bash
TASK
[Pre-install fencing agents which support fence_kubevirt] *****************\nf$
tal: [172.22.0.102]: FAILED! => {\"changed\": false, \"msg\": \"Failed to down$
oad metadata for repo 'rhelosp-ceph-5-tools': Cannot download repomd.xml: Cann$
t download repodata/repomd.xml: All mirrors were tried\", \"rc\": 1, \"results$
": []}\nfatal: [172.22.0.104]: FAILED! => {\"changed\": false, \"msg\": \"Fail$
d to download metadata for repo 'rhelosp-ceph-5-tools': Cannot download repomd$
xml: Cannot download repodata/repomd.xml: All mirrors were tried\", \"rc\": 1,
\"results\": []}\nfatal: [172.22.0.103]: FAILED! => {\"changed\": false, \"msg$
": \"Failed to download metadata for repo 'rhelosp-ceph-5-tools': Cannot downl$
ad repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried\", $
"rc\": 1, \"results\": []}\n\nPLAY RECAP *************************************$
*******************************\n172.22.0.102               : ok=1    changed=$
```
