### PR TITLE
Collect overcloud system logs and add workaround for  Jira 18571

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -215,6 +215,7 @@ openstack_scenario_default:
 	$(MAKE) computes
 	$(MAKE) osp_deploy
 	$(MAKE) must_gather
+	$(MAKE) get_logs
 
 openstack_scenario_dcn:
 	$(MAKE) patch_csv
@@ -227,6 +228,7 @@ openstack_scenario_dcn:
 	$(MAKE) osp_deploy_dcn_1
 	$(MAKE) osp_cell_v2_discover_hosts
 	$(MAKE) must_gather
+	$(MAKE) get_logs
 
 osp_cell_v2_discover_hosts: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
@@ -247,6 +249,7 @@ openstack_scenario_dmbs:
 	$(MAKE) osp_redeploy_dcn_central
 	$(MAKE) osp_cell_v2_discover_hosts
 	$(MAKE) must_gather
+	$(MAKE) get_logs
 
 osp_redeploy_dcn_central: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
@@ -260,6 +263,7 @@ openstack_update: ## perform an overcloud minor update bu patching the csv for t
 	$(MAKE) patch_csv
 	$(MAKE) osp_update
 	$(MAKE) must_gather
+	$(MAKE) get_logs
 
 osp_update:
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
@@ -272,6 +276,7 @@ osp_update:
 openstack_upgrade:
 	$(MAKE) osp_upgrade
 	$(MAKE) must_gather
+	$(MAKE) get_logs
 
 osp_upgrade:
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
@@ -286,6 +291,7 @@ openstack_upgrade_multirhel:
 	$(MAKE) osp_upgrade_multirhel_ctrls_comp1
 	$(MAKE) osp_upgrade_multirhel_computes
 	$(MAKE) must_gather
+	$(MAKE) get_logs
 
 .PHONY: osp_upgrade_multirhel_ctrls_comp1
 osp_upgrade_multirhel_ctrls_comp1:
@@ -509,6 +515,13 @@ must_gather: hosts local-defaults.yaml ## collect data from the env running must
 	-e @vars/${OSP_RELEASE}.yaml \
 	-e @local-defaults.yaml \
 	must_gather.yaml
+
+.PHONY: get_logs
+get_logs: hosts local-defaults.yaml ## collect data from overcloud nodes
+	ANSIBLE_FORCE_COLOR=true ansible-playbook -i hosts \
+	-e @vars/${OSP_RELEASE}.yaml \
+	-e @local-defaults.yaml \
+	get_logs.yaml
 
 demo: hosts
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \

--- a/ansible/files/get_logs.yaml
+++ b/ansible/files/get_logs.yaml
@@ -1,0 +1,40 @@
+---
+- name: Collect Logs from Nodes
+  hosts: all
+  become: true
+  gather_facts: false
+  ignore_unreachable: yes # Continue with the next host if one is unreachable
+
+  tasks:
+    - name: Get short hostname from the remote node
+      ansible.builtin.shell: "hostname -s"
+      register: short_hostname
+      changed_when: false # This command doesn't change the state
+
+    - name: Create a temporary directory for the archive
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: ansible_log_
+      register: tmp_dir
+
+    - name: Archive logs from /var/log, excluding the journal directory
+      ansible.builtin.archive:
+        path: /var/log/*
+        dest: "{{ tmp_dir.path }}/all_logs_{{ short_hostname.stdout }}.tar.gz"
+        format: gz
+        exclude_path:
+          - /var/log/journal
+          - /var/log/audit
+      register: archive_result
+
+    - name: Fetch the log archive to the local machine
+      ansible.builtin.fetch:
+        src: "{{ archive_result.dest }}"
+        dest: /tmp/ansible_collected_logs/
+        flat: yes # Copies the file directly, without the remote path structure
+
+    - name: Clean up the temporary directory on the remote node
+      ansible.builtin.file:
+        path: "{{ tmp_dir.path }}"
+        state: absent
+      when: tmp_dir.path is defined

--- a/ansible/files/osp/16.2/extraconfig/post_deploy/validate_ovn_bundle.yaml
+++ b/ansible/files/osp/16.2/extraconfig/post_deploy/validate_ovn_bundle.yaml
@@ -1,0 +1,33 @@
+heat_template_version: 2015-04-30
+
+parameters:
+  servers:
+    type: json
+  EndpointMap:
+    default: {}
+    description: Mapping of service endpoint -> protocol.
+    type: json
+
+resources:
+  CustomPostConfigOvnCheck:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: script
+      config: |
+        #!/bin/bash
+        # This script will only execute on the node
+        # where the 'ovn-dbs-bundle-0' container is running.
+        if sudo podman ps --format '{{.Names}}' | grep -q '^ovn-dbs-bundle-podman-0$'; then
+          echo "Running post-deployment ovn check on the ovn-dbs-bundle-podman-0 node." >> /var/log/post_ovn_check_script.log
+          # validate if ovn bundle was reported as "not running" if so, restart
+          sudo pcs status |grep "ovn-dbs-bundle.*not running" && sudo pcs resource restart ovn-dbs-bundle
+        fi
+
+  MyPostDeployments:
+    type: OS::Heat::SoftwareDeploymentGroup
+    properties:
+      servers: {get_param: servers}
+      config: {get_resource: CustomPostConfigOvnCheck}
+      actions:
+        - CREATE
+        - UPDATE

--- a/ansible/get_logs.yaml
+++ b/ansible/get_logs.yaml
@@ -1,0 +1,57 @@
+---
+- name: Get Logs
+  hosts: localhost
+  gather_facts: false
+  vars_files: vars/default.yaml
+  roles:
+    - oc_local
+
+  tasks:
+    - name: Include variables
+      ansible.builtin.include_vars: vars/default.yaml
+
+    - name: System logs run dir
+      ansible.builtin.set_fact:
+        _log_gather_dir: "{{ log_gather_directory | default(working_log_dir) }}/system-logs-{{ ansible_date_time.iso8601_basic }}"
+
+    - name: Create log run dir
+      ansible.builtin.file:
+        path: "{{ _log_gather_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Copy the log collection playbook to openstackclient
+      ansible.builtin.shell: |
+        #!/bin/bash
+        oc cp -n openstack files/get_logs.yaml openstackclient:/home/cloud-admin/get_logs.yaml
+      environment: &oc_env
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Run log collection playbook via openstackclient
+      ansible.builtin.shell: |
+        oc rsh -n openstack openstackclient <<"EOF_RSH"
+          ansible-playbook -i /home/cloud-admin/ctlplane-ansible-inventory /home/cloud-admin/get_logs.yaml
+        EOF_RSH
+      environment:
+        <<: *oc_env
+      register: playbook_run
+
+    - name: Display playbook execution output
+      ansible.builtin.debug:
+        var: playbook_run.stdout_lines
+
+    - name: Copy the collected log archives from the pod to the local host
+      ansible.builtin.command:
+        cmd: "oc -n openstack cp openstackclient:/tmp/ansible_collected_logs/ {{ _log_gather_dir }}/"
+      environment:
+        <<: *oc_env
+      changed_when: false
+
+    - name: Clean up temporary files inside the pod
+      ansible.builtin.command:
+        cmd: "oc -n openstack exec openstackclient -- rm -rf /tmp/ansible_collected_logs"
+      environment:
+        <<: *oc_env
+      changed_when: false
+      ignore_errors: true # Ignore if cleanup fails for any reason

--- a/ansible/templates/osp/tripleo_heat_envs/16.2/workarounds.yaml.j2
+++ b/ansible/templates/osp/tripleo_heat_envs/16.2/workarounds.yaml.j2
@@ -1,3 +1,8 @@
+{%- if workaround_jira18571 | default(false) %}
+resource_registry:
+  OS::TripleO::NodeExtraConfigPost: ./extraconfig/post_deploy/validate_ovn_bundle.yaml
+{%- endif %}
+
 {%- if workaround_bz2087231 | default(false) %}
 parameter_defaults:
     ValidateGatewaysIcmp: false

--- a/ansible/vars/16.2_fencing.yaml
+++ b/ansible/vars/16.2_fencing.yaml
@@ -25,3 +25,5 @@ osp_release_defaults:
           storage_class: host-nfs-storageclass
           storage_access_mode: ReadWriteMany
           storage_volume_mode: Filesystem
+
+workaround_jira18571: true

--- a/ansible/vars/16.2_fencing.yaml
+++ b/ansible/vars/16.2_fencing.yaml
@@ -1,12 +1,18 @@
 ---
 enable_fencing: true
 
+ocp_master_memory: 50000
+ocp_master_vcpu: 12
+ocp_num_workers: 0
+ocp_worker_memory: 20000
+ocp_worker_disk: 20
+
 osp_release_defaults:
   vmset:
     Controller:
       count: 3
       cores: 6
-      memory: 20
+      memory: 30
       networks:
         - ctlplane
         - internal_api

--- a/ansible/vars/16.2_fencing_nfs.yaml
+++ b/ansible/vars/16.2_fencing_nfs.yaml
@@ -1,12 +1,18 @@
 ---
 enable_fencing: true
 
+ocp_master_memory: 50000
+ocp_master_vcpu: 12
+ocp_num_workers: 0
+ocp_worker_memory: 20000
+ocp_worker_disk: 20
+
 osp_release_defaults:
   vmset:
     Controller:
       count: 3
       cores: 6
-      memory: 20
+      memory: 30
       networks:
         - ctlplane
         - internal_api
@@ -28,3 +34,5 @@ osp_release_defaults:
   extrafeatures:
     - nova_nfs
     - cinder_nfs
+
+workaround_jira18571: true

--- a/ansible/vars/17.1_fencing.yaml
+++ b/ansible/vars/17.1_fencing.yaml
@@ -3,6 +3,12 @@ enable_fencing: true
 csv_version: latest-17.1
 osp_release_auto_version: 17.1-RHEL-9
 
+ocp_master_memory: 50000
+ocp_master_vcpu: 12
+ocp_num_workers: 0
+ocp_worker_memory: 20000
+ocp_worker_disk: 20
+
 osp_release_defaults:
   base_image_url:
     https://download.devel.redhat.com/rhel-9/rel-eng/RHEL-9/latest-RHEL-9.2.0/compose/BaseOS/x86_64/images/rhel-guest-image-9.2-20230414.17.x86_64.qcow2
@@ -10,7 +16,7 @@ osp_release_defaults:
     Controller:
       count: 3
       cores: 6
-      memory: 20
+      memory: 30
       networks:
         - ctlplane
         - internal_api

--- a/ansible/vars/17.1_fencing_nfs.yaml
+++ b/ansible/vars/17.1_fencing_nfs.yaml
@@ -3,6 +3,12 @@ enable_fencing: true
 csv_version: latest-17.1
 osp_release_auto_version: 17.1-RHEL-9
 
+ocp_master_memory: 50000
+ocp_master_vcpu: 12
+ocp_num_workers: 0
+ocp_worker_memory: 20000
+ocp_worker_disk: 20
+
 osp_release_defaults:
   base_image_url:
     https://download.devel.redhat.com/rhel-9/rel-eng/RHEL-9/latest-RHEL-9.2.0/compose/BaseOS/x86_64/images/rhel-guest-image-9.2-20230414.17.x86_64.qcow2
@@ -10,7 +16,7 @@ osp_release_defaults:
     Controller:
       count: 3
       cores: 6
-      memory: 20
+      memory: 30
       networks:
         - ctlplane
         - internal_api
@@ -41,3 +47,5 @@ ephemeral_heat:
   heat_engine_image: "rhos-qe-mirror-rdu2.usersys.redhat.com:5002/rh-osbs/rhosp17-openstack-heat-engine:{{ osp_release_auto.tag }}"
   mariadb_image: "rhos-qe-mirror-rdu2.usersys.redhat.com:5002/rh-osbs/rhosp17-openstack-mariadb:{{ osp_release_auto.tag }}"
   rabbit_image: "rhos-qe-mirror-rdu2.usersys.redhat.com:5002/rh-osbs/rhosp17-openstack-rabbitmq:{{ osp_release_auto.tag }}"
+
+workaround_jira18571: true


### PR DESCRIPTION
* Adds a playbook with make target to go collect a tar of the system logs of the overcloud nodes for debugging. Not collecting a full sosreport due to size limitation we have to store them
* also adds a workaround for Jira https://issues.redhat.com/browse/OSPRH-18571 , where on slow ci systems, the ovn bundle on the 16.2 base deployment might not be successful on all nodes, especially controller-0. This node is used on an ffu to bootstrap the raft cluster. If base deployment was note successful on 16.2 on this node, the raft cluster can have broken data. This workaround make sure to restart the bundle in case an error was recorded on pcs output after the 16.2 deployment
* moves 16.2_fencing, 16.2_fencing_nfs and 17.2_fencing, 17.2_fencing_nfs to a master/worker combo deployment to deduce the required resources

Jira: OSPRH-18571
Jira: OSPRH-15717