### PR TITLE
Disable BMH disk cleaning by default in AI installations

### DIFF
--- a/ansible/templates/ai/metal3/extra_workers_bmhs.yml.j2
+++ b/ansible/templates/ai/metal3/extra_workers_bmhs.yml.j2
@@ -21,6 +21,7 @@ metadata:
   labels:
     app: openstack
 spec:
+  automatedCleaningMode: {{ ocp_ai_automated_cleaning_mode }}
   online: false
   bootMACAddress: {{ ocp_ai_prov_bridge_worker_mac_prefix }}{{ i }}
   bmc:
@@ -56,6 +57,7 @@ metadata:
   labels:
     app: openstack
 spec:
+  automatedCleaningMode: {{ ocp_ai_automated_cleaning_mode }}
   online: false
   bootMACAddress: {{ worker["prov_mac"] }}
   bmc:

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -15,6 +15,9 @@ ocp_ai_prov_bridge_worker_mac_prefix: 3c:fd:fe:78:cd:1
 ocp_ai_prov_interface: enp1s0
 
 # ocp_ai_sushy_port: defaults to "8082"
+# ocp_ai_automated_cleaning_mode can be set to "metadata" to enable cleaning of BMHs
+# during provisioning and deprovisioning
+ocp_ai_automated_cleaning_mode: disabled
 
 ocp_ai_libvirt_storage_dir: /var/lib/libvirt/images
 


### PR DESCRIPTION
It might not be necessary to always clean BMH disks during provisioning and deprovisioning.  Not doing so saves about 5 minutes of deploy time.  Let's see how this does in CI.  It seems to work locally when I provision/deprovision the same BMHs over and over again.