### PR TITLE
[OSPK8-812] Use a more reliable root device hint for computes

### DIFF
--- a/ansible/templates/ai/metal3/extra_workers_bmhs.yml.j2
+++ b/ansible/templates/ai/metal3/extra_workers_bmhs.yml.j2
@@ -29,7 +29,7 @@ spec:
   hardwareProfile: unknown
   bootMode: legacy
   rootDeviceHints:
-    deviceName: /dev/sda
+    hctl: "0:0:0:0"
 
 {% endfor %}
 {% for name, worker in (ocp_bm_extra_workers | default({})).items() %}


### PR DESCRIPTION
Using `deviceName: /dev/sda` is not the best idea because sometimes this device is not the actual root disk when multiple disks are attached to a compute VM.  Let's try using `hctl: "0:0:0:0"` instead, as this might be more reliable.  Otherwise, when the wrong disk happens to be chosen, the VM will fail to reboot into hard disk and the deployment fails.

Jira: https://issues.redhat.com/browse/OSPK8-812