### PR TITLE
Improve overall OCP version support and add 4.13

### DIFF
--- a/ansible/ocp_ai_destroy.yaml
+++ b/ansible/ocp_ai_destroy.yaml
@@ -178,7 +178,7 @@
 
   - name: Delete AI podman images
     shell: |
-      for i in $(podman images | grep -E '(assisted-service|ocp-metal-ui)' | awk '{print $3}'); do podman rmi $i; done
+      for i in $(podman images | grep -E '(assisted-service|assisted-image-service|assisted-installer-ui)' | awk '{print $3}'); do podman rmi $i; done
 
   - name: Cleanup crucible
     become: true

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -661,13 +661,12 @@
 
       - name: Get RHCOS image version for {{ ocp_version }}.{{ ocp_minor_version }}
         set_fact:
-          rhcos_image_version: "{{ rhcos_image_version_raw_data.content | regex_search('second_release=([^&]+)', '\\1') | default ([''], true) | first }}"
-          rhcos_image_version_alt: "{{ rhcos_image_version_raw_data.content | regex_search('&amp;release=([^&]+)', '\\1') | default ([''], true) | first }}"
+          rhcos_image_version: "{{ rhcos_image_version_raw_data.content | regex_search('machine-os\\s(.+)\\sRed\\sHat\\sEnterprise\\sLinux\\sCoreOS', '\\1') | default ([''], true) | first }}"
 
       - name: Fail when an RHCOS version cannot be determined
         fail:
           msg: "Unable to determine RHCOS version for OCP version {{ ocp_version }}.{{ ocp_minor_version }}"
-        when: rhcos_image_version == "" and rhcos_image_version_alt == ""
+        when: rhcos_image_version == ""
 
     - name: Remove NTP validation due to prevelance of random false-negatives
       replace:

--- a/ansible/templates/ai/crucible/inventory.ospd.yml.j2
+++ b/ansible/templates/ai/crucible/inventory.ospd.yml.j2
@@ -77,12 +77,18 @@ all:
         disk_size_gb: {{ ocp_master_disk|default(120) }}
         installation_disk_speed_threshold_ms: 10
 
+    ai_version: {{ ocp_ai_version }}
+
+{% if ocp_ai_version in ocp_ai_image_hashes %}
+    image_hashes: {{ ocp_ai_image_hashes[ocp_ai_version] }}
+{% endif %}
+
     os_images:
     - openshift_version: '{{ ocp_version }}'
       cpu_architecture: x86_64
       url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{{ ocp_version }}/latest/rhcos-live.x86_64.iso
       rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{{ ocp_version }}/latest/rhcos-live-rootfs.x86_64.img
-      version: {{ rhcos_image_version if rhcos_image_version != "" else rhcos_image_version_alt }}
+      version: {{ rhcos_image_version }}
 
     release_images:
     - openshift_version: '{{ ocp_version }}'
@@ -172,8 +178,8 @@ all:
         - template: 50-worker-nm-fix-ipv6.yml.j2
         - template: 50-worker-remove-ipi-leftovers.yml.j2
         - template: 02-fix-ingress-config.yml.j2
-{# Needed for 4.12 until the fix for https://issues.redhat.com/browse/OCPBUGS-1482 appears in that version #}
-{% if ocp_version != '4.12' %}
+{# Needed for 4.11 and earlier, but must not be included for 4.12+ #}
+{% if ocp_version|string is version('4.12', '<') %}
         - template: 01-master-node-scheduler.yml.j2
 {% endif %}
 

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -42,7 +42,7 @@ podman_insecure_registries:
 ocp_version: "4.10"
 ocp_minor_version: 63
 ocp_release_image: "quay.io/openshift-release-dev/ocp-release:{{ ocp_version }}.{{ ocp_minor_version }}-x86_64"
-ocp_release_data_url: "https://amd64.ocp.releases.ci.openshift.org/releasestream/4-stable/release/{{ ocp_version }}.{{ ocp_minor_version }}"
+ocp_release_data_url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ ocp_version }}.{{ ocp_minor_version }}/release.txt"
 ocp_release_type: ga
 
 # OCP cluster wide proxy settings `oc get proxy/cluster`

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -21,3 +21,24 @@ ocp_ai_libvirt_storage_dir: /var/lib/libvirt/images
 # Pin aicli and its associated client library to a known working pair for AI API v2
 ocp_ai_cli_version: "99.0.202205080021.202103111306"
 ocp_ai_cli_lib_version: "2.3.0.post43"
+
+# WARNING: Changing these will likely break installation, so proceed with caution
+# Pin AI version based on ocp_version
+ocp_ai_version: "{{ 'v2.20.0' if ocp_version|string is version('4.12', '>=') else 'v2.12.1' }}"
+# These improve the speed of the spin-up of the image service container and thus reduce the
+# overall deployment time
+ocp_ai_image_hashes:
+  v2.12.1:
+    controller: sha256:63b2a9f68853ceedf7e2e2b4501d1457d496be0813722a5a4def3b8b5174b1b6
+    gui: sha256:47e59e6b9e54aae4438cc11c1e98895214e3ba4bc870426e369306232fde958d
+    image_service: sha256:55a3decc0da4188c34bd43acca053b247c789b613e7f54832b78a75483eb2144
+    installer: sha256:87e535b54ac472c872835088ed46cbbf2eaf3ca91abfca082f5c428bc8414db0
+    installer_agent: sha256:6d782042debb951b202c80869f2dd30fffb9272010a46d77ea39ce8f6a862162
+    service: sha256:5204f25b617500a949eaef78731b906351b6c60855b59033880c0f2935e01348
+  v2.20.0:
+    controller: sha256:b2ac9f71c4033225be347deb73a6f29162f3ac88b6ca12b2d5da71394c835bfc
+    gui: sha256:2185ab37e94fbdeb5a8aedd1315cb847af6f2035407e0fc951bf75fb05b68029
+    image_service: sha256:082fef632e8b448e15753dd067b69b926bc8bb8f252e1dbdd3b5567a1cebd494
+    installer: sha256:12396d2ea1929d1b3ccc5117c6fd164bd87abdb9b113d0570f6e4c14c9a16f20
+    installer_agent: sha256:2fb4d3556b252f692d105e3609363611e6844758c84b198445fc023c8b0bfbf9
+    service: sha256:0dc7bf3172d6b3e6ec39bc766816766525c3bb40f8fba394d21483b73ba436b6


### PR DESCRIPTION
Pins AI versions based on desired OCP version, which is needed to enable support for OCP 4.13.  Also adds general improvements for various version-related concerns.  These changes have been tested on:

- 4.10.63
- 4.11.48
- 4.12.13
- 4.13.8

Each version was tried as a 3-master-worker and a 3-master, 3-worker cluster.