### PR TITLE
Re-enable local registry mirrors for old container images

### DIFF
--- a/ansible/roles/oc_local/tasks/auto_dict.yaml
+++ b/ansible/roles/oc_local/tasks/auto_dict.yaml
@@ -63,13 +63,12 @@
       with_items:
         - { "key": "debug", "value": "{{ osp_release_auto_content_rc.content }}" }
         - key: "registry_proxy"
-          value: >-
-            {{ (osp_release_auto_content_rc.content | regex_findall('namespace: (.+)', '\\1') | first | default(''))
-            .split('/') | first }}
+          value: "{{ registry_proxy }}"
         - key: "namespace"
           value: >-
-            {{ (osp_release_auto_content_rc.content | regex_findall('namespace: (.+)', '\\1') | first | default(''))
-            | trim("'") | trim }}
+            {{ registry_proxy }}/{{
+            (osp_release_auto_content_rc.content | regex_findall('namespace: (.+)', '\\1') | first | default(''))
+            .split('/', 1) | last }}
         - key: "prefix"
           value: >-
             {{ (osp_release_auto_content_rc.content | regex_findall('prefix: (.+)', '\\1') | first | default(''))
@@ -85,8 +84,9 @@
             |trim("'") | trim }}
         - key: "ceph_namespace"
           value: >-
-            {{ (osp_release_auto_content_rc.content | regex_findall('ceph[-_]namespace: (.+)', '\\1') | first | default(''))
-            | trim("'") | trim }}
+            {{ registry_proxy }}/{{
+            (osp_release_auto_content_rc.content | regex_findall('ceph[-_]namespace: (.+)', '\\1') | first | default(''))
+            .split('/', 1) | last }}
         - key: "ceph_image"
           value: >-
             {{ (osp_release_auto_content_rc.content | regex_findall('ceph[-_]image: (.+)', '\\1') | first | default(''))
@@ -104,6 +104,22 @@
         - key: "rhel_version"
           value: >-
             {{ osp_release_auto_content_rc.content | regex_findall('rhel_version: (.+)', '\\1') | first | default('') }}
+
+    - name: Use registry mirror for new containers
+      when:
+        - registry_proxy_new is defined
+        - (osp_release_auto.tag.split('_')[1] | default('99999999')) >= '20251006'
+      ansible.builtin.set_fact:
+        osp_release_auto: "{{ osp_release_auto | combine({item.key: item.value}) }}"
+      with_items:
+        - key: "registry_proxy"
+          value: "{{ registry_proxy_new }}"
+        - key: "namespace"
+          value: >-
+            {{ registry_proxy_new }}/{{ osp_release_auto.namespace.split('/', 1) | last }}
+        - key: "ceph_namespace"
+          value: >-
+            {{ registry_proxy_new }}/{{ osp_release_auto.ceph_namespace.split('/', 1) | last }}
 
 - name: Create osp_release_auto_rhel8 dict
   when: osp_release_auto_version_rhel8 | default('')
@@ -130,13 +146,12 @@
       with_items:
         - { "key": "debug", "value": "{{ osp_release_auto_content_rc.content }}" }
         - key: "registry_proxy"
-          value: >-
-            {{ (osp_release_auto_content_rc.content | regex_findall('namespace: (.+)', '\\1') | first | default(''))
-            .split('/') | first }}
+          value: "{{ registry_proxy }}"
         - key: "namespace"
           value: >-
-            {{ (osp_release_auto_content_rc.content | regex_findall('namespace: (.+)', '\\1') | first | default(''))
-            | trim("'") | trim }}
+            {{ registry_proxy }}/{{
+            (osp_release_auto_content_rc.content | regex_findall('namespace: (.+)', '\\1') | first | default(''))
+            .split('/', 1) | last }}
         - key: "prefix"
           value: >-
             {{ (osp_release_auto_content_rc.content | regex_findall('prefix: (.+)', '\\1') | first | default(''))
@@ -152,8 +167,9 @@
             | trim("'") | trim }}
         - key: "ceph_namespace"
           value: >-
-            {{ (osp_release_auto_content_rc.content | regex_findall('ceph[-_]namespace: (.+)', '\\1') | first | default(''))
-            | trim("'") | trim }}
+            {{ registry_proxy }}/{{
+            (osp_release_auto_content_rc.content | regex_findall('ceph[-_]namespace: (.+)', '\\1') | first | default(''))
+            .split('/', 1) | last }}
         - key: "ceph_image"
           value: >-
             {{ (osp_release_auto_content_rc.content | regex_findall('ceph[-_]image: (.+)', '\\1') | first | default(''))
@@ -171,6 +187,22 @@
         - key: "rhel_version"
           value: >-
             {{ osp_release_auto_content_rc.content | regex_findall('rhel_version: (.+)', '\\1') | first | default('') }}
+
+    - name: Use registry mirror for new rhel8 containers
+      when:
+        - registry_proxy_new is defined
+        - (osp_release_auto_rhel8.tag.split('_')[1] | default('99999999')) >= '20251006'
+      ansible.builtin.set_fact:
+        osp_release_auto_rhel8: "{{ osp_release_auto_rhel8 | combine({item.key: item.value}) }}"
+      with_items:
+        - key: "registry_proxy"
+          value: "{{ registry_proxy_new }}"
+        - key: "namespace"
+          value: >-
+            {{ registry_proxy_new }}/{{ osp_release_auto_rhel8.namespace.split('/', 1) | last }}
+        - key: "ceph_namespace"
+          value: >-
+            {{ registry_proxy_new }}/{{ osp_release_auto_rhel8.ceph_namespace.split('/', 1) | last }}
 
 - name: Add insecure registies to /etc/containers/registries.conf
   when: podman_insecure_registries is defined

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -16,20 +16,26 @@ site_location: "{{
 # Site specific settings, local mirrors etc...
 site_settings:
   default:
+    registry_proxy_mirror: rhos-qe-mirror.lab.eng.rdu2.redhat.com:5002
     rhos_release_mirror: rhos-qe-mirror.lab.eng.rdu2.redhat.com
     dns_servers:
       - 10.11.5.19
       - 10.2.32.1
   brq:
+    registry_proxy_mirror: rhos-qe-mirror.lab.eng.brq2.redhat.com:5002
     rhos_release_mirror: rhos-qe-mirror.lab.eng.brq2.redhat.com
     dns_servers:
       - 10.45.248.15
       - 10.38.5.26
   tlv:
+    registry_proxy_mirror: rhos-qe-mirror.lab.eng.tlv2.redhat.com:5002
     rhos_release_mirror: rhos-qe-mirror.lab.eng.tlv2.redhat.com
     dns_servers:
       - 10.47.242.10
       - 10.38.5.26
+
+registry_proxy: "{{ site_settings[site_location]['registry_proxy_mirror'] }}"
+registry_proxy_new: registry.stage.redhat.io
 
 base_domain_name: test.metalkube.org
 


### PR DESCRIPTION
For container tags with dates before 20251006 (old registry), use site-specific local mirrors (rhos-qe-mirror.lab.eng.*.redhat.com:5002) to avoid image pull timeouts in CI. For newer containers, override with registry.stage.redhat.io since the new registry has no geo mirrors.

Jira: OSPRH-31105