### PR TITLE
[OSPK8-821] Support OCP 4.15+ (and bump to final Crucible)

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -615,10 +615,32 @@
 
     - name: Clone the assisted installer playbooks repo
       git:
-        repo: "{{ ocp_ai_ansible_repo | default('https://github.com/redhat-partner-solutions/crucible.git', true) }}"
+        repo: "{{ ocp_ai_ansible_repo | default('https://github.com/openstack-k8s-operators/crucible.git', true) }}"
         dest: "{{ base_path }}/crucible"
         force: true
-        version: "{{ ocp_ai_ansible_branch | default('85ad8f8a98a7c43ad0f46d3fc2e99f792b37b43f', true) }}"
+        version: "{{ ocp_ai_ansible_branch | default('82801743b9510192d3f737b47fffeb53af80e0bb', true) }}"
+
+    # FIXME: Remove once https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/371 merges
+    - name: Clone the assisted installer Ansible collection repo
+      git:
+        repo: "{{ ocp_ai_ansible_collection_repo | default('https://github.com/openstack-k8s-operators/ansible-collection-redhatci-ocp.git', true) }}"
+        dest: "{{ base_path }}/ansible-collection-redhatci-ocp"
+        force: true
+        version: "{{ ocp_ai_ansible_collection_branch | default('ocp_4_16', true) }}"
+
+    # FIXME: Remove once https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/371 merges
+    - name: Build the assisted installer Ansible collection
+      shell: |
+        ansible-galaxy collection build --force
+      args:
+        chdir: "{{ base_path }}/ansible-collection-redhatci-ocp"
+
+    # FIXME: Remove once https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/371 merges
+    - name: Install the assisted installer Ansible collection
+      shell: |
+        ansible-galaxy collection install {{ base_path }}/ansible-collection-redhatci-ocp/redhatci-ocp-0.15.0.tar.gz
+      args:
+        chdir: "{{ base_path }}/crucible"
 
     - name: Get BMC-network-connected interface's IP for baremetal deployments
       when: ocp_cluster_has_bm|bool
@@ -626,28 +648,20 @@
         /usr/bin/nmcli -g ip4.address device show {{ ocp_bmc_interface }} | cut -d '/' -f 1
       register: ocp_bmc_interface_ip
 
+    - name: Create Crucible templates dir
+      file:
+        path: "{{ base_path }}/crucible/playbooks/templates"
+        state: directory
+        mode: 0755
+
     - name: Add Crucible template to inject Red Hat CA
       template:
         src: ai/crucible/50-RH-Root-CA.yml.j2
-        dest: "{{ base_path }}/crucible/roles/patch_cluster/templates/50-{{ ocp_node_role }}-RH-Root-CA.yml.j2"
+        dest: "{{ base_path }}/crucible/playbooks/templates/50-{{ ocp_node_role }}-RH-Root-CA.yml.j2"
         mode: '0664'
       loop_control:
         loop_var: ocp_node_role
       loop: "{{ ocp_node_roles }}"
-
-    - name: Override Crucible OCP version constraint
-      replace:
-        path: "{{ base_path }}/crucible/roles/validate_inventory/tasks/cluster.yml"
-        regexp: 'openshift_full_version in supported_ocp_versions'
-        replace: 'openshift_full_version is defined'
-
-    # FIXME: Needed for 4.12 until the fix for https://issues.redhat.com/browse/OCPBUGS-1482 appears in that version
-    - name: Remove schedulable_masters from initial cluster creation
-      when: ocp_version == "4.12"
-      ansible.builtin.lineinfile:
-        path: "{{ base_path }}/crucible/roles/create_cluster/tasks/main.yml"
-        state: absent
-        regexp: '^.*"schedulable_masters"'
 
     - name: Inject specific RHCOS image version
       block:
@@ -667,12 +681,6 @@
         fail:
           msg: "Unable to determine RHCOS version for OCP version {{ ocp_version }}.{{ ocp_minor_version }}"
         when: rhcos_image_version == ""
-
-    - name: Remove NTP validation due to prevelance of random false-negatives
-      replace:
-        path: "{{ base_path }}/crucible/roles/validate_inventory/tasks/network.yml"
-        regexp: '\(setup_ntp_service\s\|\sdefault\(True\)\)\s!=\sTrue'
-        replace: 'false'
 
     - name: Configure inventory variables
       template:
@@ -700,11 +708,12 @@
         dest: "{{ base_path }}/crucible/deploy_cluster.sh"
         mode: '0755'
 
-    - name: Install Crucible Ansible dependencies
-      shell: |
-        ansible-galaxy collection install -r requirements.yml
-      args:
-        chdir: "{{ base_path }}/crucible"
+    # FIXME: Add this back once https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/371 merges
+    # - name: Install Crucible Ansible dependencies
+    #   shell: |
+    #     ansible-galaxy collection install -r requirements.yml
+    #   args:
+    #     chdir: "{{ base_path }}/crucible"
 
     - name: Show assisted service info
       debug:

--- a/ansible/templates/ai/crucible/inventory.ospd.yml.j2
+++ b/ansible/templates/ai/crucible/inventory.ospd.yml.j2
@@ -7,6 +7,9 @@ all:
     # https://generator.swagger.io/?url=https://raw.githubusercontent.com/openshift/assisted-service/58a6abd5c99d4e41d939be89cd0962433849a861/swagger.yaml
     # See section: cluster-create-params
 
+    # Use AI and not agent installer
+    use_agent_based_installer: false
+
     # Cluster name and dns domain combine to give the cluster namespace that will contain OpenShift endpoints
     # e.g. api.clustername.example.lab, worker1.clustername.example.lab
     cluster_name: {{ ocp_cluster_name }}
@@ -95,6 +98,8 @@ all:
       cpu_architecture: x86_64
       url: quay.io/openshift-release-dev/ocp-release:{{ ocp_version }}.{{ ocp_minor_version }}-x86_64
       version: {{ ocp_version }}.{{ ocp_minor_version }}
+
+    assisted_postgres_image: quay.io/centos7/postgresql-12-centos7:centos7
 
     ######################################
     # Prerequisite Service Configuration #

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -229,7 +229,7 @@ perf_version: "{{ ocp_version }}"
 
 # CNV addon operator version (usually should correspond to X.X release)
 # Current version from https://docs.openshift.com/container-platform/4.14/virt/install/installing-virt.html#installing-virt-operator-cli_installing-virt
-cnv_hyperconverged_operator_version: "{{ {'4.14':'4.14.4', '4.13':'4.13.8', '4.12':'4.12.10', '4.11':'4.11.8', '4.10':'4.10.10', '4.9':'4.9.7', '4.8':'4.8.7'}.get(ocp_version|string) }}"
+cnv_hyperconverged_operator_version: "{{ {'4.16':'4.16.1', '4.15':'4.15.0', '4.14':'4.14.4', '4.13':'4.13.8', '4.12':'4.12.10', '4.11':'4.11.8', '4.10':'4.10.10', '4.9':'4.9.7', '4.8':'4.8.7'}.get(ocp_version|string) }}"
 
 # namespace to deploy the operator to
 # Note: right now only openstack is supported as it is hardcoded in the Dockerfile

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -2,10 +2,8 @@
 # this address needs to be reachable from IPMI/iDRAC if BM worker is used 
 ocp_ai_discovery_iso_server: 192.168.111.1
 
-# ocp_ai_ansible_repo: defaults to "https://github.com/redhat-partner-solutions/crucible.git"
-# ocp_ai_ansible_branch: defaults to "85ad8f8a98a7c43ad0f46d3fc2e99f792b37b43f"
-ocp_ai_ansible_repo: "https://github.com/openstack-k8s-operators/crucible.git"
-ocp_ai_ansible_branch: "ospdo_dev_tools"
+# ocp_ai_ansible_repo: defaults to "https://github.com/openstack-k8s-operators/crucible.git"
+# ocp_ai_ansible_branch: defaults to "82801743b9510192d3f737b47fffeb53af80e0bb"
 
 ocp_ai_bm_bridge_master_mac_prefix: 3c:fd:fe:78:ab:0
 ocp_ai_bm_bridge_worker_mac_prefix: 3c:fd:fe:78:ab:1
@@ -26,7 +24,7 @@ ocp_ai_cli_lib_version: "2.3.0.post43"
 
 # WARNING: Changing these will likely break installation, so proceed with caution
 # Pin AI version based on ocp_version
-ocp_ai_version: "{{ 'v2.20.0' if ocp_version|string is version('4.12', '>=') else 'v2.12.1' }}"
+ocp_ai_version: "{{ 'v2.33.1' if ocp_version|string is version('4.15', '>=') else 'v2.20.0' if ocp_version|string is version('4.12', '>=') else 'v2.12.1' }}"
 # These improve the speed of the spin-up of the image service container and thus reduce the
 # overall deployment time
 ocp_ai_image_hashes:
@@ -44,3 +42,14 @@ ocp_ai_image_hashes:
     installer: sha256:12396d2ea1929d1b3ccc5117c6fd164bd87abdb9b113d0570f6e4c14c9a16f20
     installer_agent: sha256:2fb4d3556b252f692d105e3609363611e6844758c84b198445fc023c8b0bfbf9
     service: sha256:0dc7bf3172d6b3e6ec39bc766816766525c3bb40f8fba394d21483b73ba436b6
+  v2.33.1:
+    controller: sha256:020a58d5f00acf335dccf5369c3a1d4c49d3b7418f4df8053a4e57f189d323ae
+    gui: sha256:fcc0d892bf2dcaf847e6615c73adfc4f17fb64651a981ac886cb238eea183df1
+    image_service: sha256:2ee3f3619fe4056de18ce894f803c5644fa02febd62f02e6acf6606d4f819804
+    installer: sha256:aba8e94044bfa46f182ea55c99e56ff1429e3742798c0bdb543ad7cf40639d3a
+    installer_agent: sha256:7242477abd7791f0aa3cc587b0bb3b4be94bff5807ef8bb1a7a45a88b639a10f
+    service: sha256:eda8876d41ff5eb300e18145bb9d6a6a5d44815fcf2ea4968837aecf7588c2e1
+
+# FIXME: Remove once https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/371 merges
+# ocp_ai_ansible_collection_repo: defaults to "https://github.com/openstack-k8s-operators/ansible-collection-redhatci-ocp.git"
+# ocp_ai_ansible_collection_branch: defaults to "ocp_4_16"


### PR DESCRIPTION
Our Crucible fork has been resynced to the final version of upstream Crucible.  Also, [our Crucible fork has a new branch](https://github.com/openstack-k8s-operators/crucible/tree/ocp_4_16) which uses [a branch on our fork of ansible-collection-redhatci-ocp](https://github.com/openstack-k8s-operators/ansible-collection-redhatci-ocp/tree/ocp_4_16), which includes change to support OCP 4.15+.  This PR updates dev-tools to use the aforementioned forks/branches.