### PR TITLE
Wait until AI OCP cluster is stable after installation

### DIFF
--- a/ansible/ocp_ai_post_install.yaml
+++ b/ansible/ocp_ai_post_install.yaml
@@ -11,6 +11,12 @@
     - name: Include AI variables
       include_vars: vars/ocp_ai.yaml
 
+    - name: Wait until the OpenShift cluster is stable
+      shell: |
+        oc adm wait-for-stable-cluster --minimum-stable-period=1m --timeout={{ (default_timeout * 3)|int }}s
+      environment: &oc_env
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ base_path }}/crucible/kubeconfig.{{ ocp_cluster_name }}"
 
     ### UN-SCHEDULABLE MASTERS
 
@@ -40,9 +46,8 @@
       - name: Make masters unschedulable
         shell: |
           oc apply -f {{ ai_sched_ingress_yaml_dir }}/50-master-scheduler.yml
-        environment: &oc_env
-          PATH: "{{ oc_env_path }}"
-          KUBECONFIG: "{{ base_path }}/crucible/kubeconfig.{{ ocp_cluster_name }}"
+        environment:
+          <<: *oc_env
 
 
     ### PROVISIONING NETWORK


### PR DESCRIPTION
After installing OCP AI cluster, we should wait until its cluster operators are stable before proceeding.  Otherwise we can get API errors when trying to issue `oc` commands, like so:

```
TASK [Make masters unschedulable] **********************************************
Friday 26 July 2024  01:13:55 +0000 (0:00:00.515)       0:00:31.593 *********** 
[0;31mfatal: [localhost]: FAILED! => {[0m
[0;31m    "changed": true,[0m
[0;31m    "cmd": "oc apply -f /home/rhos-ci/jenkins/workspace/DFG-ospk8s-osp-director-dev-tools-ai-pr/openstack-k8s/ostest-working/yamls/ai_schedule_ingress/50-master-scheduler.yml\n",[0m
[0;31m    "delta": "0:00:00.116433",[0m
[0;31m    "end": "2024-07-26 01:13:56.094568",[0m
[0;31m    "rc": 1,[0m
[0;31m    "start": "2024-07-26 01:13:55.978135"[0m
[0;31m}[0m
[0;31m[0m
[0;31mSTDERR:[0m
[0;31m[0m
[0;31merror: error when retrieving current configuration of:[0m
[0;31mResource: "config.openshift.io/v1, Resource=schedulers", GroupVersionKind: "config.openshift.io/v1, Kind=Scheduler"[0m
[0;31mName: "cluster", Namespace: ""[0m
[0;31mfrom server for: "/home/rhos-ci/jenkins/workspace/DFG-ospk8s-osp-director-dev-tools-ai-pr/openstack-k8s/ostest-working/yamls/ai_schedule_ingress/50-master-scheduler.yml": Get "https://api.ostest.test.metalkube.org:6443/apis/config.openshift.io/v1/schedulers/cluster": dial tcp 192.168.111.3:6443: connect: connection refused[0m
[0;31m[0m
[0;31m[0m
[0;31mMSG:[0m
[0;31m[0m
[0;31mnon-zero return code[0m
```