### PR TITLE
Use latest 17.1 tempest image

### DIFF
--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -254,7 +254,8 @@ sts_repo_url: https://code.engineering.redhat.com/gerrit/openstack-pidone-qe
 sts_repo_url: https://gitlab.cee.redhat.com/openstack-pidone-qe1/openstack-pidone-qe.git
 
 # image used to run tempest
-tempest_image: "{{ osp_release_auto.namespace }}/{{ osp_release_auto.name_prefix }}tempest:{{ osp_defaults.container_tag }}"
+#tempest_image: "{{ osp_release_auto.namespace }}/{{ osp_release_auto.name_prefix }}tempest:{{ osp_defaults.container_tag }}"
+tempest_image: "{{ registry_proxy }}/rh-osbs/rhosp17-openstack-tempest:17.1"
 
 # tempest timeout in seconds
 tempest_timeout: 3600


### PR DESCRIPTION
There is an issue with 16.2 tempest image which make the tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_bootable_volume_snapshot_stop_start_instance

to fail. It works with the 17.1 tempest image. Lets use this image for now.