### PR TITLE
Make the PV NFS backend configurable

### DIFF
--- a/ansible/ocp_default_storageclass.yaml
+++ b/ansible/ocp_default_storageclass.yaml
@@ -5,15 +5,7 @@
   user: root
   vars_files: vars/default.yaml
   vars: &pv_exports
-    pvs:
-    - size: 4
-      number: 16
-    - size: 128
-      number: 4
-    - size: 128
-      number: 8
-      shared: true
-    exports: "{{ pvs | expand_pvs | list }}"
+    exports: "{{ nfs_pvs | expand_pvs | list }}"
 
   tasks:
   - name: Create datadir

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -300,6 +300,15 @@ local_working_dir: "~/{{ ocp_cluster_name }}-working"
 nfs_data_dir: /home/nfs/data
 nfs_export_dir: /home/nfs
 
+nfs_pvs:
+  - size: 4
+    number: 16
+  - size: 128
+    number: 4
+  - size: 128
+    number: 8
+    shared: true
+
 default_timeout: 240
 
 # OSP release and compose file to fetch if specified. This is used to populate osp_release_auto dict


### PR DESCRIPTION
I use dev-tools for Podified and have found that more and more services require more PVs than the hard-coded defaults provide.  This allows users to define their PV backend quantity and sizes.