### PR TITLE
Replace hardcoded FreeIPA and node root passwords with dynamic generation

### DIFF
--- a/ansible/templates/nfv_tests/nfv_tests.sh.j2
+++ b/ansible/templates/nfv_tests/nfv_tests.sh.j2
@@ -9,7 +9,7 @@ function wait_for_sshping_vms () {
 
     while true; do
         echo "  [$(date)] Trying to sshping between to ${1} and ${2}"
-        sshpass -p 12345678 ssh root@${1} ping -c 3 ${2}
+        sshpass -p {{ node_root_password }} ssh root@${1} ping -c 3 ${2}
 
 
         if [[ ${?} -eq 0 ]]; then
@@ -59,7 +59,7 @@ openstack flavor create --vcpus 1         --ram 1024         --disk 20         -
 cat >user_data<<EOF
 #cloud-config
 user: root
-password: 12345678
+password: {{ node_root_password }}
 chpasswd:
     expire: false
 ssh_pwauth: True
@@ -92,7 +92,7 @@ wait_for_sshping_vms $sriov_vm_ip_0 $sriov_vm_ip_1
 # #manual check, if macs are the same , meaning the vm is using the same mac
 # #as the passthrough (vfio) nic, pci:
 # virsh dumpxml $vm_name0|grep -C 3 vfio|grep 'mac address'
-# sshpass -p 12345678 ssh root@${sriov_vm_ip_0} ip link show eth0|grep link
+# sshpass -p {{ node_root_password }} ssh root@${sriov_vm_ip_0} ip link show eth0|grep link
 
 
 ##############################################
@@ -129,7 +129,7 @@ openstack flavor create --vcpus 1  --ram 1024 --disk 20 --swap 1024 --property h
 #cat >user_data<<EOF
 ##cloud-config
 #user: root
-#password: 12345678
+#password: {{ node_root_password }}
 #chpasswd:
 #    expire: false
 #ssh_pwauth: True

--- a/ansible/templates/osp/ctlplane/password-secret.yaml.j2
+++ b/ansible/templates/osp/ctlplane/password-secret.yaml.j2
@@ -4,5 +4,4 @@ metadata:
   name: userpassword
   namespace: openstack
 data:
-  # 12345678
-  NodeRootPassword: MTIzNDU2Nzg=
+  NodeRootPassword: {{ node_root_password | b64encode }}

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -550,8 +550,9 @@ no_proxy: ""
 
 # Configure freeipa and use for base_domain_name DNS (required for internal TLS)
 enable_freeipa: false
-freeipa_admin_password: abcd4321
-freeipa_directory_manager_password: dcba1234
+freeipa_admin_password: "{{ lookup('ansible.builtin.password', working_vars_dir + '/freeipa_admin_password length=24 chars=ascii_letters,digits') }}"
+freeipa_directory_manager_password: "{{ lookup('ansible.builtin.password', working_vars_dir + '/freeipa_dm_password length=24 chars=ascii_letters,digits') }}"
+node_root_password: "{{ lookup('ansible.builtin.password', working_vars_dir + '/node_root_password length=24 chars=ascii_letters,digits') }}"
 freeipa_image_url: quay.io/freeipa/freeipa-server:centos-9-stream
 # must-gather image
 must_gather_image: quay.io/openstack-k8s-operators/must-gather:latest


### PR DESCRIPTION
Use Ansible's built-in password lookup to generate random credentials on first use and cache them in working_vars_dir for consistency across playbook runs. This eliminates well-known default passwords (abcd4321, dcba1234, 12345678) from the codebase. Users can still override via local-defaults.yaml.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>