### PR TITLE
Secure RPM downloads: use HTTPS for rhos-release

### DIFF
--- a/ansible/roles/prepare_rhos_release/defaults/main.yaml
+++ b/ansible/roles/prepare_rhos_release/defaults/main.yaml
@@ -3,4 +3,4 @@
 rhos_release_bin: /usr/bin/rhos-release
 
 # Default rhos-release RPM path
-rhos_release_rpm_url: http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm
+rhos_release_rpm_url: https://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm

--- a/ansible/templates/osp/rhsm.yaml.j2
+++ b/ansible/templates/osp/rhsm.yaml.j2
@@ -25,7 +25,7 @@
 {% elif osp.release|float() >=  16.2 %}
   - name: install rhos-release
     dnf:
-      name: http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm
+      name: https://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm
       state: present
       disable_gpg_check: true
   - name: run rhos-release


### PR DESCRIPTION
Switch rhos-release RPM download URL from plain HTTP to HTTPS in both the role defaults and the rhsm template.  GPG check bypasses are retained because these packages are not signed.