### PR TITLE
Move openstackclient FreeIPA cleanup to openstack_cleanup target

### DIFF
--- a/ansible/olm_cleanup.yaml
+++ b/ansible/olm_cleanup.yaml
@@ -35,9 +35,3 @@
       - "oc delete -n {{ namespace }} catalogsource osp-director-operator-index"
       - "oc delete -n {{ namespace }} {{ operatorgroup_name.stdout }}"
 
-  - name: Cleanup FreeIPA objects
-    become: true
-    become_user: root
-    ignore_errors: true
-    command: podman exec freeipa-server /root/bin/olm_cleanup.sh
-

--- a/ansible/templates/freeipa/olm_cleanup.sh.j2
+++ b/ansible/templates/freeipa/olm_cleanup.sh.j2
@@ -1,9 +1,0 @@
-#! /bin/bash
-
-kinit admin <<< {{ freeipa_admin_password }}
-
-# Delete the openstackclient pod (enrolled by admin user)
-for h in $(ipa host-find --pkey-only --not-in-hostgroups=ipaservers --enroll-by-users=admin | sed -ne 's/\s*Host name:\s*//p'); do
-  ipa host-del $h --updatedns
-done
-

--- a/ansible/templates/freeipa/openstack_cleanup.sh.j2
+++ b/ansible/templates/freeipa/openstack_cleanup.sh.j2
@@ -2,8 +2,8 @@
 
 kinit admin <<< {{ freeipa_admin_password }}
 
-# Delete all hosts except the IPA server and the openstackclient pod (enrolled by admin user)
-for h in $(ipa host-find --pkey-only --not-in-hostgroups=ipaservers --not-enroll-by-users=admin | sed -ne 's/\s*Host name:\s*//p'); do
+# Delete all hosts except the IPA server
+for h in $(ipa host-find --pkey-only --not-in-hostgroups=ipaservers | sed -ne 's/\s*Host name:\s*//p'); do
   ipa host-del $h --updatedns
 done
 


### PR DESCRIPTION
The openstackclient FreeIPA object cleanup was occurring in the wrong target - olm_cleanup. openstack_cleanup is the correct target (where the CR is removed).