### PR TITLE
Add dependabot config and pin GitHub Actions to digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -8,9 +8,9 @@ jobs:
     name: Ansible Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Lint Ansible Playbooks
-        uses: ansible/ansible-lint@v25.6.1
+        uses: ansible/ansible-lint@06f616d6e86e9ce4c74393318d1cbb2d016af413 # v25.6.1
         with:
           requirements_file: ansible/requirements.yml


### PR DESCRIPTION
Add dependabot.yml to automatically bump github-actions weekly. Pin actions/checkout and ansible/ansible-lint to SHA digests instead of floating tags for supply-chain security.
