### PR TITLE
Bump master disk size issues

### DIFF
--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -88,7 +88,7 @@ ocp_num_extra_workers: 2
 ocp_extra_workers_online_status: false
 ocp_master_memory: 16384
 ocp_master_vcpu: 8
-ocp_master_disk: 30
+ocp_master_disk: 40
 ocp_worker_memory: 35000
 ocp_worker_vcpu: 8
 ocp_worker_disk: 50


### PR DESCRIPTION
in CI jobs on fresh deploymend some pods get evicted due to DiskPressure:

```
Events:
  Type     Reason     Age   From               Message
  ----     ------     ----  ----               -------
  Normal   Scheduled  31s   default-scheduler  Successfully assigned openshift-multus/network-metrics-daemon-5hps6 to ostest-master-1
  Warning  Evicted    31s   kubelet            The node had condition: [DiskPressure].
```