### PR TITLE
[OSPRH-15719] Improve resiliency of overcloud node reboot

### DIFF
--- a/ansible/templates/osp/rhsm.yaml.j2
+++ b/ansible/templates/osp/rhsm.yaml.j2
@@ -1,8 +1,16 @@
 ---
 - hosts: overcloud
   become: true
+  gather_facts: false
 
   tasks:
+  - name: Wait for all overcloud nodes to be available
+    wait_for_connection:
+      connect_timeout: 10
+      sleep: 5
+      delay: 5
+      timeout: {{ ((default_timeout | int) * 6) if (ocp_bm_extra_workers | default ({}) | length) > 0 else ((default_timeout | int) * 3) }}
+
 {% if osp_registry_method == "rhsm" %}
   - name: Red Hat Subscription Management configuration
     import_role:
@@ -57,7 +65,17 @@
     dnf:
       name: "*"
       state: latest
+
   - name: Reboot for new kernel
-    reboot:
+    shell: reboot
+    async: 1
+    poll: 0
+
+  - name: Wait for the reboot and reconnect
+    wait_for_connection:
+      connect_timeout: 10
+      sleep: 5
+      delay: 5
+      timeout: {{ ((default_timeout | int) * 6) if (ocp_bm_extra_workers | default ({}) | length) > 0 else ((default_timeout | int) * 3) }}
 {% endif %}
 


### PR DESCRIPTION
The reboot logic for the "register overcloud nodes with subscription manager" playbook is somewhat vulnerable to intermittent network connectivity errors and slow node reboot times.  This has plagued CI runs recently and caused false failures where otherwise the job was likely to succeed.  This PR improves the playbook so that it is more tolerant of unstable networking and slow overcloud nodes.

Jira: https://issues.redhat.com/browse/OSPRH-15719