### PR TITLE
Fix yaml indent when ceph_extraconfig_network is not defined

### DIFF
--- a/ansible/templates/osp/tripleo_heat_envs/common/storage-backend.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/common/storage-backend.yaml.j2
@@ -54,7 +54,9 @@ parameter_defaults:
     osd_objectstore: bluestore
   CephAnsibleExtraConfig:
     is_hci: true
-    {% if ceph_extraconfig_network is defined %}{{ ceph_extraconfig_network|to_nice_yaml|indent(4) }}{% endif %}
+{% if ceph_extraconfig_network is defined %}
+    {{ ceph_extraconfig_network|to_nice_yaml|indent(4) }}
+{%- endif %}
   CephConfigOverrides:
     rgw_swift_enforce_content_length: true
     rgw_swift_versioning_enabled: true


### PR DESCRIPTION
Ansible defaults to trims_blocks=True which messed up the indentation ceph_extraconfig_network is not set