### PR TITLE
WA OSPRH 3411

### DIFF
--- a/ansible/ocp_vm_setup_extra_nics.yaml
+++ b/ansible/ocp_vm_setup_extra_nics.yaml
@@ -35,8 +35,8 @@
 
       - name: Find requested MTU for ospnetwork bridge and interface
         set_fact:
-          ospnetwork_bridge_mtu: "{{ osp.attach_configs['br-osp'] | community.general.json_query('interfaces[?type==`bridge`].mtu') | first }}"
-          ospnetwork_intf_mtu: "{{ osp.attach_configs['br-osp'] | community.general.json_query('interfaces[?type==`ethernet`].mtu') | first }}"
+          ospnetwork_bridge_mtu: "{{ (osp.attach_configs['br-osp']['interfaces'] | selectattr('type', 'equalto', 'bridge') | map(attribute='mtu') | first) }}"
+          ospnetwork_intf_mtu: "{{ (osp.attach_configs['br-osp']['interfaces'] | selectattr('type', 'equalto', 'ethernet') | map(attribute='mtu') | first) }}"
 
       - name: Create ospnetwork bridge
         shell: |


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/OSPRH-3411

issue comes after :
https://github.com/openstack-k8s-operators/osp-director-dev-tools/blob/master/ansible/ocp_vm_setup_extra_nics.yaml#L36-L39

       - name: Find requested MTU for ospnetwork bridge and interface
        set_fact:
          ospnetwork_bridge_mtu: "{{ osp.attach_configs['br-osp'] | community.general.json_query('interfaces[?type==`bridge`].mtu') | first }}"
          ospnetwork_intf_mtu: "{{ osp.attach_configs['br-osp'] | community.general.json_query('interfaces[?type==`ethernet`].mtu') | first }}"

with json string being broken :
ERROR:
template error while templating string: No module named 'ansible.module_utils.compat.version'. String: {{ osp.attach_configs['br-osp'] | community.general.json_query('interfaces[?type==`bridge`].mtu') | first }}�[0m

We can maybe w/a this with a non json_querry usage like here :

Unit Tested:
```

---
- name: Extract MTU value without json_query
  hosts: localhost
  gather_facts: false
  vars:
    attach_configs:
      br-osp:
        interfaces:
          - type: bridge
            name: br-osp
            interface: enp7s0
            mtu: 9000_brmtu
          - type: ethernet
            interface: enp7s0
            mtu: 9000_ethmtu

  tasks:
    - name: Get mtu value without json_query
      debug:
        msg: "{{ (attach_configs['br-osp']['interfaces'] | selectattr('type', 'equalto', 'bridge') | map(attribute='mtu') | first) }}"
    - name: Get mtu value without json_query
      debug:
        msg: "{{ (attach_configs['br-osp']['interfaces'] | selectattr('type', 'equalto', 'ethernet') | map(attribute='mtu') | first) }}"
```
```

[root@titan36 ~]# ansible-playbook -v ./check.yaml
Using /etc/ansible/ansible.cfg as config file
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [Extract MTU value without json_query] *********************************************************************************************************************************

TASK [Get mtu value without json_query] *************************************************************************************************************************************
ok: [localhost] => {
    "msg": "9000_brmtu"
}

TASK [Get mtu value without json_query] *************************************************************************************************************************************
ok: [localhost] => {
    "msg": "9000_ethmtu"
}

PLAY RECAP ******************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```