### PR TITLE
[OSPK8-829] Expose interface to disable BM OSP compute cert validation

### DIFF
--- a/ansible/templates/ai/metal3/extra_workers_bmhs.yml.j2
+++ b/ansible/templates/ai/metal3/extra_workers_bmhs.yml.j2
@@ -61,6 +61,9 @@ spec:
   bmc:
     address: {{ worker["bmc_protocol"] | default("ipmi") }}://{{ worker["bmc_address"] }}
     credentialsName: openshift-worker-{{ worker_index }}-bmc-secret
+{% if worker["bmc_disable_cert_verify"] is defined and worker["bmc_disable_cert_verify"] == True %}
+    disableCertificateVerification: true
+{% endif %}
   hardwareProfile: unknown
   bootMode: legacy
   rootDeviceHints:

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -178,13 +178,14 @@ ocp_bm_extra_workers: {}
 # ocp_bm_extra_workers:
 #   worker-2:
 #     vendor: Dell
-#     bm_mac: 40:a6:b7:2b:20:03   # optional, if for some reason the OSP compute needs an assigned IP on the OCP network
-#     prov_mac: 4b:40:40:40:40:01 # extra workers use Metal3, which uses provisioning network MAC
-#     bmc_protocol: idrac         # extra workers use Metal3, which need this extra detail
+#     bm_mac: 40:a6:b7:2b:20:03       # optional, if for some reason the OSP compute needs an assigned IP on the OCP network
+#     prov_mac: 4b:40:40:40:40:01     # extra workers use Metal3, which uses provisioning network MAC
+#     bmc_protocol: idrac             # extra workers use Metal3, which need this extra detail
 #     bmc_address: 10.10.1.17
 #     bmc_username: username
 #     bmc_password: password
-#     root_device: /dev/sda       # optional, defaults to /dev/sda
+#     bmc_disable_cert_verify: false  # optional, defaults to false
+#     root_device: /dev/sda           # optional, defaults to /dev/sda
 #   worker-3:
 #     ...
 


### PR DESCRIPTION
We need to be able to disable SSL cert validation for the BMCs for baremetal OSP computes.  This is needed for hybrid deployment scenario CI to get `idrac-redfish` to work properly, as we had to switch to this newer protocol after Metal3 deprecated and removed `idrac`.

Part of the work for this Jira: https://issues.redhat.com/browse/OSPK8-829