### PR TITLE
Follow up to PR#502

### DIFF
--- a/ansible/freeipa.yaml
+++ b/ansible/freeipa.yaml
@@ -90,7 +90,6 @@
           mode: '0755'
         loop:
           - openstack_cleanup.sh
-          - olm_cleanup.sh
 
       - name: Update FreeIPA DNS ACL
         blockinfile:


### PR DESCRIPTION
[1] deleted the ansible/templates/freeipa/olm_cleanup.sh.j2 template which is still being called in this task. Lets remove it.

[1] https://github.com/openstack-k8s-operators/osp-director-dev-tools/pull/502