### PR TITLE
bump freeipa_image_url to centos-9-stream

### DIFF
--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -518,7 +518,7 @@ no_proxy: ""
 enable_freeipa: false
 freeipa_admin_password: abcd4321
 freeipa_directory_manager_password: dcba1234
-freeipa_image_url: quay.io/freeipa/freeipa-server:centos-8-stream
+freeipa_image_url: quay.io/freeipa/freeipa-server:centos-9-stream
 
 # must-gather image
 must_gather_image: quay.io/openstack-k8s-operators/must-gather:latest


### PR DESCRIPTION
quay.io/freeipa/freeipa-server:centos-8-stream is gone.