### PR TITLE
Trust local CA when running tempest

### DIFF
--- a/ansible/osp_tempest.yaml
+++ b/ansible/osp_tempest.yaml
@@ -89,13 +89,30 @@
       environment:
         <<: *oc_env
 
-    - name: Add IPA CA cert
-      when: osp.tlse|default(false)|bool and not osp.tls_public_endpoints
+    - name: Set CA bundle path in clouds.yaml
+      when: osp.tlse|default(false)|bool or osp.tls_public_endpoints
       shell: |
         #!/bin/bash
         set -e
-        /usr/bin/cp -f /opt/freeipa/data/etc/ipa/ca.crt {{ tempest_working_dir }}/ca.crt
         sed -i -e 's!\(\s*cacert:\).*!\1 /var/lib/tempest/.config/openstack/ca.crt!' {{ tempest_working_dir }}/clouds.yaml
+      environment:
+        <<: *oc_env
+
+    - name: Add IPA CA cert to CA bundle
+      when: osp.tlse|default(false)|bool
+      shell: |
+        #!/bin/bash
+        set -e
+        cat /opt/freeipa/data/etc/ipa/ca.crt >> {{ tempest_working_dir }}/ca.crt
+      environment:
+        <<: *oc_env
+
+    - name: Add local CA cert to CA bundle
+      when: osp.tls_public_endpoints
+      shell: |
+        #!/bin/bash
+        set -e
+        cat /opt/local_CA/cacert.pem >> {{ tempest_working_dir }}/ca.crt
       environment:
         <<: *oc_env
 


### PR DESCRIPTION
Previously would just warn that an unverified HTTPS request was being made, seems it's now stricter in 17.1