### PR TITLE
Prototype of RHEL9 support

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -500,7 +500,8 @@ nfs_cleanup: hosts
 	 temp=$$(mktemp); \
 	 grep -v "^/home/nfs/data/pv-" /etc/fstab > \$$temp; \
 	 cat \$$temp > /etc/fstab; \
-	 rm \$$temp"
+	 rm \$$temp; \
+	 systemctl daemon-reload"
 
 .PHONY: must_gather
 must_gather: hosts local-defaults.yaml ## collect data from the env running must-gather

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -34,7 +34,7 @@ The quickstart procedure will allow you to deploy an OpenShift environment on a 
 
 1. Install the dependencies:
     ```
-    dnf install -y ansible git libvirt-client python3-netaddr python3-lxml make gcc
+    dnf install -y ansible-core git libvirt-client python3-netaddr python3-lxml make gcc
     ```
 
 1. Generate an SSH key which will be used during the deployment to allow access to the environment:

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -63,9 +63,9 @@ The quickstart procedure will allow you to deploy an OpenShift environment on a 
     ```
     cat > local-defaults.yaml <<EOF
     # version setup
-    ocp_version: "4.12"
-    ocp_minor_version: "0"
-    sriov_version: "4.12"
+    ocp_version: "4.16"
+    ocp_minor_version: "13"
+    sriov_version: "4.16"
 
     # topology configuration
     ocp_ai: true

--- a/ansible/host_prep.yaml
+++ b/ansible/host_prep.yaml
@@ -56,6 +56,12 @@
                 and ocp_num_storage_workers > ocp_master_count|int
                )
 
+  # Temporary (perhaps) until we can figure out how to find a CNV-4.12 repo for RHEL 9
+  - name: CNV validation check
+    fail:
+      msg: Only OCP 4.13+ is supported for RHEL 9 environments, due to CNV repo availability
+    when: ocp_version is version('4.12', 'le', strict=True ) and ansible_distribution_version|int == 9
+
   - name: add RH CA to ca store
     block:
     - name: copy CA cert to anchors dir
@@ -161,51 +167,15 @@
         server_hostname: "{{ rhel_subscription_server_hostname|default(omit) }}"
       when: manual_rhel_subscription is undefined
 
-    - name: enable rhel-8-for-x86_64-appstream-rpms and advanced-virt-for-rhel-8-x86_64-rpms
-      command: subscription-manager repos --enable=rhel-8-for-x86_64-appstream-rpms --enable=advanced-virt-for-rhel-8-x86_64-rpms --enable=openstack-16-for-rhel-8-x86_64-rpms
-
+    - name: enable required repos
+      command: subscription-manager repos --enable={{ ' --enable='.join(rhel_repos[ansible_distribution_version|int]) }}
 
   - name: install packages and enable services
     block:
     - name: Install packages
       package:
         state: installed
-        name:
-          # Directly configured/used in this playbook
-          - chrony
-          - sysstat
-          - cronie
-          - tuned
-          - firewalld
-
-          # Required for dev-scripts
-          - libvirt-daemon-kvm
-          - libvirt-client
-          - libvirt
-          - podman
-          - buildah
-          - git
-          - make
-
-          # Required to run osp-director-operator/scripts/build_and_push_images.sh
-          - skopeo
-
-          # Required for assisted installer
-          - dnsmasq
-          - libvirt-devel
-          - python3-netaddr
-          - python3-pip
-          - qemu-kvm
-          - virt-install
-
-          # required to customize the guest-image to remove net.ifnames=0 kernel param
-          - libguestfs-tools-c
-
-          # required to run recent sushy-tools
-          - python39
-          - python39-devel
-          - python3-virtualenv
-          - gcc
+        name: "{{ rhel_packages[ansible_distribution_version|int] | list }}"
 
     - name: Enable helpful services
       service: name={{ item }} enabled=yes state=started

--- a/ansible/install_networks.yaml
+++ b/ansible/install_networks.yaml
@@ -81,7 +81,8 @@
     become: true
     become_user: root
     shell: |
-      firewall-cmd --zone=trusted --add-source=0.0.0.0/32
+      firewall-cmd --zone=trusted --add-source=0.0.0.0/32 --permanent
+      firewall-cmd --reload
 
   - name: Create IPv4 gateways on ctlplane network
     become: true

--- a/ansible/install_networks.yaml
+++ b/ansible/install_networks.yaml
@@ -75,6 +75,14 @@
   # * can not use nmcli module https://github.com/ansible/ansible/issues/48055
   # * don't apply these persistent, in case of a host reboot those need to be reapplied
 
+  # REMOVEME?: Seems to be needed in RHEL 9, otherwise PXE boot requests coming in on
+  # ostestpr bridge from source 0.0.0.0 are dropped
+  - name: Allow BOOTP 0.0.0.0 source on trusted network
+    become: true
+    become_user: root
+    shell: |
+      firewall-cmd --zone=trusted --add-source=0.0.0.0/32
+
   - name: Create IPv4 gateways on ctlplane network
     become: true
     become_user: root

--- a/ansible/install_networks.yaml
+++ b/ansible/install_networks.yaml
@@ -81,8 +81,10 @@
     become: true
     become_user: root
     shell: |
-      firewall-cmd --zone=trusted --add-source=0.0.0.0/32 --permanent
-      firewall-cmd --reload
+      firewall-cmd --zone=trusted --add-source=0.0.0.0/32 {{ item }}
+    with_items:
+      - ""
+      - "--permanent"
 
   - name: Create IPv4 gateways on ctlplane network
     become: true

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -123,6 +123,8 @@
           conn_name: "bridge-slave-{{ item }}"
           type: bridge-slave
           state: absent
+        register: delete_bridge_slaves
+        failed_when: delete_bridge_slaves.stderr != "" and "unknown connection" not in delete_bridge_slaves.stderr
         when: item != ""
         with_items:
           - "{{ ocp_bm_prov_interface }}"
@@ -142,7 +144,7 @@
           - "{{ osp_ext_bm_interface }}"
 
       - name: Create BM bridge
-        nmcli:
+        community.general.nmcli:
           conn_name: "{{ ocp_cluster_name }}bm"
           type: bridge
           ifname: "{{ ocp_cluster_name }}bm"
@@ -150,6 +152,7 @@
           stp: off
           # TODO: Support any netmask?
           ip4: "192.168.111.1/24"
+          zone: libvirt
           state: present
 
       - name: Add BM interface to BM bridge
@@ -172,7 +175,7 @@
             state: present
 
       - name: Create provisioning bridge
-        nmcli:
+        community.general.nmcli:
           conn_name: "{{ ocp_cluster_name }}pr"
           type: bridge
           ifname: "{{ ocp_cluster_name }}pr"
@@ -180,6 +183,7 @@
           stp: off
           # TODO: Support any netmask?
           ip4: "172.22.0.1/24"
+          zone: libvirt
           state: present
 
       - name: Add prov interface to prov bridge
@@ -319,6 +323,10 @@
     become: true
     become_user: root
     block:
+    - name: Acquire podman interface name
+      shell: ip a | grep "podman0:" | cut -d ' ' -f 2 | sed 's/.$//'
+      register: podman_intf
+
     - name: Create dnsmasq conf
       template:
         src: "ai/dnsmasq/dnsmasq.conf.j2"

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -582,7 +582,7 @@
       pip:
         name: ['sushy-tools<0.21.1', 'libvirt-python']
         virtualenv: /opt/sushy-tools/venv
-        virtualenv_python: python3.9
+        virtualenv_command: /usr/bin/python3.9 -m venv
         state: latest
 
     - name: Create sushy-tools conf

--- a/ansible/ocp_cnv.yaml
+++ b/ansible/ocp_cnv.yaml
@@ -86,19 +86,14 @@
     until: result.rc == 0
 
   - name: install kubevirt client
-    block:
-    - name: get cnv version from {{ cnv_hyperconverged_operator_version }}
-      set_fact:
-        cnv_version: "{{ cnv_hyperconverged_operator_version | regex_search('(.+\\..+)\\..*', '\\1') | first }}"
-
-    - name: enable cnv-{{ cnv_version }}-for-rhel-{{ ansible_distribution_version|int }}-x86_64-rpms to install kubevirt-virtctl
-      become: true
-      become_user: root
-      command: subscription-manager repos --enable=cnv-{{ cnv_version }}-for-rhel-{{ ansible_distribution_version|int }}-x86_64-rpms
-
-    - name: Install kubevirt-virtctl package
-      become: true
-      become_user: root
-      package:
-        name:  kubevirt-virtctl
-        state: latest
+    shell: |
+      set -e
+      oc cp -n openshift-cnv $(oc get -n openshift-cnv pods -l name=hyperconverged-cluster-cli-download -o custom-columns=:metadata.name):amd64/linux/virtctl.tar.gz /tmp/virtctl.tar.gz
+      tar -C "{{ working_bin_dir }}" -xzvf /tmp/virtctl.tar.gz
+    environment:
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
+    retries: 5
+    delay: 30
+    register: result
+    until: result.rc == 0

--- a/ansible/ocp_cnv.yaml
+++ b/ansible/ocp_cnv.yaml
@@ -91,10 +91,10 @@
       set_fact:
         cnv_version: "{{ cnv_hyperconverged_operator_version | regex_search('(.+\\..+)\\..*', '\\1') | first }}"
 
-    - name: enable cnv-{{ cnv_version }}-for-rhel-8-x86_64-rpms to install kubevirt-virtctl
+    - name: enable cnv-{{ cnv_version }}-for-rhel-{{ ansible_distribution_version|int }}-x86_64-rpms to install kubevirt-virtctl
       become: true
       become_user: root
-      command: subscription-manager repos --enable=cnv-{{ cnv_version }}-for-rhel-8-x86_64-rpms
+      command: subscription-manager repos --enable=cnv-{{ cnv_version }}-for-rhel-{{ ansible_distribution_version|int }}-x86_64-rpms
 
     - name: Install kubevirt-virtctl package
       become: true

--- a/ansible/ocp_vm_setup_extra_nics.yaml
+++ b/ansible/ocp_vm_setup_extra_nics.yaml
@@ -64,7 +64,7 @@
           when: check_ospnetwork_bridge_exists.stderr != "" and 'no such connection profile' in check_ospnetwork_bridge_exists.stderr
 
       - name: Create osp external bridge (if IP set)
-        nmcli:
+        community.general.nmcli:
           conn_name: "external"
           type: bridge
           ifname: "external"
@@ -72,6 +72,7 @@
           stp: off
           ip4: "{{ osp_ext_bridge_ip4 }}"
           ip6: "{{ osp_ext_bridge_ip6 }}"
+          zone: libvirt
           state: present
         when: osp_ext_bridge_ip4|default != ""
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -6,6 +6,7 @@ roles:
 
 collections:
   - name: ansible.posix
+  - name: ansible.netcommon
   - name: containers.podman
   - name: community.general
     version: '<5.0.0'

--- a/ansible/templates/ai/dnsmasq/dnsmasq.conf.j2
+++ b/ansible/templates/ai/dnsmasq/dnsmasq.conf.j2
@@ -16,8 +16,8 @@ domain={{ ocp_ai_full_cluster_name }}
 no-dhcp-interface={{ ocp_ai_ext_intf.stdout }}
 # Enable DHCP for baremetal bridge
 interface={{ ocp_cluster_name }}bm
-# include cni-podman0 interface that connects to assisted-installer container for DNS requests to succeed
-interface=cni-podman0
+# include {{ podman_intf.stdout }} interface that connects to assisted-installer container for DNS requests to succeed
+interface={{ podman_intf.stdout }}
 bind-interfaces
 
 #### DHCP (dnsmasq --help dhcp)

--- a/ansible/templates/ai/libvirt/baremetalvm.xml.j2
+++ b/ansible/templates/ai/libvirt/baremetalvm.xml.j2
@@ -4,8 +4,6 @@
   <vcpu>{{ vcpu }}</vcpu>
   <os>
     <type arch='x86_64' machine='q35'>hvm</type>
-    <loader readonly='yes' secure='yes' type='pflash'>/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd</loader>
-    <nvram>/var/lib/libvirt/qemu/nvram/{{ ocp_cluster_name }}-{{ role }}-{{ item }}_VARS.fd</nvram>
     <boot dev='network'/>
     <bootmenu enable='no'/>
   </os>

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -597,6 +597,7 @@ rhel_packages:
   # Required for assisted installer
   - dnsmasq
   - libvirt-devel
+  - python3-jmespath
   - python3-netaddr
   - python3-pip
   - python3.11-pip

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -245,8 +245,8 @@ director_operator_image: quay.io/openstack-k8s-operators/osp-director-operator
 # CSV version is used for both the CSV version and container image tag
 csv_version: latest-16.2
 
-#ocp_network_type: OVNKubernetes
-ocp_network_type: OpenShiftSDN
+#ocp_network_type: OpenShiftSDN #for OCP pre 4.16
+ocp_network_type: OVNKubernetes
 
 # ansible-sts test suite repo url
 sts_repo_url: https://code.engineering.redhat.com/gerrit/openstack-pidone-qe

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -526,3 +526,87 @@ must_gather_image: quay.io/openstack-k8s-operators/must-gather:latest
 must_gather_compress_logs: false
 
 cnosp_csv_version: 0.0.1
+
+rhel_repos:
+  8:
+  - rhel-8-for-x86_64-appstream-rpms
+  - advanced-virt-for-rhel-8-x86_64-rpms
+  - openstack-16-for-rhel-8-x86_64-rpms
+  9:
+  - rhel-9-for-x86_64-appstream-rpms
+  - codeready-builder-for-rhel-9-x86_64-rpms
+
+rhel_packages:
+  8:
+  # Directly configured/used in this playbook
+  - chrony
+  - sysstat
+  - cronie
+  - tuned
+  - firewalld
+
+  # Required for dev-scripts
+  - libvirt-daemon-kvm
+  - libvirt-client
+  - libvirt
+  - podman
+  - buildah
+  - git
+  - make
+
+  # Required to run osp-director-operator/scripts/build_and_push_images.sh
+  - skopeo
+
+  # Required for assisted installer
+  - dnsmasq
+  - libvirt-devel
+  - python3-netaddr
+  - python3-pip
+  - qemu-kvm
+  - virt-install
+
+  # required to customize the guest-image to remove net.ifnames=0 kernel param
+  - libguestfs-tools-c
+
+  # required to run recent sushy-tools
+  - python39
+  - python39-devel
+  - python3-virtualenv
+  - gcc
+
+  9:
+  # Directly configured/used in this playbook
+  - chrony
+  - sysstat
+  - cronie
+  - tuned
+  - firewalld
+
+  # Required for dev-scripts
+  - libvirt-daemon-kvm
+  - libvirt-client
+  - libvirt
+  - podman
+  - buildah
+  - git
+  - make
+
+  # Required to run osp-director-operator/scripts/build_and_push_images.sh
+  - skopeo
+
+  # Required for assisted installer
+  - dnsmasq
+  - libvirt-devel
+  - python3-netaddr
+  - python3-pip
+  - python3.11-pip
+  - qemu-kvm
+  - virt-install
+
+  # required to customize the guest-image to remove net.ifnames=0 kernel param
+  - libguestfs-tools-c
+
+  # required to run recent sushy-tools
+  - python3
+  - python3-devel
+  - gcc


### PR DESCRIPTION
These changes allowed me to run `make default` successfully in a RHEL 9.3 environment.  I also tested some of them on RHEL 8, but not everything here has been tested there by me.  CI, however, passed on RHEL8 here [1].

To prepare the RHEL 9.3 environment, I simply used `subscription-manager` to register.  I did not attach to any specific pool.

[1] https://rhos-ci-jenkins.lab.eng.tlv2.redhat.com/blue/organizations/jenkins/DFG-ospk8s-osp-director-dev-tools-ai-pr/detail/DFG-ospk8s-osp-director-dev-tools-ai-pr/643/pipeline