### PR TITLE
Fix - Untar oc non rerunable

### DIFF
--- a/ansible/ocp_ai.yaml
+++ b/ansible/ocp_ai.yaml
@@ -105,6 +105,11 @@
       mode: '0755'
       timeout: 30
 
+  - name: Remove temp oc file
+    ansible.builtin.file:
+      path: /tmp/oc
+      state: absent
+
   - name: "Untar the openshift-client-linux.tar.gz"
     unarchive:
       src: "/tmp/openshift-client-linux.tar.gz"


### PR DESCRIPTION
- Fix - Untar oc non rerunable

```bash
[rhos-ci@titan131 tmp]$ ls -ltr openshift-client-linux.tar.gz
-rwxr-xr-x. 1 rhos-ci rhos-ci 53207799 Jul  6 10:08 openshift-client-linux.tar.gz


[rhos-ci@titan131 tmp]$ cat ./1.yaml

- hosts: localhost
  #  vars_files: vars/default.yaml
  #  roles:
  #  - oc_local

  ### OC CLIENT

  tasks:
  - name: Get the ocp client tar gunzip file
    get_url:
      url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.10/openshift-client-linux.tar.gz"
      dest: "/tmp/openshift-client-linux.tar.gz"
      mode: '0755'
      timeout: 30

  - name: "Untar the openshift-client-linux.tar.gz"
    unarchive:
      src: "/tmp/openshift-client-linux.tar.gz"
      dest: "/tmp"
      mode: '0755'



[rhos-ci@titan131 tmp]$ ansible-playbook -v ./1.yaml
Using /etc/ansible/ansible.cfg as config file
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] *********************************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************************************
ok: [localhost]

TASK [Get the ocp client tar gunzip file] ********************************************************************************************************************
ok: [localhost] => {"changed": false, "dest": "/tmp/openshift-client-linux.tar.gz", "elapsed": 0, "gid": 1000, "group": "rhos-ci", "mode": "0755", "msg": "HTT
P Error 304: Not Modified", "owner": "rhos-ci", "secontext": "unconfined_u:object_r:user_home_t:s0", "size": 53207799, "state": "file", "uid": 1000, "url": "h
ttps://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.10/openshift-client-linux.tar.gz"}

TASK [Untar the openshift-client-linux.tar.gz] ***************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "dest": "/tmp", "extract_results": {"cmd": ["/usr/bin/gtar", "--extract", "-C", "/tmp", "-z", "-f", "/home/r
hos-ci/.ansible/tmp/ansible-tmp-1688889840.6441405-1349600-211604002775725/source"], "err": "/usr/bin/gtar: README.md: Cannot open: File exists\n/usr/bin/gtar
: oc: Cannot open: File exists\n/usr/bin/gtar: kubectl: Cannot hard link to 'oc': File exists\n/usr/bin/gtar: Exiting with failure status due to previous erro
rs\n", "out": "", "rc": 2}, "gid": 0, "group": "root", "handler": "TgzArchive", "mode": "01777", "msg": "failed to unpack /home/rhos-ci/.ansible/tmp/ansible-t
mp-1688889840.6441405-1349600-211604002775725/source to /tmp", "owner": "root", "secontext": "system_u:object_r:tmp_t:s0", "size": 4096, "src": "/home/rhos-ci
/.ansible/tmp/ansible-tmp-1688889840.6441405-1349600-211604002775725/source", "state": "directory", "uid": 0}

PLAY RECAP ***************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0


Fix :  add creates:


  - name: "Untar the openshift-client-linux.tar.gz"
    unarchive:
      src: "/tmp/openshift-client-linux.tar.gz"
      dest: "/tmp"
      mode: '0755'
      creates: /tmp/oc
```
