### PR TITLE
Ignore ansible-lint major version bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "ansible/ansible-lint"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
ansible-lint v26.x introduces unskippable syntax-check rules and defaults to Python 3.14, which breaks module resolution for ansible.posix, containers.podman, and community.libvirt collections. Pin to 25.x until the ecosystem catches up.