### PR TITLE
Fix external bridge name so it works with OVNKubernetes clusters

### DIFF
--- a/ansible/vars/16.2_fencing_3combo_dpdk.yaml
+++ b/ansible/vars/16.2_fencing_3combo_dpdk.yaml
@@ -76,7 +76,7 @@ osp_release_defaults:
     br-ex:
       interfaces:
       - type: bridge
-        name: br-ex
+        name: br-ex-osp
         interface: enp6s0
         mtu: 1500
   networks: ipv4_hybrid

--- a/ansible/vars/16.2_fencing_3combo_dpdk_sriov.yaml
+++ b/ansible/vars/16.2_fencing_3combo_dpdk_sriov.yaml
@@ -85,7 +85,7 @@ osp_release_defaults:
     br-ex:
       interfaces:
       - type: bridge
-        name: br-ex
+        name: br-ex-osp
         interface: enp6s0
         mtu: 1500
   networks: ipv4_hybrid

--- a/ansible/vars/16.2_fencing_3combo_sriov.yaml
+++ b/ansible/vars/16.2_fencing_3combo_sriov.yaml
@@ -78,7 +78,7 @@ osp_release_defaults:
     br-ex:
       interfaces:
       - type: bridge
-        name: br-ex
+        name: br-ex-osp
         interface: enp6s0
         mtu: 1500
   networks: ipv4_hybrid

--- a/ansible/vars/17.1_fencing_3combo_dpdk_sriov.yaml
+++ b/ansible/vars/17.1_fencing_3combo_dpdk_sriov.yaml
@@ -99,7 +99,7 @@ osp_release_defaults:
     br-ex:
       interfaces:
       - type: bridge
-        name: br-ex
+        name: br-ex-osp
         interface: enp6s0
         mtu: 1500
   networks: ipv4_hybrid

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -423,7 +423,7 @@ osp_defaults:
     br-ex:
       interfaces:
       - type: bridge
-        name: br-ex
+        name: br-ex-osp
         interface: enp6s0
         mtu: 1500
   networks: ipv4


### PR DESCRIPTION
`br-ex` is already used on OCP clusters with `OVNKubernetes`, so we will get an error if we happen to create NNCPs that land on such nodes.  Using a different interface name avoids the collision.