### PR TITLE
Copy the whole feature tarball config's directory content

### DIFF
--- a/ansible/extrafeature_tarball_config.yaml
+++ b/ansible/extrafeature_tarball_config.yaml
@@ -6,15 +6,7 @@
 
 - name: copy feature files if directory exists
   when: p.stat.exists
-  block:
-  - name: Find files in feature dir
-    delegate_to: localhost
-    find:
-      paths: "{{ feature_dir }}"
-    register: f
-  - name: copy feature {{ feature }} files to custom tripleo tarball dir
-    copy:
-      src: "{{ item.path }}"
-      dest: "{{ ooo_tarball_dir }}/{{ item.path | basename }}"
-      mode: '0644'
-    with_items: "{{ f.files }}"
+  copy:
+    src: "{{ feature_dir }}/"
+    dest: "{{ ooo_tarball_dir }}"
+    mode: '0644'


### PR DESCRIPTION
Similarly as in [1], copy the whole content of extrafeature tarball config directory and not only files (supposedly tht files) found in top directory. It's useful If someone wants to use patched tht files which will replaced the original tht files i.e. to workaround a bug in tht.

[1] https://github.com/openstack-k8s-operators/osp-director-dev-tools/blob/4462a78548928763a136c4cffa4fb7d225136171/ansible/osp_custom_config.yaml#LL84C1-L88C19