### PR TITLE
Pin sushy-tools < 0.21.1 to avoid VM boot problems

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -570,7 +570,7 @@
 
     - name: Install sushy-tools in virtualenv
       pip:
-        name: ['sushy-tools!=0.21.1', 'libvirt-python']
+        name: ['sushy-tools<0.21.1', 'libvirt-python']
         virtualenv: /opt/sushy-tools/venv
         virtualenv_python: python3.9
         state: latest


### PR DESCRIPTION
`v1.0.0` introduces this error:

```
errorMessage: 'Failed to inspect hardware. Reason: unable to start inspection: Redfish
    exception occurred. Error: Setting boot mode to bios failed for node 06b5384c-0884-430a-94a6-b3c53ec901cc.
    Error: HTTP PATCH http://192.168.111.1:8082/redfish/v1/Systems/5b16e543-b839-442e-b51c-1d02725f0c92
    returned code 500. Base.1.0.GeneralError: Error changing boot mode at libvirt
    URI "qemu:///system": no loader path specified and firmware auto selection disabled
    Extended information: [{''@odata.type'': ''/redfish/v1/$metadata#Message.1.0.0.Message'',
    ''MessageId'': ''Base.1.0.GeneralError''}]'
```

...and previously we did not want `v0.21.1` for a particular reason, so let's pin it to the latest available below that version.