### PR TITLE
Forward the reverse zones for all network to IPA DNS when TLSe is enabled

### DIFF
--- a/ansible/templates/dnsmasq/ctlplane.conf.j2
+++ b/ansible/templates/dnsmasq/ctlplane.conf.j2
@@ -9,6 +9,16 @@ no-hosts
 server={{ dns_server }}
 {% if osp.tlse|default(false)|bool %}
 server=/{{ base_domain_name }}/10.99.0.2 # Forward to FreeIPA
+{% for id, net in osp_networks.items() %}
+{% for subnet in net.subnets %}
+{% if subnet.ipv4 is defined %}
+rev-server={{ subnet.ipv4.cidr }},10.99.0.2 # Forward to FreeIPA
+{% endif %}
+{% if subnet.ipv6 is defined %}
+rev-server={{ subnet.ipv6.cidr }},10.99.0.2 # Forward to FreeIPA
+{% endif %}
+{% endfor %}
+{% endfor %}
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
PTR records must resolve to generate TLS certs for etcd at the edge sites.