### PR TITLE
Dcn ci fixes

### DIFF
--- a/ansible/freeipa.yaml
+++ b/ansible/freeipa.yaml
@@ -37,21 +37,21 @@
         containers.podman.podman_network:
           name: freeipa-network
           disable_dns: true
-          subnet: 10.89.0.0/30
+          subnet: 10.99.0.0/30
 
       - name: Create freeipa-server container
         containers.podman.podman_container:
           state: created
           name: freeipa-server
           network: freeipa-network
-          ip: 10.89.0.2
+          ip: 10.99.0.2
           conmon_pidfile: /run/podman-freeipa-server-conman.pid
           hostname: freeipa.test.metalkube.org
           image: "{{ freeipa_image_url }}"
           #FIXME: need this to workaround a bug in podman ansible module
           stop_signal: 37
           env:
-            IPA_SERVER_IP: 10.89.0.2
+            IPA_SERVER_IP: 10.99.0.2
           volume:
             - "/opt/freeipa/data/:/data:Z"
             - "/opt/freeipa/bin/:/root/bin:Z"
@@ -122,7 +122,7 @@
       - name: Update dev_script dnsmasq to forward to freeipa
         lineinfile:
           path: /etc/NetworkManager/dnsmasq.d/openshift-{{ ocp_cluster_name }}.conf
-          line: 'server=/{{ base_domain_name }}/10.89.0.2 # Forward to FreeIPA'
+          line: 'server=/{{ base_domain_name }}/10.99.0.2 # Forward to FreeIPA'
           regexp: '# Forward to FreeIPA'
         when: not (ocp_ai|bool)
         register: ds_dnsmasq
@@ -139,7 +139,7 @@
       - name: Update AI dnsmasq to forward to freeipa
         lineinfile:
           path: /etc/dnsmasq.d/dnsmasq_ai.conf
-          line: 'server=/{{ base_domain_name }}/10.89.0.2 # Forward to FreeIPA'
+          line: 'server=/{{ base_domain_name }}/10.99.0.2 # Forward to FreeIPA'
           regexp: '# Forward to FreeIPA'
           insertbefore: '^server='
         when: ocp_ai|bool

--- a/ansible/osp_deploy_dcn_1.yaml
+++ b/ansible/osp_deploy_dcn_1.yaml
@@ -21,13 +21,13 @@
     config_generator_name: dcn1
     custom_config_dmbs_remote_site: "{{ 'dmbs' in osp.extrafeatures }}"
     config_generator_roles:
-      - DistributedComputeHCILeaf1
+      - DistComputeHCILeaf1
 
 - name: Overcloud node repo setup
   import_playbook: osp_register_overcloud_nodes.yaml
   vars:
     config_generator_roles:
-      - DistributedComputeHCILeaf1
+      - DistComputeHCILeaf1
 
 - name: Overcloud deployment
   import_playbook: osp_deployment.yaml

--- a/ansible/templates/dnsmasq/ctlplane.conf.j2
+++ b/ansible/templates/dnsmasq/ctlplane.conf.j2
@@ -8,7 +8,7 @@ no-hosts
 {% for dns_server in external_dns %}
 server={{ dns_server }}
 {% if osp.tlse|default(false)|bool %}
-server=/{{ base_domain_name }}/10.89.0.2 # Forward to FreeIPA
+server=/{{ base_domain_name }}/10.99.0.2 # Forward to FreeIPA
 {% endif %}
 {% endfor %}
 

--- a/ansible/templates/osp/tripleo_heat_envs/16.2/register-nic-templates.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/16.2/register-nic-templates.yaml.j2
@@ -8,5 +8,5 @@ resource_registry:
   OS::TripleO::ComputeSriov::Net::SoftwareConfig: net-config-two-nic-vlan-computesriov-qe.yaml
   OS::TripleO::ComputeOvsDpdk::Net::SoftwareConfig: net-config-two-nic-vlan-computedpdk-qe.yaml
   OS::TripleO::ComputeOvsDpdkSriov::Net::SoftwareConfig: net-config-two-nic-vlan-computedpdksriov-qe.yaml
-  OS::TripleO::DistributedComputeHCILeaf1::Net::SoftwareConfig: net-config-two-nic-vlan-computehci_leaf1.yaml
+  OS::TripleO::DistComputeHCILeaf1::Net::SoftwareConfig: net-config-two-nic-vlan-computehci_leaf1.yaml
 

--- a/ansible/templates/osp/tripleo_heat_envs/17.0/register-nic-templates.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/17.0/register-nic-templates.yaml.j2
@@ -7,4 +7,4 @@ parameter_defaults:
   ComputeHCILeaf2NetworkConfigTemplate: 'multiple_nics_vlans_dvr.j2'
   ComputeSriovNetworkConfigTemplate: 'net-config-two-nic-vlan-computesriov-qe.j2'
   ComputeOvsDpdkSriovNetworkConfigTemplate: 'net-config-two-nic-vlan-computedpdksriov-qe.j2'
-  DistributedComputeHCILeaf1NetworkConfigTemplate: 'multiple_nics_vlans_dvr.j2'
+  DistComputeHCILeaf1NetworkConfigTemplate: 'multiple_nics_vlans_dvr.j2'

--- a/ansible/templates/osp/tripleo_tarball_config/16.2/roles_data.yaml.j2
+++ b/ansible/templates/osp/tripleo_tarball_config/16.2/roles_data.yaml.j2
@@ -1273,7 +1273,7 @@
 ###############################################################################
 # Role: DistributedComputeHCILeaf1                                            #
 ###############################################################################
-- name: DistributedComputeHCILeaf1
+- name: DistComputeHCILeaf1
   description: |
     Distributed Compute Node role with Ceph, Cinder volume, and Glance.
   networks:

--- a/ansible/templates/osp/tripleo_tarball_config/17.0/roles_data.yaml.j2
+++ b/ansible/templates/osp/tripleo_tarball_config/17.0/roles_data.yaml.j2
@@ -640,7 +640,7 @@
 ###############################################################################
 # Role: DistributedComputeHCILeaf1                                            #
 ###############################################################################
-- name: DistributedComputeHCILeaf1
+- name: DistComputeHCILeaf1
   description: |
     Distributed Compute Node role with Ceph, Cinder volume, and Glance.
   tags:

--- a/ansible/templates/osp/tripleo_tarball_config/17.1/roles_data.yaml.j2
+++ b/ansible/templates/osp/tripleo_tarball_config/17.1/roles_data.yaml.j2
@@ -647,7 +647,7 @@
 ###############################################################################
 # Role: DistributedComputeHCILeaf1                                            #
 ###############################################################################
-- name: DistributedComputeHCILeaf1
+- name: DistComputeHCILeaf1
   description: |
     Distributed Compute Node role with Ceph, Cinder volume, and Glance.
   tags:

--- a/ansible/vars/16.2_dcn.yaml
+++ b/ansible/vars/16.2_dcn.yaml
@@ -33,7 +33,7 @@ osp_release_defaults:
         - tenant
         - storage
         - storage_mgmt
-    DistributedComputeHCILeaf1:
+    DistComputeHCILeaf1:
       count: 3
       ctlplane_interface: enp1s0
       networks:

--- a/ansible/vars/16.2_dcn_dmbs.yaml
+++ b/ansible/vars/16.2_dcn_dmbs.yaml
@@ -33,7 +33,7 @@ osp_release_defaults:
         - tenant
         - storage
         - storage_mgmt
-    DistributedComputeHCILeaf1:
+    DistComputeHCILeaf1:
       count: 3
       ctlplane_interface: enp1s0
       networks:

--- a/ansible/vars/17.0_dcn.yaml
+++ b/ansible/vars/17.0_dcn.yaml
@@ -39,7 +39,7 @@ osp_release_defaults:
         - tenant
         - storage
         - storage_mgmt
-    DistributedComputeHCILeaf1:
+    DistComputeHCILeaf1:
       count: 3
       ctlplane_interface: enp1s0
       networks:

--- a/ansible/vars/17.1_dcn.yaml
+++ b/ansible/vars/17.1_dcn.yaml
@@ -39,7 +39,7 @@ osp_release_defaults:
         - tenant
         - storage
         - storage_mgmt
-    DistributedComputeHCILeaf1:
+    DistComputeHCILeaf1:
       count: 3
       ctlplane_interface: enp1s0
       networks:

--- a/ansible/vars/17.1_dcn_dmbs.yaml
+++ b/ansible/vars/17.1_dcn_dmbs.yaml
@@ -7,7 +7,10 @@ ocp_num_workers: 3
 ocp_num_extra_workers: 5
 ocp_ai_bmc_protocol: redfish-virtualmedia+http
 
+enable_freeipa: true
+
 osp_release_defaults:
+  tlse: true
   base_image_url: http://download.devel.redhat.com/brewroot/packages/rhel-guest-image/9.2/20230414.43/images/rhel-guest-image-9.2-20230414.43.x86_64.qcow2
   networks: ipv4_dcn
   vmset:

--- a/ansible/vars/17.1_dcn_dmbs.yaml
+++ b/ansible/vars/17.1_dcn_dmbs.yaml
@@ -42,7 +42,7 @@ osp_release_defaults:
         - tenant
         - storage
         - storage_mgmt
-    DistributedComputeHCILeaf1:
+    DistComputeHCILeaf1:
       count: 3
       ctlplane_interface: enp1s0
       networks:


### PR DESCRIPTION
Change the subnet used for freeipa-network, it conflicts with a default podman network on newer systems.
Shorten the role name for DistributedComputeHCILeaf1 as it is used to generate the hostname and result in the gqdn exceeding a 64 char fqdn limit in the tripleo FreeIPA integration.
Default to TLSe for the DCN DMBS jobs.