### PR TITLE
Wait for BMHs to become available during compute provisioning

### DIFF
--- a/ansible/install_computes.yaml
+++ b/ansible/install_computes.yaml
@@ -83,6 +83,15 @@
       KUBECONFIG: "{{ kubeconfig }}"
     when: ocp_ai|bool and ocp_extra_worker_count|int > 0
 
+  - name: Wait for BMHs to become available
+    shell: |
+      set -e
+      oc wait bmh -n openshift-machine-api --for jsonpath='{.status.provisioning.state}'=available -l app=openstack --timeout={{ (default_timeout * 2)|int }}s
+    environment:
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
+    when: ocp_ai|bool and ocp_extra_worker_count|int > 0
+
   # render openstackbaremetalset.yaml per bmset
   - name: Render templates to yaml dir
     template:

--- a/ansible/templates/ai/metal3/extra_workers_bmhs.yml.j2
+++ b/ansible/templates/ai/metal3/extra_workers_bmhs.yml.j2
@@ -16,6 +16,10 @@ kind: BareMetalHost
 metadata:
   name: openshift-worker-{{ i }}
   namespace: openshift-machine-api
+  annotations:
+    inspect.metal3.io: disabled
+  labels:
+    app: openstack
 spec:
   online: false
   bootMACAddress: {{ ocp_ai_prov_bridge_worker_mac_prefix }}{{ i }}
@@ -47,6 +51,10 @@ kind: BareMetalHost
 metadata:
   name: openshift-worker-{{ worker_index }}
   namespace: openshift-machine-api
+  annotations:
+    inspect.metal3.io: disabled
+  labels:
+    app: openstack
 spec:
   online: false
   bootMACAddress: {{ worker["prov_mac"] }}


### PR DESCRIPTION
We now have a more sensitive check in our `OpenStackBaremetalSet` webhook that requires BMHs to be in the `Available` state for them to be considered for use [1].  This adds a check for that.  It also adds a label to the BMHs so that we can select them as a group.  Furthermore, it disables BMH introspection to speed-up deployment (we don't use the introspection data anyhow).

This is needed to unblock https://github.com/openstack-k8s-operators/osp-director-dev-tools/pull/517

[1] https://github.com/openstack-k8s-operators/osp-director-operator/pull/969