### PR TITLE
Support enabling additional features for each custom deployment

### DIFF
--- a/ansible/osp_custom_config.yaml
+++ b/ansible/osp_custom_config.yaml
@@ -54,14 +54,14 @@
   - include_tasks: extrafeature_heat_env.yaml
     vars:
       feature_dir: "{{ playbook_dir }}/templates/osp/tripleo_heat_envs/features/common/{{ feature }}"
-    loop: "{{ osp.extrafeatures }}"
+    loop: "{{ osp.extrafeatures + custom_config_extrafeatures|default([]) }}"
     loop_control:
       loop_var: feature
 
   - include_tasks: extrafeature_heat_env.yaml
     vars:
       feature_dir: "{{ playbook_dir }}/templates/osp/tripleo_heat_envs/features/{{ osp.release }}/{{ feature }}"
-    loop: "{{ osp.extrafeatures }}"
+    loop: "{{ osp.extrafeatures + custom_config_extrafeatures|default([]) }}"
     loop_control:
       loop_var: feature
 

--- a/ansible/osp_deploy_dcn_1.yaml
+++ b/ansible/osp_deploy_dcn_1.yaml
@@ -4,7 +4,7 @@
   import_playbook: osp_custom_config.yaml
   vars:
     custom_config_name: dcn1
-    config_custom_ceph_cluster_name: dcn1
+    custom_config_ceph_cluster_name: dcn1
     custom_config_imports:
       - deploy: central
         src: ctlplane-export.yaml

--- a/ansible/osp_deploy_dcn_central.yaml
+++ b/ansible/osp_deploy_dcn_central.yaml
@@ -4,7 +4,7 @@
   import_playbook: osp_custom_config.yaml
   vars:
     custom_config_name: central
-    config_custom_ceph_cluster_name: central
+    custom_config_ceph_cluster_name: central
 
 - name: Config generate
   import_playbook: config_generator.yaml

--- a/ansible/templates/osp/tripleo_heat_envs/common/storage-backend.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/common/storage-backend.yaml.j2
@@ -62,8 +62,8 @@ parameter_defaults:
   GlanceRbdPoolName: "images"
   CephPoolDefaultPgNum: 32
   CephPoolDefaultSize: 2
-{% if config_custom_ceph_cluster_name|default(False) %}
-  CephClusterName: {{ config_custom_ceph_cluster_name }}
+{% if custom_config_ceph_cluster_name|default(False) %}
+  CephClusterName: {{ custom_config_ceph_cluster_name }}
 {% endif %}
 {% elif "external_ceph" in osp.extrafeatures %}
   CinderEnableIscsiBackend: false


### PR DESCRIPTION
Add a custom_config_extrafeatures var, defaults to an empty list, that is appended to the osp.extrafeatures list