### PR TITLE
fix br slv undef

### DIFF
--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -124,7 +124,6 @@
           type: bridge-slave
           state: absent
         register: delete_bridge_slaves
-        failed_when: delete_bridge_slaves.stderr != "" and "unknown connection" not in delete_bridge_slaves.stderr
         when: item != ""
         with_items:
           - "{{ ocp_bm_prov_interface }}"

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -124,6 +124,7 @@
           type: bridge-slave
           state: absent
         register: delete_bridge_slaves
+        failed_when: delete_bridge_slaves.stderr is defined and "unknown connection" not in delete_bridge_slaves.stderr
         when: item != ""
         with_items:
           - "{{ ocp_bm_prov_interface }}"


### PR DESCRIPTION
fix for fails on ocp install because delete_bridge_slaves.stderr is undef

