### PR TITLE
static opm set

### DIFF
--- a/ansible/roles/download_tools/defaults/main.yaml
+++ b/ansible/roles/download_tools/defaults/main.yaml
@@ -3,7 +3,7 @@
 kuttl_version: 0.9.0
 
 # Released version of the opm package (can be set to 'latest')
-opm_version: latest
+opm_version: v1.30.0
 
 # operator-sdk version to use (must be specific version)
 #sdk_version: v0.19.2 - cnosp is right now based on that version

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -205,7 +205,7 @@ ocp_cluster_name: ostest
 ocp_domain_name: "{{ base_domain_name }}"
 
 # Released version of the opm package (can be set to 'latest')
-opm_version: latest
+opm_version: v1.30.0
 
 # operator-sdk version to use (must be specific version)
 #sdk_version: v0.19.2 - cnosp is right now based on that version


### PR DESCRIPTION
- Improve overall OCP version support and add 4.13
- set sefault osp puddle to passed_phase2
- Pin sushy-tools < 0.21.1 to avoid VM boot problems
- set opm url path
