### PR TITLE
Switch to the 0.5.2 cirros for DMBS deployments

### DIFF
--- a/ansible/osp_tempest.yaml
+++ b/ansible/osp_tempest.yaml
@@ -129,9 +129,9 @@
     - name: download cirros and convert the image to raw format
       shell: |
         #!/bin/bash
-        curl --location --insecure --output /tmp/cirros-0.4.0-x86_64-disk.img https://github.com/cirros-dev/cirros/releases/download/0.4.0/cirros-0.4.0-x86_64-disk.img
-        qemu-img convert -f qcow2 -O raw /tmp/cirros-0.4.0-x86_64-disk.img /tmp/cirros-0.4.0-x86_64-disk.raw
-        oc cp -n openstack /tmp/cirros-0.4.0-x86_64-disk.raw tempest:/var/lib/tempest/.config/openstack/cirros-0.4.0-x86_64-disk.raw
+        curl --location --insecure --output /tmp/cirros-0.5.2-x86_64-disk.img https://github.com/cirros-dev/cirros/releases/download/0.5.2/cirros-0.5.2-x86_64-disk.img
+        qemu-img convert -f qcow2 -O raw /tmp/cirros-0.5.2-x86_64-disk.img /tmp/cirros-0.5.2-x86_64-disk.raw
+        oc cp -n openstack /tmp/cirros-0.5.2-x86_64-disk.raw tempest:/var/lib/tempest/.config/openstack/cirros-0.5.2-x86_64-disk.raw
       environment:
         <<: *oc_env
 

--- a/ansible/templates/tempest/tempest_script.sh.j2
+++ b/ansible/templates/tempest/tempest_script.sh.j2
@@ -30,9 +30,9 @@ fi
   export OS_PROJECT_NAME=admin
   export OS_USER_DOMAIN_NAME=Default
   export OS_USERNAME=admin
-  glance image-create --disk-format raw --container-format bare --id 12345678-aaaa-bbbb-cccc-0123456789ab --visibility public --name cirros-0.4.0-x86_64-disk.img --file /var/lib/tempest/.config/openstack/cirros-0.4.0-x86_64-disk.raw --store central
+  glance image-create --disk-format raw --container-format bare --id 12345678-aaaa-bbbb-cccc-0123456789ab --visibility public --name cirros-0.5.2-x86_64-disk.img --file /var/lib/tempest/.config/openstack/cirros-0.5.2-x86_64-disk.raw --store central
   glance image-import 12345678-aaaa-bbbb-cccc-0123456789ab --stores dcn1 --import-method copy-image
-  glance image-create --disk-format raw --container-format bare --id 87654321-aaaa-bbbb-cccc-0123456789ab --visibility public --name cirros-0.4.0-x86_64-disk.img_alt --file /var/lib/tempest/.config/openstack/cirros-0.4.0-x86_64-disk.raw --store central
+  glance image-create --disk-format raw --container-format bare --id 87654321-aaaa-bbbb-cccc-0123456789ab --visibility public --name cirros-0.5.2-x86_64-disk.img_alt --file /var/lib/tempest/.config/openstack/cirros-0.5.2-x86_64-disk.raw --store central
   glance image-import 87654321-aaaa-bbbb-cccc-0123456789ab --stores dcn1 --import-method copy-image
 {% endif %}
 

--- a/ansible/vars/16.2_dcn_dmbs.yaml
+++ b/ansible/vars/16.2_dcn_dmbs.yaml
@@ -76,3 +76,5 @@ tempest_enable_feature_dict:
 # Create nova/volume resources in the AZ of the DCN's site
   compute:
     compute_volume_common_az: az-dcn1
+  image:
+    image_path: https://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img

--- a/ansible/vars/17.1_dcn_dmbs.yaml
+++ b/ansible/vars/17.1_dcn_dmbs.yaml
@@ -89,7 +89,7 @@ tempest_enable_feature_dict:
   compute:
     compute_volume_common_az: az-dcn1
   image:
-    image_path: https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
+    image_path: https://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img
 
 # (mschuppert) can be deleted when released
 openstackclient_image: "rhos-qe-mirror-rdu2.usersys.redhat.com:5002/rh-osbs/rhosp17-openstack-tripleoclient:{{ osp_release_auto.tag }}"


### PR DESCRIPTION
There is one tempest test [1] which seems to fail with 0.4.0 cirros image but passes with 0.5.2 cirros image on OSP 17.1.

[1] tempest.scenario.test_server_basic_ops.TestServerBasicOps.test_server_basic_ops