### PR TITLE
[OSPK8-820] Do not use port 8080 for OsProvServer due to conflicts

### DIFF
--- a/ansible/templates/osp/compute/openstackprovisionserver.yaml.j2
+++ b/ansible/templates/osp/compute/openstackprovisionserver.yaml.j2
@@ -4,6 +4,6 @@ metadata:
   name: openstack
   namespace: openstack
 spec:
-  port: 8080
+  port: 6190
   baseImageUrl: http://192.168.111.1/images/{{ osp.base_image_url | basename }}
   interface: br-ctlplane


### PR DESCRIPTION
See the Jira for details: https://issues.redhat.com/browse/OSPK8-820