### PR TITLE
Require explicit ocp_ai_ansible_repo and ocp_ai_ansible_branch

### DIFF
--- a/ansible/host_prep.yaml
+++ b/ansible/host_prep.yaml
@@ -39,6 +39,17 @@
           ansible.builtin.fail:
             msg: "OCP version {{ ocp_version }} is not allowed.  Only OCP greater than 4.6 is currently supported for assisted installer deployments."
           when: ocp_version is version('4.6', 'le', strict=True)
+
+        - name: Fail if ocp_ai_ansible_repo is not provided
+          ansible.builtin.fail:
+            msg: "ocp_ai_ansible_repo must be explicitly provided (e.g. in local-defaults.yaml)"
+          when: ocp_ai_ansible_repo is not defined or ocp_ai_ansible_repo | length == 0
+
+        - name: Fail if ocp_ai_ansible_branch is not provided
+          ansible.builtin.fail:
+            msg: "ocp_ai_ansible_branch must be explicitly provided (e.g. in local-defaults.yaml)"
+          when: ocp_ai_ansible_branch is not defined or ocp_ai_ansible_branch | length == 0
+
     - name: OCS validation checks
       when: (enable_ocs | bool)
       block:

--- a/ansible/ocp_ai_prep.yaml
+++ b/ansible/ocp_ai_prep.yaml
@@ -616,10 +616,10 @@
 
         - name: Clone the assisted installer playbooks repo
           ansible.builtin.git:
-            repo: "{{ ocp_ai_ansible_repo | default('https://github.com/openstack-k8s-operators/crucible.git', true) }}"
+            repo: "{{ ocp_ai_ansible_repo }}"
             dest: "{{ base_path }}/crucible"
             force: true
-            version: "{{ ocp_ai_ansible_branch | default('82801743b9510192d3f737b47fffeb53af80e0bb', true) }}"
+            version: "{{ ocp_ai_ansible_branch }}"
 
         # FIXME: Remove once https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/371 merges
         - name: Clone the assisted installer Ansible collection repo

--- a/ansible/vars/ocp_ai.yaml
+++ b/ansible/vars/ocp_ai.yaml
@@ -2,8 +2,8 @@
 # this address needs to be reachable from IPMI/iDRAC if BM worker is used
 ocp_ai_discovery_iso_server: 192.168.111.1
 
-# ocp_ai_ansible_repo: defaults to "https://github.com/openstack-k8s-operators/crucible.git"
-# ocp_ai_ansible_branch: defaults to "82801743b9510192d3f737b47fffeb53af80e0bb"
+# ocp_ai_ansible_repo: must be explicitly provided (e.g. "https://github.com/<some repo>/crucible.git")
+# ocp_ai_ansible_branch: must be explicitly provided (e.g. "main" or a commit SHA)
 
 ocp_ai_bm_bridge_master_mac_prefix: 3c:fd:fe:78:ab:0
 ocp_ai_bm_bridge_worker_mac_prefix: 3c:fd:fe:78:ab:1


### PR DESCRIPTION
Remove hardcoded default values for the crucible repo URL and commit SHA so that users must explicitly provide them (e.g. in local-defaults.yaml). Add early validation in host_prep.yaml that fails with a clear message when either variable is undefined or empty.